### PR TITLE
Readd parachain node key cmd

### DIFF
--- a/node/parachain/src/cli.rs
+++ b/node/parachain/src/cli.rs
@@ -5,6 +5,10 @@ use std::path::PathBuf;
 /// Sub-commands supported by the collator.
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
+    /// Key management CLI utilities
+    #[clap(subcommand)]
+    Key(sc_cli::KeySubcommand),
+
     /// Export the genesis state of the parachain.
     #[clap(name = "export-genesis-state")]
     ExportGenesisState(ExportGenesisStateCommand),

--- a/node/parachain/src/command.rs
+++ b/node/parachain/src/command.rs
@@ -141,6 +141,7 @@ pub fn run() -> Result<()> {
     let cli = Cli::from_args();
 
     match &cli.subcommand {
+        Some(Subcommand::Key(cmd)) => cmd.run(&cli),
         Some(Subcommand::BuildSpec(cmd)) => {
             let runner = cli.create_runner(cmd)?;
             runner.sync_run(|config| cmd.run(config.chain_spec, config.network))

--- a/node/standalone/src/cli.rs
+++ b/node/standalone/src/cli.rs
@@ -11,7 +11,7 @@ pub struct Cli {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
-    /// Key management cli utilities
+    /// Key management CLI utilities
     #[clap(subcommand)]
     Key(sc_cli::KeySubcommand),
 


### PR DESCRIPTION
For some reason the `circuit-collator key` subcommand got missing for our parachain node... 🗝️ back now