### PR TITLE
Fixes fetching Polkadot & Kusama runtime metadata - Closes #132

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ comms
 /target
 ./Cargo.lock
 .idea
+*.iml

--- a/circuit/Cargo.lock
+++ b/circuit/Cargo.lock
@@ -1120,6 +1120,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "jsonrpc-core",
  "jsonrpc-runtime-client",
+ "log",
  "node-inspect",
  "pallet-bridge-messages",
  "pallet-evm",
@@ -2421,12 +2422,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96616f82e069102b95a72c87de4c84d2f87ef7f0f20630e78ce3824436483110"
+dependencies = [
+ "cfg-if 1.0.0",
+ "parity-scale-codec",
+ "scale-info 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "frame-support"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.8#74101dc21cfffb4c2d014fcc28edc166d5ca1b16"
 dependencies = [
  "bitflags",
- "frame-metadata",
+ "frame-metadata 13.0.0",
  "frame-support-procedural",
  "impl-trait-for-tuples 0.2.1",
  "log",
@@ -3553,7 +3566,7 @@ dependencies = [
  "async-trait",
  "bp-polkadot-core",
  "env_logger 0.8.4",
- "frame-metadata",
+ "frame-metadata 14.0.0",
  "futures 0.1.31",
  "hyper 0.12.36",
  "jsonrpc-core-client",
@@ -5127,7 +5140,7 @@ dependencies = [
  "pallet-mmr-primitives",
  "pallet-session",
  "parity-scale-codec",
- "scale-info",
+ "scale-info 0.10.0",
  "serde",
  "sp-core",
  "sp-io",
@@ -5203,7 +5216,7 @@ dependencies = [
  "ethabi-decode",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-metadata",
+ "frame-metadata 14.0.0",
  "frame-support",
  "frame-system",
  "hash-db",
@@ -5717,7 +5730,7 @@ version = "0.4.0"
 dependencies = [
  "bp-runtime",
  "frame-benchmarking",
- "frame-metadata",
+ "frame-metadata 14.0.0",
  "frame-support",
  "frame-system",
  "log",
@@ -7917,7 +7930,21 @@ dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
- "scale-info-derive",
+ "scale-info-derive 0.7.0",
+]
+
+[[package]]
+name = "scale-info"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
+dependencies = [
+ "bitvec",
+ "cfg-if 1.0.0",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -7925,6 +7952,18 @@ name = "scale-info-derive"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b648fa291891a4c80187a25532f6a7d96b82c70353e30b868b14632b8fe043d6"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",

--- a/circuit/node/Cargo.toml
+++ b/circuit/node/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/t3rn/t3rn/"
 jsonrpc-core = "15.1.0"
 structopt = "0.3.21"
 serde_json = "1.0.59"
+log = "0.4.14"
 
 # Bridge dependencies
 

--- a/circuit/node/src/chain_spec.rs
+++ b/circuit/node/src/chain_spec.rs
@@ -18,6 +18,7 @@ use async_std::task;
 use beefy_primitives::crypto::AuthorityId as BeefyId;
 use bp_circuit::derive_account_from_gateway_id;
 use bp_runtime::{KUSAMA_CHAIN_ID, POLKADOT_CHAIN_ID};
+use log::info;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{sr25519, Encode, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
@@ -87,7 +88,7 @@ fn fetch_xdns_record_from_rpc(
 
         let mut modules_vec = vec![];
         let mut extension_vec = vec![];
-        metadata.modules.encode_to(&mut modules_vec);
+        metadata.pallets.encode_to(&mut modules_vec);
         metadata
             .extrinsic
             .signed_extensions
@@ -126,9 +127,10 @@ fn seed_xdns_registry() -> Result<Vec<XdnsRecord<AccountId>>, std::io::Error> {
 
     let polkadot_xdns =
         fetch_xdns_record_from_rpc(&polkadot_connection_params, POLKADOT_CHAIN_ID).unwrap();
-
+    info!("Fetched Polkadot metadata successfully!");
     let kusama_xdns =
         fetch_xdns_record_from_rpc(&kusama_connection_params, KUSAMA_CHAIN_ID).unwrap();
+    info!("Fetched Kusama metadata successfully!");
 
     Ok(vec![polkadot_xdns, kusama_xdns])
 }

--- a/circuit/pallets/execution-delivery/Cargo.toml
+++ b/circuit/pallets/execution-delivery/Cargo.toml
@@ -29,7 +29,7 @@ plain_hasher = { version = "0.2.2", default-features = false }
 
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8' }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8'  }
-frame-metadata = { version = "13.0.0", git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8', default-features = false }
+frame-metadata = { version = "14.0.0", features = ["v13", "v14"], default-features = false }
 
 sp-keystore = { default-features = false, version = "0.9.0", git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8', optional = true }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8' }

--- a/circuit/pallets/execution-delivery/src/message_assembly/chain_generic_metadata.rs
+++ b/circuit/pallets/execution-delivery/src/message_assembly/chain_generic_metadata.rs
@@ -3,7 +3,9 @@ use sp_std::fmt::Debug;
 
 use sp_std::vec;
 
-use frame_metadata::{DecodeDifferent, ExtrinsicMetadata, RuntimeMetadataV13};
+use frame_metadata::decode_different::DecodeDifferent;
+use frame_metadata::v13::{ExtrinsicMetadata, RuntimeMetadataV13};
+use frame_metadata::RuntimeMetadataLastVersion;
 use frame_support::ensure;
 use sp_std::default::Default;
 use sp_std::prelude::*;
@@ -17,7 +19,7 @@ impl Default for Metadata {
     fn default() -> Self {
         Self {
             runtime_metadata: RuntimeMetadataV13 {
-                modules: frame_metadata::DecodeDifferent::Decoded(vec![]),
+                modules: DecodeDifferent::Decoded(vec![]),
                 extrinsic: ExtrinsicMetadata {
                     version: 4,
                     signed_extensions: vec![],
@@ -91,8 +93,9 @@ fn convert<B: 'static, O: 'static>(dd: DecodeDifferent<B, O>) -> Result<O, &'sta
 #[cfg(test)]
 mod tests {
     use super::Metadata;
-    use frame_metadata::{
-        DecodeDifferent, ExtrinsicMetadata, FunctionMetadata, ModuleMetadata, RuntimeMetadataV13,
+    use frame_metadata::decode_different::DecodeDifferent;
+    use frame_metadata::v13::{
+        ExtrinsicMetadata, FunctionMetadata, ModuleMetadata, RuntimeMetadataV13,
     };
     use frame_support::assert_err;
 

--- a/circuit/pallets/execution-delivery/src/message_assembly/substrate_gateway_assembly.rs
+++ b/circuit/pallets/execution-delivery/src/message_assembly/substrate_gateway_assembly.rs
@@ -137,8 +137,9 @@ where
 #[cfg(test)]
 pub mod tests {
 
-    use frame_metadata::{
-        DecodeDifferent, ExtrinsicMetadata, FunctionMetadata, ModuleMetadata, RuntimeMetadataV13,
+    use frame_metadata::decode_different::DecodeDifferent;
+    use frame_metadata::v13::{
+        ExtrinsicMetadata, FunctionMetadata, ModuleMetadata, RuntimeMetadataV13,
     };
     use frame_support::assert_err;
     use sp_core::H256;

--- a/circuit/pallets/execution-delivery/src/message_assembly/test_utils.rs
+++ b/circuit/pallets/execution-delivery/src/message_assembly/test_utils.rs
@@ -1,5 +1,6 @@
-use frame_metadata::{
-    DecodeDifferent, ExtrinsicMetadata, FunctionMetadata, ModuleMetadata, RuntimeMetadataV13,
+use frame_metadata::decode_different::DecodeDifferent;
+use frame_metadata::v13::{
+    ExtrinsicMetadata, FunctionMetadata, ModuleMetadata, RuntimeMetadataV13,
 };
 use sp_core::H256;
 use sp_version::{ApisVec, RuntimeVersion};
@@ -49,7 +50,7 @@ pub fn create_test_metadata(
         let functions = fn_names.into_iter().map(fn_metadata_generator).collect();
         modules.push(module_metadata_generator(
             module_name,
-            module_index,
+            module_index.clone(),
             functions,
         ));
         module_index = module_index + 1;

--- a/circuit/pallets/xdns/Cargo.toml
+++ b/circuit/pallets/xdns/Cargo.toml
@@ -22,7 +22,7 @@ bp-runtime = { path = "../../../vendor/bridges/primitives/runtime", default-feat
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.8', optional = true }
 frame-support = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.8' }
 frame-system = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.8' }
-frame-metadata = { version = "13.0.0", default-features = false, git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.8' }
+frame-metadata = { version = "14.0.0", features = ["v13", "v14"], default-features = false }
 
 pallet-balances = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.8' }
 pallet-timestamp = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.8' }

--- a/circuit/rpc/rpc-test/jsonrpc-runtime-client/Cargo.toml
+++ b/circuit/rpc/rpc-test/jsonrpc-runtime-client/Cargo.toml
@@ -21,7 +21,7 @@ node-primitives = { version = "2.0.0", git = "https://github.com/paritytech/subs
 sp-tracing = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8" }
 sc-rpc = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8"}
 sp-core = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8"}
-frame-metadata = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8"}
+frame-metadata = { version = "14.0.0", features = ["v13", "v14"] }
 
 async-std = { version = "1.6.5", features = ["attributes", "tokio1"] }
 async-trait = "0.1.40"

--- a/circuit/rpc/rpc-test/jsonrpc-runtime-client/src/useful_queries.rs
+++ b/circuit/rpc/rpc-test/jsonrpc-runtime-client/src/useful_queries.rs
@@ -1,6 +1,7 @@
 use crate::polkadot_like_chain::PolkadotLike;
 use codec::{Decode, Encode};
-use frame_metadata::{RuntimeMetadata, RuntimeMetadataPrefixed, RuntimeMetadataV13};
+use frame_metadata::v14::RuntimeMetadataV14;
+use frame_metadata::{RuntimeMetadata, RuntimeMetadataLastVersion, RuntimeMetadataPrefixed};
 use jsonrpsee_types::{traits::Client, v2::params::JsonRpcParams};
 use num_traits::Zero;
 use relay_substrate_client::Client as SubstrateClient;
@@ -18,7 +19,7 @@ pub async fn get_first_header(
 
 pub async fn get_metadata(
     sub_client: &SubstrateClient<PolkadotLike>,
-) -> Result<RuntimeMetadataV13, String> {
+) -> Result<RuntimeMetadataV14, String> {
     let bytes: Bytes = sub_client
         .client
         .request("state_getMetadata", JsonRpcParams::NoParams)
@@ -27,7 +28,7 @@ pub async fn get_metadata(
 
     let meta: RuntimeMetadataPrefixed = Decode::decode(&mut &bytes[..]).unwrap();
     match meta.1 {
-        RuntimeMetadata::V13(md13) => Ok(md13),
+        RuntimeMetadata::V14(md14) => Ok(md14),
         _ => Err("Could not parse metadata".into()),
     }
 }

--- a/circuit/test-utils/Cargo.toml
+++ b/circuit/test-utils/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-frame-metadata = { version = "13.0.0", git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8', default-features = false }
+frame-metadata = { version = "14.0.0", features = ["v13", "v14"], default-features = false }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8' }
 sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8' }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.8' }


### PR DESCRIPTION
Closes #132 .

Now properly fetches Polkadot & Kusama runtime metadata which as been upgraded to V14.

NOTE: Existing Metadata for circuit and gateway remains at V13. To be upgraded in a future task.