### PR TITLE
Refactor authority selection - Closes #60

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-05
+          toolchain: nightly
           profile: minimal
           components: rustfmt
           override: true
@@ -76,7 +76,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-05
+          toolchain: nightly
           target: wasm32-unknown-unknown
           components: clippy
           override: true
@@ -132,7 +132,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-05
+          toolchain: nightly
           target: wasm32-unknown-unknown
           override: true
 
@@ -181,7 +181,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-07-05
+          toolchain: nightly
           target: wasm32-unknown-unknown
           override: true
 

--- a/circuit/src/execution-delivery/src/lib.rs
+++ b/circuit/src/execution-delivery/src/lib.rs
@@ -803,7 +803,7 @@ impl<T: Config> Pallet<T> {
             .binary_search(&auth)
             .ok()
             .map(|location| local_keys[location].clone())
-            .ok_or("Can't match")?;
+            .ok_or("Can't match authority for given account")?;
 
         Ok(submitter)
     }
@@ -825,10 +825,7 @@ impl<T: Config> Pallet<T> {
                 .map_err(|_e| "Can't cast value in dry_run_single_contract")?,
         );
 
-        let submitter = match Self::select_authority(escrow_account.clone()) {
-            Ok(submitter) => submitter,
-            Err(e) => return Err(e),
-        };
+        let submitter = Self::select_authority(escrow_account.clone())?;
 
         let gateway_xdns_record = pallet_xdns::Pallet::<T>::xdns_registry(step.gateway_entry_id)
             .ok_or(Error::<T>::ProcessStepGatewayNotRecognised)?;

--- a/circuit/src/execution-delivery/src/tests.rs
+++ b/circuit/src/execution-delivery/src/tests.rs
@@ -1308,12 +1308,13 @@ fn test_authority_selection() {
 }
 
 #[test]
-fn error_if_keystore_is_empty(){
+fn error_if_keystore_is_empty() {
     let keystore = KeyStore::new();
-    
+
     // Alice's escrow account
-    let escrow: AccountId = hex_literal::hex!["8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48"]
-    .into();
+    let escrow: AccountId =
+        hex_literal::hex!["8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48"]
+            .into();
 
     let mut ext = TestExternalities::new_empty();
     ext.register_extension(KeystoreExt(keystore.into()));
@@ -1325,7 +1326,7 @@ fn error_if_keystore_is_empty(){
 }
 
 #[test]
-fn error_if_incorrect_escrow_is_submitted(){
+fn error_if_incorrect_escrow_is_submitted() {
     let keystore = KeyStore::new();
 
     // Insert Alice's keys
@@ -1363,9 +1364,11 @@ fn error_if_incorrect_escrow_is_submitted(){
     .expect("Inserts unknown key");
 
     // Alice's original account => d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
-    // Alice's tempered account => a51593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d 
+    // Alice's tempered account => a51593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
     // The first 3 bytes are changed, thus making the account invalid
-    let escrow: AccountId = hex_literal::hex!["a51593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"].into();
+    let escrow: AccountId =
+        hex_literal::hex!["a51593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"]
+            .into();
 
     let mut ext = TestExternalities::new_empty();
     ext.register_extension(KeystoreExt(keystore.into()));

--- a/circuit/src/execution-delivery/src/tests.rs
+++ b/circuit/src/execution-delivery/src/tests.rs
@@ -1257,36 +1257,36 @@ fn it_should_throw_with_empty_io_schedule() {
 fn test_authority_selection() {
     let keystore = KeyStore::new();
 
-    // Insert Alice
-    let suri_alice = "//Alice";
-    let key_pair_alice = sr25519::Pair::from_string(suri_alice, None).expect("Generates key pair");
+    // Insert Alice's keys
+    const SURI_ALICE: &str = "//Alice";
+    let key_pair_alice = sr25519::Pair::from_string(SURI_ALICE, None).expect("Generates key pair");
     SyncCryptoStore::insert_unknown(
         &keystore,
         KEY_TYPE,
-        suri_alice,
+        SURI_ALICE,
         key_pair_alice.public().as_ref(),
     )
     .expect("Inserts unknown key");
 
-    // Insert Bob
-    let suri_bob = "//Bob";
-    let key_pair_bob = sr25519::Pair::from_string(suri_bob, None).expect("Generates key pair");
+    // Insert Bob's keys
+    const SURI_BOB: &str = "//Bob";
+    let key_pair_bob = sr25519::Pair::from_string(SURI_BOB, None).expect("Generates key pair");
     SyncCryptoStore::insert_unknown(
         &keystore,
         KEY_TYPE,
-        suri_bob,
+        SURI_BOB,
         key_pair_bob.public().as_ref(),
     )
     .expect("Inserts unknown key");
 
-    // Insert Charlie
-    let suri_charlie = "//Charlie";
+    // Insert Charlie's keys
+    const SURI_CHARLIE: &str = "//Charlie";
     let key_pair_charlie =
-        sr25519::Pair::from_string(suri_charlie, None).expect("Generates key pair");
+        sr25519::Pair::from_string(SURI_CHARLIE, None).expect("Generates key pair");
     SyncCryptoStore::insert_unknown(
         &keystore,
         KEY_TYPE,
-        suri_charlie,
+        SURI_CHARLIE,
         key_pair_charlie.public().as_ref(),
     )
     .expect("Inserts unknown key");
@@ -1303,7 +1303,6 @@ fn test_authority_selection() {
     ext.execute_with(|| {
         let submitter = ExecDelivery::select_authority(escrow.clone());
 
-        // println!("{:#?}", submitter);
         assert_eq!(submitter.is_ok(), true);
     });
 }


### PR DESCRIPTION
In this PR I: 

- Implemented a function called `select_authority` which changed the method of selection from selecting the first authority to selecting the authority with a given escrow account
- Added tests  