### PR TITLE
Assert contracts pallet storage in RPC tests - Closes #145

### DIFF
--- a/circuit/rpc/rpc-test/src/smart_contract_deployment_remote.rs
+++ b/circuit/rpc/rpc-test/src/smart_contract_deployment_remote.rs
@@ -24,7 +24,7 @@ use sp_core::Bytes;
 use sp_io::TestExternalities;
 use sp_keystore::KeystoreExt;
 
-use circuit_runtime::{Runtime};
+use circuit_runtime::Runtime;
 use circuit_test_utils::create_gateway_protocol_from_client;
 use sp_keyring::Sr25519Keyring;
 use volatile_vm::wasm::PrefabWasmModule;


### PR DESCRIPTION
Assert contracts pallet storage in RPC tests : successfully_deploys_flipper_and_calls_flip

Closes #145 