### PR TITLE
ci: a minimal pipeline for the circuit

### DIFF
--- a/.github/workflows/circuit_ci.yml
+++ b/.github/workflows/circuit_ci.yml
@@ -1,0 +1,44 @@
+name: Circuit CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - development
+    paths:
+      - circuit/**/*.rs
+      - circuit/**/*.toml
+      - circuit/**/*.lock
+      - .github/workflows/circuit_ci.yml
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  build_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: 🦀 install stable
+        uses: hecrj/setup-rust-action@v1.3.4
+
+      - name: 🌘 install nightly and its wasm target
+        run: |
+          rustup toolchain install nightly-2021-04-05 --profile minimal
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2021-04-05
+
+      - name: 🌌 circuit
+        run: cd ./circuit
+
+      - name: 🏭 build
+        run: cargo build
+
+      - name: 🙈 monkey test
+        run: ./target/debug/circuit --version
+
+      - name: 📼 build unit tests
+        run: cargo test --locked --workspace --no-run
+
+      - name: 🎥 run unit tests
+        run: cargo test --locked --workspace


### PR DESCRIPTION
Would basically run `cargo build` and `cargo test` for the `circuit` node when

+ pushing to `development`
+ pushing to branches that target `development` in a pull request

Defines a workflow file for just the circuit node because the [`paths`](https://github.com/t3rn/t3rn/compare/development...chiefbiiko:pipeline?expand=1#diff-051eddd49916e87d0bb5d1dd2fe0bedbada41e88871263c52801bedfd33f0bafR8) trigger filter is only available for workflows, not on job level.