### PR TITLE
Refactor exec composable at Gateway into separately-callable methods - Closes #64

### DIFF
--- a/gateway/pallet-escrow-gateway/runtime-gateway/Cargo.toml
+++ b/gateway/pallet-escrow-gateway/runtime-gateway/Cargo.toml
@@ -12,6 +12,7 @@ version = '0.5.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
+bitflags = "1.2.0"
 reduce = "0.1.4"
 anyhow = "*"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/gateway/pallet-escrow-gateway/runtime-gateway/src/lib.rs
+++ b/gateway/pallet-escrow-gateway/runtime-gateway/src/lib.rs
@@ -306,6 +306,22 @@ pub mod pallet {
 
         XEmitEvent(Vec<u8>),
 
+        XGatewayCustom(
+            T::AccountId,
+            T::AccountId,
+            BalanceOf<T>,
+            Option<T::AccountId>,
+            Option<Vec<u8>>,
+        ),
+
+        XGatewaySwap(
+            T::AccountId,
+            T::AccountId,
+            BalanceOf<T>,
+            BalanceOf<T>,
+            Option<T::AccountId>,
+        ),
+
         MultistepUnknownPhase(u8),
 
         RentProjectionCalled(T::AccountId, T::AccountId),
@@ -747,22 +763,49 @@ pub mod pallet {
             _origin: OriginFor<T>,
             event_encoded: Vec<u8>,
         ) -> DispatchResultWithPostInfo {
-            // Print a test message.
             Self::deposit_event(Event::XEmitEvent(event_encoded));
             Ok(().into())
         }
 
         #[pallet::weight(100_000_000 + T::DbWeight::get().reads_writes(1,0))]
-        pub fn generic(_origin: OriginFor<T>, key: [u8; 32]) -> DispatchResultWithPostInfo {
-            // Print a test message.
-            Self::deposit_event(Event::GetStorageResult(key.to_vec()));
+        pub fn custom(
+            _origin: OriginFor<T>,
+            from: T::AccountId,
+            to: T::AccountId,
+            value: BalanceOf<T>,
+            maybe_escrow_account: Option<T::AccountId>,
+            custom_bytes: Option<Vec<u8>>,
+            _maybe_call_flags: Option<CallFlags>,
+        ) -> DispatchResultWithPostInfo {
+            // ToDo: Unimplemented!
+            Self::deposit_event(Event::XGatewayCustom(
+                from,
+                to,
+                value,
+                maybe_escrow_account,
+                custom_bytes,
+            ));
             Ok(().into())
         }
 
         #[pallet::weight(100_000_000 + T::DbWeight::get().reads_writes(1,0))]
-        pub fn swap(_origin: OriginFor<T>, key: [u8; 32]) -> DispatchResultWithPostInfo {
-            // Print a test message.
-            Self::deposit_event(Event::GetStorageResult(key.to_vec()));
+        pub fn swap(
+            _origin: OriginFor<T>,
+            from: T::AccountId,
+            to: T::AccountId,
+            value_src: BalanceOf<T>,
+            value_dest: BalanceOf<T>,
+            maybe_escrow_account: Option<T::AccountId>,
+            _maybe_transfer_flags: Option<TransferFlags>,
+        ) -> DispatchResultWithPostInfo {
+            // ToDo: Unimplemented!
+            Self::deposit_event(Event::XGatewaySwap(
+                from,
+                to,
+                value_src,
+                value_dest,
+                maybe_escrow_account,
+            ));
             Ok(().into())
         }
 


### PR DESCRIPTION
Allows to invoke different scenarios based on provided arguments into separate methods: 
- [x] set_storage & get_storage
- [x] call_dirty, call_escrow, call_static
- [x] transfer_dirty, transfer_escrow
- [x] custom protocol call
- [x] emit event

Introduce bit flags and modify the flow of execution based on them.