### PR TITLE
fix: align GatewayVendor enum layout across sub projects

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -78,8 +78,8 @@ impl GatewayType {
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum GatewayVendor {
-    Ethereum,
     Substrate,
+    Ethereum,
 }
 
 impl Default for GatewayVendor {


### PR DESCRIPTION
While working on the demo we were seeing `GatewayVendor=Ethereum` in Polkadot Apps UI even though in JS land we were using `GatewayVendor=Substrate`. This mini change should align GatewayVendor across the various sub projects and resolve any ambiguity.