### PR TITLE
Integrate Multi Finality Verifier with Xdns to provide fresh data about active Gateways - Closes #65

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-05-26
           profile: minimal
           components: rustfmt
           override: true
@@ -76,7 +76,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-05-26
           target: wasm32-unknown-unknown
           components: clippy
           override: true
@@ -132,7 +132,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-05-26
           target: wasm32-unknown-unknown
           override: true
 
@@ -181,7 +181,7 @@ jobs:
       - name: ⚙️Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-05-26
           target: wasm32-unknown-unknown
           override: true
 

--- a/circuit/Cargo.lock
+++ b/circuit/Cargo.lock
@@ -4856,6 +4856,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-trie",
+ "t3rn-primitives",
 ]
 
 [[package]]

--- a/circuit/Cargo.lock
+++ b/circuit/Cargo.lock
@@ -4849,6 +4849,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "pallet-xdns",
  "parity-scale-codec 2.1.3",
  "serde",
  "sp-finality-grandpa",

--- a/circuit/src/chain_spec.rs
+++ b/circuit/src/chain_spec.rs
@@ -17,7 +17,7 @@
 use bp_circuit::derive_account_from_gateway_id;
 use circuit_runtime::{
     AccountId, AuraConfig, BalancesConfig, EVMConfig, GenesisConfig, GrandpaConfig, SessionConfig,
-    SessionKeys, Signature, SudoConfig, SystemConfig, WASM_BINARY,
+    SessionKeys, Signature, SudoConfig, SystemConfig, XDNSConfig, WASM_BINARY,
 };
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{sr25519, Pair, Public};
@@ -225,6 +225,9 @@ fn testnet_genesis(
                 map
             },
         },
+		pallet_xdns: XDNSConfig {
+			known_xdns_records: Vec::new(),
+		}
         //ToDo: Uncomment when upgrading to v4.0.0 substrate
         // system: SystemConfig {
         //     code: WASM_BINARY

--- a/circuit/src/contracts-registry/src/lib.rs
+++ b/circuit/src/contracts-registry/src/lib.rs
@@ -75,7 +75,7 @@ impl<AccountId: Encode> RegistryContract<AccountId> {
     pub fn generate_id<T: Config>(&self) -> RegistryContractId<T> {
         let mut protocol_part_of_contract = self.code_txt.clone();
         protocol_part_of_contract.extend(self.bytes.clone());
-        T::Hashing::hash(Encode::encode(&mut protocol_part_of_contract).as_ref())
+        T::Hashing::hash(Encode::encode(&protocol_part_of_contract).as_ref())
     }
 }
 

--- a/circuit/src/execution-delivery/src/lib.rs
+++ b/circuit/src/execution-delivery/src/lib.rs
@@ -618,11 +618,6 @@ impl<T: SigningTypes> SignedPayload<T> for Payload<T::Public, T::BlockNumber> {
 }
 
 impl<T: Config> Pallet<T> {
-    #[allow(dead_code)]
-    pub fn say_hello() -> &'static str {
-        "hello"
-    }
-
     /// Receives a list of available components and an io schedule in text format
     /// and parses it to create an execution schedule
     pub fn decompose_io_schedule(

--- a/circuit/src/primitives/Cargo.toml
+++ b/circuit/src/primitives/Cargo.toml
@@ -38,5 +38,5 @@ std = [
 	"bp-header-chain/std",
 	"pallet-sudo/std",
 	"frame-system/std",
-	"frame-support/std"
+	"frame-support/std",
 ]

--- a/circuit/src/primitives/src/lib.rs
+++ b/circuit/src/primitives/src/lib.rs
@@ -31,9 +31,9 @@ use sp_std::prelude::*;
 pub mod abi;
 pub mod transfers;
 
-pub type InstanceId = [u8; 4];
+pub type ChainId = [u8; 4];
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Encode, Decode, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum GatewayType {
     ProgrammableInternal,
@@ -61,7 +61,7 @@ pub struct GenericPrimitivesHeader {
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct GatewayPointer {
-    pub id: InstanceId,
+    pub id: ChainId,
     pub vendor: GatewayVendor,
     pub gateway_type: GatewayType,
 }
@@ -151,4 +151,15 @@ pub struct InterExecSchedule<Account, Balance> {
 pub trait EscrowTrait: frame_system::Config + pallet_sudo::Config {
     type Currency: Currency<Self::AccountId>;
     type Time: Time;
+}
+
+/// Retrieves all available gateways for a given ChainId.
+/// Currently returns a vector with a single hardcoded result.
+/// Eventually this will return all known gateways on pallet-xdns.
+pub fn retrieve_gateway_pointers(gateway_id: ChainId) -> Result<Vec<GatewayPointer>, &'static str> {
+    Ok(vec![GatewayPointer {
+        id: gateway_id,
+        gateway_type: GatewayType::ProgrammableExternal,
+        vendor: GatewayVendor::Substrate,
+    }])
 }

--- a/circuit/src/runtime/src/lib.rs
+++ b/circuit/src/runtime/src/lib.rs
@@ -311,7 +311,6 @@ impl pallet_multi_finality_verifier::Config<PolkadotLikeGrandpaInstance> for Run
     type MaxRequests = MaxRequests;
     type WeightInfo = pallet_multi_finality_verifier::weights::GatewayWeight<Runtime>;
     type HeadersToKeep = HeadersToKeep;
-    type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 }
 
 impl pallet_session::Config for Runtime {
@@ -522,7 +521,7 @@ construct_runtime!(
         Randomness: pallet_randomness_collective_flip::{Pallet, Storage},
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>},
         EVM: pallet_evm::{Pallet, Config, Storage, Event<T>},
-        XDNS: pallet_xdns::{Pallet, Call, Config, Storage, Event<T>},
+        XDNS: pallet_xdns::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 

--- a/circuit/src/runtime/src/lib.rs
+++ b/circuit/src/runtime/src/lib.rs
@@ -311,6 +311,7 @@ impl pallet_multi_finality_verifier::Config<PolkadotLikeGrandpaInstance> for Run
     type MaxRequests = MaxRequests;
     type WeightInfo = pallet_multi_finality_verifier::weights::GatewayWeight<Runtime>;
     type HeadersToKeep = HeadersToKeep;
+    type TimeProvider = pallet_timestamp::Pallet<Runtime>;
 }
 
 impl pallet_session::Config for Runtime {
@@ -493,11 +494,16 @@ impl pallet_bridge_messages::Config<WithGatewayMessagesInstance> for Runtime {
     type MessageDispatch = crate::gateway_messages::FromGatewayMessageDispatch;
 }
 
+impl pallet_xdns::Config for Runtime {
+    type Event = Event;
+    type WeightInfo = ();
+}
+
 construct_runtime!(
     pub enum Runtime where
         Block = Block,
         NodeBlock = opaque::Block,
-        UncheckedExtrinsic = UncheckedExtrinsic
+        UncheckedExtrinsic = UncheckedExtrinsic,
     {
         BridgeGatewayMessages: pallet_bridge_messages::{Pallet, Call, Storage, Event<T>},
         BridgeDispatch: pallet_bridge_dispatch::{Pallet, Event<T>},
@@ -516,6 +522,7 @@ construct_runtime!(
         Randomness: pallet_randomness_collective_flip::{Pallet, Storage},
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>},
         EVM: pallet_evm::{Pallet, Config, Storage, Event<T>},
+        XDNS: pallet_xdns::{Pallet, Call, Config, Storage, Event<T>},
     }
 );
 

--- a/circuit/src/xdns/src/lib.rs
+++ b/circuit/src/xdns/src/lib.rs
@@ -143,12 +143,12 @@ pub mod pallet {
     // Import various types used to declare pallet in scope.
     use super::*;
     use frame_support::pallet_prelude::*;
-	use frame_support::traits::Time;
-	use frame_system::pallet_prelude::*;
-	use t3rn_primitives::{ChainId, EscrowTrait};
-	use sp_std::convert::TryInto;
+    use frame_support::traits::Time;
+    use frame_system::pallet_prelude::*;
+    use sp_std::convert::TryInto;
+    use t3rn_primitives::{ChainId, EscrowTrait};
 
-	#[pallet::config]
+    #[pallet::config]
     pub trait Config:
         pallet_balances::Config + frame_system::Config + t3rn_primitives::EscrowTrait
     {
@@ -221,7 +221,8 @@ pub mod pallet {
 
             xdns_record.assign_registrant(registrant.clone());
 
-			let now = TryInto::<u64>::try_into(<T as EscrowTrait>::Time::now()).map_err(|_| "Unable to compute current timestamp")?;
+            let now = TryInto::<u64>::try_into(<T as EscrowTrait>::Time::now())
+                .map_err(|_| "Unable to compute current timestamp")?;
 
             xdns_record.set_last_finalized(now);
 

--- a/circuit/src/xdns/src/lib.rs
+++ b/circuit/src/xdns/src/lib.rs
@@ -23,7 +23,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use frame_support::dispatch::DispatchResult;
 use frame_system::ensure_signed;
 use sp_runtime::{traits::Hash, RuntimeDebug};
 use sp_std::prelude::*;
@@ -40,7 +39,11 @@ mod weights;
 
 pub use weights::*;
 
+/// A hash based on encoding the complete XdnsRecord
 pub type XdnsRecordId<T> = <T as frame_system::Config>::Hash;
+
+/// A hash based on encoding the Gateway ID
+pub type XdnsGatewayId<T> = <T as frame_system::Config>::Hash;
 
 /// A preliminary representation of a xdns_record in the onchain registry.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -62,6 +65,8 @@ pub struct XdnsRecord<AccountId> {
     pub gateway_id: bp_runtime::ChainId,
 
     pub registrant: Option<AccountId>,
+
+    pub last_finalized: Option<u64>,
 }
 
 impl<AccountId: Encode> XdnsRecord<AccountId> {
@@ -76,6 +81,7 @@ impl<AccountId: Encode> XdnsRecord<AccountId> {
         gateway_vendor: t3rn_primitives::GatewayVendor,
         gateway_type: t3rn_primitives::GatewayType,
         registrant: Option<AccountId>,
+        last_finalized: Option<u64>,
     ) -> Self {
         let gateway_genesis = GatewayGenesisConfig {
             modules_encoded,
@@ -92,6 +98,7 @@ impl<AccountId: Encode> XdnsRecord<AccountId> {
             gateway_type,
             gateway_id,
             registrant,
+            last_finalized,
         }
     }
 
@@ -111,6 +118,7 @@ impl<AccountId: Encode> XdnsRecord<AccountId> {
             gateway_type,
             gateway_genesis,
             registrant: None,
+            last_finalized: None,
         }
     }
 
@@ -118,8 +126,13 @@ impl<AccountId: Encode> XdnsRecord<AccountId> {
         self.registrant = Some(registrant)
     }
 
+    /// Function that generates an XdnsRecordId hash based on the gateway id
     pub fn generate_id<T: Config>(&self) -> XdnsRecordId<T> {
-        T::Hashing::hash(Encode::encode(self).as_ref())
+        T::Hashing::hash(Encode::encode(&self.gateway_id).as_ref())
+    }
+
+    pub fn set_last_finalized(&mut self, last_finalized: u64) {
+        self.last_finalized = Some(last_finalized)
     }
 }
 
@@ -131,6 +144,7 @@ pub mod pallet {
     use super::*;
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
+    use t3rn_primitives::ChainId;
 
     #[pallet::config]
     pub trait Config:
@@ -205,6 +219,9 @@ pub mod pallet {
 
             xdns_record.assign_registrant(registrant.clone());
 
+            // TODO fix this value
+            xdns_record.set_last_finalized(0);
+
             let xdns_record_id = xdns_record.generate_id::<T>();
 
             if <XDNSRegistry<T>>::contains_key(&xdns_record_id) {
@@ -216,17 +233,28 @@ pub mod pallet {
             }
         }
 
-        /// Removes a xdns_record from the onchain registry. Root only access.
+        /// Updates the last_ xdns_record from the onchain registry. Root only access.
         #[pallet::weight(500_000_000 + T::DbWeight::get().reads_writes(1,1))]
         pub fn update_ttl(
             origin: OriginFor<T>,
-            xdns_record_id: XdnsRecordId<T>,
+            gateway_id: ChainId,
+            last_finalized: u64,
         ) -> DispatchResultWithPostInfo {
             ensure_root(origin)?;
 
-            if !<XDNSRegistry<T>>::contains_key(&xdns_record_id) {
-                Err(Error::<T>::UnknownXdnsRecord)?
+            let xdns_record_id = T::Hashing::hash(Encode::encode(&gateway_id).as_ref());
+
+            if !XDNSRegistry::<T>::contains_key(xdns_record_id) {
+                Err(Error::<T>::XdnsRecordNotFound.into())
             } else {
+                XDNSRegistry::<T>::mutate(xdns_record_id, |xdns_record| match xdns_record {
+                    None => Err(Error::<T>::XdnsRecordNotFound),
+                    Some(record) => {
+                        record.set_last_finalized(last_finalized);
+                        Ok(())
+                    }
+                })?;
+
                 Self::deposit_event(Event::<T>::XdnsRecordUpdated(xdns_record_id));
                 Ok(().into())
             }
@@ -269,6 +297,8 @@ pub mod pallet {
         XdnsRecordAlreadyExists,
         /// Access of unknown xdns_record
         UnknownXdnsRecord,
+        /// Xdns Record not found
+        XdnsRecordNotFound,
     }
 
     /// The pre-validated composable xdns_records on-chain registry.
@@ -303,14 +333,41 @@ pub mod pallet {
     impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
         fn build(&self) {}
     }
-}
 
-impl<T: Config> Pallet<T> {
-    // Add public immutables and private mutables.
-    #[allow(dead_code)]
-    fn placeholder(origin: T::Origin) -> DispatchResult {
-        let _sender = ensure_signed(origin)?;
+    impl<T: Config> Pallet<T> {
+        /// Locates the best available gateway based on the time they were last finalized.
+        /// Priority goes Internal > External > TxOnly
+        pub fn best_available(
+            gateway_id: ChainId,
+        ) -> Result<XdnsRecord<T::AccountId>, &'static str> {
+            // ensure_signed(origin)?;
 
-        Ok(())
+            // we sort each available gateway pointer based on its GatewayType
+            let gateway_pointers = t3rn_primitives::retrieve_gateway_pointers(gateway_id);
+            ensure!(gateway_pointers.is_ok(), "No available gateway pointers");
+            let mut sorted_gateway_pointers = gateway_pointers.unwrap();
+            sorted_gateway_pointers.sort_by(|a, b| a.gateway_type.cmp(&b.gateway_type));
+
+            // we then fetch each XdnsRecord and re-sort based on its last_finalized descending
+            let mut sorted_gateways: Vec<XdnsRecord<T::AccountId>> = sorted_gateway_pointers
+                .into_iter()
+                .map(|gateway_pointer| {
+                    <XDNSRegistry<T>>::get(T::Hashing::hash(
+                        Encode::encode(&gateway_pointer.id).as_ref(),
+                    ))
+                })
+                .filter(|xdns_record| xdns_record.is_some())
+                .map(|xdns_record| xdns_record.unwrap())
+                .collect();
+            sorted_gateways
+                .sort_by(|xdns_a, xdns_b| xdns_b.last_finalized.cmp(&xdns_a.last_finalized));
+
+            // then we return the first result
+            if sorted_gateways.is_empty() {
+                return Err("Xdns record not found");
+            }
+
+            Ok(sorted_gateways[0].clone())
+        }
     }
 }


### PR DESCRIPTION
This PR implements *most* of the acceptance criteria for #65 . The complete implementation requires an additional PR to be made on the [parity-bridges-common](https://github.com/MaciejBaj/parity-bridges-common) repo ([found here](https://github.com/paritytech/parity-bridges-common/pull/1072)).

In this PR: 
* [pallet-xdns] Implemented `update_ttl` call and `best_available` function.
* Refactored `retrieve_gateway_pointer`. Moved to t3rn-primitives and now returns a vector of Gateway Pointers.
* Used `retrieve_gateway_pointer` function in `retrieve_gateway_protocol` so that it fetches gateway metadata and uses it to instantiate a Gateway Protocol.
* Refactored `XdnsRecordId` to ony use the 4-character gateway id instead of the whole XdnsRecord struct to make it queriable from external pallets.
* Added the `last_finalized` field to XdnsRecord which contains the u64 TTL value.

In the remote PR in `MaciejBaj/parity-bridges-common`:
* Added pallet-xdns as a dependency to the multi-finality-verifier pallet.
* Used the `update_ttl` function to update the `pallet-xdns` storage.

**Open issues:**
* Add unit tests to the implementation
* Add `pallet-xdns` to the circuit runtime