### PR TITLE
Introduce Volatile State to primitives and link with Xtx

### DIFF
--- a/circuit/pallets/execution-delivery/src/lib.rs
+++ b/circuit/pallets/execution-delivery/src/lib.rs
@@ -47,6 +47,7 @@ use sp_std::vec;
 use sp_std::vec::*;
 use t3rn_primitives::abi::{ContractActionDesc, GatewayABIConfig, HasherAlgo as HA};
 use t3rn_primitives::transfers::BalanceOf;
+use t3rn_primitives::volatile::LocalState;
 use t3rn_primitives::*;
 use volatile_vm::VolatileVM;
 
@@ -743,6 +744,7 @@ impl<T: Config> Pallet<T> {
             timeouts_at,
             delay_steps_at,
             Some(reward),
+            LocalState::new(),
             vec![],
         );
 

--- a/circuit/primitives/src/lib.rs
+++ b/circuit/primitives/src/lib.rs
@@ -37,6 +37,7 @@ pub mod contract_metadata;
 pub mod gateway_inbound_protocol;
 pub mod side_effect;
 pub mod transfers;
+pub mod volatile;
 pub mod xtx;
 
 pub use gateway_inbound_protocol::GatewayInboundProtocol;

--- a/circuit/primitives/src/volatile.rs
+++ b/circuit/primitives/src/volatile.rs
@@ -1,0 +1,153 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+use sp_runtime::RuntimeDebug;
+
+use sp_std::collections::btree_map::BTreeMap;
+
+use sp_std::vec::*;
+
+type StateKey = [u8; 32];
+type StateVal = Vec<u8>;
+// Although check if no longer than 64 bytes
+pub type State = BTreeMap<StateKey, StateVal>;
+
+use sp_io::hashing::twox_256;
+
+#[derive(Clone, Eq, PartialEq, Default, Encode, Decode, RuntimeDebug)]
+pub struct LocalState {
+    pub state: State,
+}
+
+impl LocalState {
+    pub fn new() -> Self {
+        LocalState {
+            state: BTreeMap::new(),
+        }
+    }
+}
+
+impl Volatile for LocalState {
+    fn get_state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
+    fn get_state(&self) -> &State {
+        &self.state
+    }
+}
+
+pub trait Volatile {
+    fn get_state_mut(&mut self) -> &mut State;
+
+    fn get_state(&self) -> &State;
+
+    fn hash(x: &[u8]) -> [u8; 32] {
+        twox_256(x)
+    }
+
+    fn key_2_state_key<K: Encode>(key: K) -> [u8; 32] {
+        let key_as_array = &key.encode()[..];
+        Self::hash(key_as_array)
+    }
+
+    fn get<K: Encode>(&self, key: K) -> Option<&StateVal> {
+        self.get_state().get(&Self::key_2_state_key(key))
+    }
+
+    fn cmp<K: Encode>(&self, key: K, cmp_value: Vec<u8>) -> bool {
+        self.get(key) == Some(cmp_value).as_ref()
+    }
+
+    // fn value_2_state_value(value: Vec<u8>) -> Result<[u8; 64], &'static str>  {
+    fn value_2_state_value(value: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+        // let value_as_array = &value[..];
+        return if value.len() > 64 {
+            Err("Value is larger than max. 64 bytes allowed in the Volatile State")
+        } else {
+            Ok(value)
+        };
+    }
+
+    fn insert<K: Encode>(
+        &mut self,
+        key: K,
+        val: Vec<u8>,
+    ) -> Result<(StateKey, StateVal), &'static str> {
+        let key_candidate = Self::key_2_state_key(key);
+        if self.get_state().contains_key(&key_candidate) {
+            return Err("Key already exists in the Volatile State");
+        }
+        let value_candidate = Self::value_2_state_value(val)?;
+
+        match self
+            .get_state_mut()
+            .insert(key_candidate.clone(), value_candidate.clone())
+        {
+            Some(_) => Err("Critical ERR - key override in Volatile storage, despite check!"),
+            None => Ok((key_candidate, value_candidate)),
+        }
+    }
+}
+
+pub const FROM_2XX_32B_HASH: [u8; 32] = [
+    47u8, 140u8, 44u8, 35u8, 27u8, 124u8, 17u8, 66u8, 71u8, 139u8, 84u8, 182u8, 189u8, 44u8, 255u8,
+    9u8, 216u8, 225u8, 72u8, 92u8, 140u8, 153u8, 36u8, 176u8, 243u8, 84u8, 204u8, 37u8, 235u8,
+    116u8, 243u8, 46u8,
+];
+pub const TO_2XX_32B_HASH: [u8; 32] = [
+    158u8, 28u8, 58u8, 252u8, 48u8, 192u8, 42u8, 109u8, 5u8, 152u8, 177u8, 124u8, 120u8, 75u8,
+    35u8, 127u8, 172u8, 179u8, 9u8, 243u8, 249u8, 54u8, 121u8, 35u8, 254u8, 120u8, 104u8, 24u8,
+    148u8, 166u8, 97u8, 122u8,
+];
+pub const VALUE_2XX_32B_HASH: [u8; 32] = [
+    92u8, 190u8, 233u8, 194u8, 88u8, 78u8, 131u8, 17u8, 72u8, 80u8, 231u8, 10u8, 137u8, 245u8,
+    128u8, 209u8, 66u8, 12u8, 149u8, 254u8, 145u8, 206u8, 210u8, 112u8, 210u8, 191u8, 191u8, 97u8,
+    176u8, 219u8, 170u8, 83u8,
+];
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[test]
+    fn successfully_generates_correct_keys_for_inserted_values() {
+        let _encoded_transfer_args_input = vec![
+            hex!("0909090909090909090909090909090909090909090909090909090909090909").into(),
+            hex!("0606060606060606060606060606060606060606060606060606060606060606").into(),
+            1u64.encode(),
+        ];
+        let mut local_state = LocalState::new();
+
+        let mut res = local_state.insert(
+            "from",
+            hex!("0909090909090909090909090909090909090909090909090909090909090909").into(),
+        );
+        assert_eq!(
+            res,
+            Ok((
+                FROM_2XX_32B_HASH,
+                hex!("0909090909090909090909090909090909090909090909090909090909090909").into()
+            ))
+        );
+
+        res = local_state.insert(
+            "to",
+            hex!("0606060606060606060606060606060606060606060606060606060606060606").into(),
+        );
+        assert_eq!(
+            res,
+            Ok((
+                TO_2XX_32B_HASH,
+                hex!("0606060606060606060606060606060606060606060606060606060606060606").into()
+            ))
+        );
+
+        res = local_state.insert("value", 1u64.encode());
+        assert_eq!(
+            res,
+            Ok((VALUE_2XX_32B_HASH, hex!("0100000000000000").into()))
+        );
+    }
+}

--- a/circuit/primitives/src/xtx.rs
+++ b/circuit/primitives/src/xtx.rs
@@ -5,8 +5,11 @@ use sp_runtime::{
     RuntimeDebug,
 };
 use sp_std::vec::Vec;
+
 type SystemHashing<T> = <T as frame_system::Config>::Hashing;
 pub type XtxId<T> = <T as frame_system::Config>::Hash;
+
+pub use crate::volatile::{LocalState, Volatile};
 use sp_std::fmt::Debug;
 
 /// A composable cross-chain (X) transaction that has already been verified to be valid and submittable
@@ -34,6 +37,9 @@ pub struct Xtx<AccountId, BlockNumber, BalanceOf> {
     /// Total reward
     pub total_reward: Option<BalanceOf>,
 
+    /// Local Xtx State
+    pub local_state: LocalState,
+
     /// Vector of Steps that each can consist out of at least one FullSideEffect
     pub full_side_effects: Vec<Vec<FullSideEffect<AccountId, BlockNumber, BalanceOf>>>,
 }
@@ -55,7 +61,7 @@ impl<
         delay_steps_at: Option<Vec<BlockNumber>>,
         // Total reward
         total_reward: Option<BalanceOf>,
-
+        local_state: LocalState,
         full_side_effects: Vec<Vec<FullSideEffect<AccountId, BlockNumber, BalanceOf>>>,
     ) -> Self {
         Xtx {
@@ -65,6 +71,7 @@ impl<
             delay_steps_at,
             result_status: None,
             total_reward,
+            local_state,
             full_side_effects,
         }
     }
@@ -100,10 +107,10 @@ impl<
 
         // Double check there are some side effects for that Xtx - should have been checked at API level tho already
         if self.full_side_effects.is_empty() {
-            return Err("Xtx has no single side effect step to confirm");
+            return Err("Xtx has no single side effect step to confirm.rs");
         }
 
-        let mut unconfirmed_step_no: Option<usize> = None;
+        let step_with_unconfirmed_steps: Option<usize>;
 
         for (i, step) in self.full_side_effects.iter_mut().enumerate() {
             // Double check there are some side effects for that Xtx - should have been checked at API level tho already
@@ -112,20 +119,17 @@ impl<
             }
             for mut full_side_effect in step.iter_mut() {
                 if full_side_effect.confirmed.is_none() {
-                    // Mark the first step no with encountered unconfirmed side effect
-                    if unconfirmed_step_no.is_none() {
-                        unconfirmed_step_no = Some(i);
-                    }
+                    step_with_unconfirmed_steps = Some(i);
                     // Recalculate the ID for each input side effect and compare with the input one.
-                    // Check the current unconfirmed step before attempt to confirm the full side effect.
+                    // Check the current unconfirmed step before attempt to confirm.rs the full side effect.
                     return if full_side_effect.input.generate_id::<Hasher>() == input_side_effect_id
-                        && unconfirmed_step_no == Some(i)
+                        && step_with_unconfirmed_steps == Some(i)
                     {
-                        // We found the side effect to confirm from inside the unconfirmed step.
+                        // We found the side effect to confirm.rs from inside the unconfirmed step.
                         full_side_effect.confirmed = Some(confirmed.clone());
                         Ok(true)
                     } else {
-                        Err("Attempt to confirm side effect from the next step, \
+                        Err("Attempt to confirm.rs side effect from the next step, \
                                 but there still is at least one unfinished step")
                     };
                 }
@@ -147,8 +151,15 @@ mod tests {
 
     #[test]
     fn successfully_creates_empty_xtx() {
-        let empty_xtx =
-            Xtx::<AccountId, BlockNumber, BalanceOf>::new(0, vec![], None, None, None, vec![]);
+        let empty_xtx = Xtx::<AccountId, BlockNumber, BalanceOf>::new(
+            0,
+            vec![],
+            None,
+            None,
+            None,
+            LocalState::new(),
+            vec![],
+        );
 
         assert_eq!(
             empty_xtx,
@@ -159,7 +170,8 @@ mod tests {
                 delay_steps_at: None,
                 result_status: None,
                 total_reward: None,
-                full_side_effects: vec![]
+                local_state: LocalState::new(),
+                full_side_effects: vec![],
             }
         );
     }
@@ -192,6 +204,7 @@ mod tests {
             None,
             None,
             None,
+            LocalState::new(),
             vec![vec![FullSideEffect {
                 input: input_side_effect_1.clone(),
                 confirmed: None,
@@ -268,6 +281,7 @@ mod tests {
             None,
             None,
             None,
+            LocalState::new(),
             vec![vec![
                 FullSideEffect {
                     input: input_side_effect_1.clone(),
@@ -377,6 +391,7 @@ mod tests {
             None,
             None,
             None,
+            LocalState::new(),
             vec![
                 vec![FullSideEffect {
                     input: input_side_effect_1.clone(),
@@ -484,6 +499,7 @@ mod tests {
             None,
             None,
             None,
+            LocalState::new(),
             vec![
                 vec![FullSideEffect {
                     input: input_side_effect_1.clone(),
@@ -501,7 +517,7 @@ mod tests {
             input_side_effect_2.clone(),
         );
 
-        assert_eq!(res_2_err, Err("Attempt to confirm side effect from the next step, but there still is at least one unfinished step"));
+        assert_eq!(res_2_err, Err("Attempt to confirm.rs side effect from the next step, but there still is at least one unfinished step"));
 
         // Check that the firsts AND second xtx.full_side_effects has NOT been updated
         assert_eq!(


### PR DESCRIPTION
Implement the Local Xtx State as a BTreeMap and collect arguments to store the arguments under the "keys" in the BTreeMap of that Xtx
