### PR TITLE
Support protocol updates removing pallet ORML and Balances dependencies 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12036,6 +12036,7 @@ dependencies = [
  "pallet-sudo",
  "parity-scale-codec 2.3.1",
  "plain_hasher",
+ "relay-substrate-client",
  "scale-info 1.0.0",
  "serde",
  "serde_json",

--- a/pallets/circuit-portal/src/lib.rs
+++ b/pallets/circuit-portal/src/lib.rs
@@ -75,8 +75,6 @@ pub use xbridges::{
     PolkadotLikeValU64Gateway,
 };
 
-pub use t3rn_protocol::side_effects::protocol::SideEffectConfirmationProtocol;
-
 pub type AllowedSideEffect = [u8; 4];
 
 /// Defines application identifier for crypto keys of this module.

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -337,7 +337,10 @@ pub mod pallet {
             // Setup: new xtx context
             let mut local_xtx_ctx: LocalXtxCtx<T> =
                 Self::setup(CircuitStatus::Requested, &requester, fee, None)?;
-            println!("on_extrinsic_trigger -- finished setup -- XTX ID {:?}", local_xtx_ctx.xtx_id);
+            log::info!(
+                "on_extrinsic_trigger -- finished setup -- xtx id {:?}",
+                local_xtx_ctx.xtx_id
+            );
 
             // Validate: Side Effects
             Self::validate(&side_effects, &mut local_xtx_ctx, &requester, sequential)?;

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -78,8 +78,6 @@ pub mod state;
 
 pub mod escrow;
 
-pub use t3rn_protocol::side_effects::protocol::SideEffectConfirmationProtocol;
-
 /// Defines application identifier for crypto keys of this module.
 /// Every module that deals with signatures needs to declare its unique identifier for
 /// its crypto keys.
@@ -339,7 +337,7 @@ pub mod pallet {
             // Setup: new xtx context
             let mut local_xtx_ctx: LocalXtxCtx<T> =
                 Self::setup(CircuitStatus::Requested, &requester, fee, None)?;
-            log::info!("on_extrinsic_trigger -- finished setup");
+            println!("on_extrinsic_trigger -- finished setup -- XTX ID {:?}", local_xtx_ctx.xtx_id);
 
             // Validate: Side Effects
             Self::validate(&side_effects, &mut local_xtx_ctx, &requester, sequential)?;
@@ -1229,7 +1227,7 @@ impl<T: Config> Pallet<T> {
         confirm_inclusion()?;
         confirm_execution(
             pallet_xdns::Pallet::<T>::best_available(side_effect.target)?.gateway_vendor,
-            pallet_xdns::Pallet::<T>::get_gateway_value_type_unsafe(side_effect.target),
+            pallet_xdns::Pallet::<T>::get_gateway_value_unsigned_type_unsafe(&side_effect.target),
             &local_ctx.local_state,
         )?;
 

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -1135,7 +1135,7 @@ impl<T: Config> Pallet<T> {
             }
         };
 
-        let confirm_execution = |gateway_vendor, state_copy| {
+        let confirm_execution = |gateway_vendor, value_abi_unsigned_type, state_copy| {
             let mut side_effect_id: [u8; 4] = [0, 0, 0, 0];
             side_effect_id.copy_from_slice(&side_effect.encoded_action[0..4]);
             let side_effect_interface =
@@ -1152,6 +1152,7 @@ impl<T: Config> Pallet<T> {
                 EthereumSideEffectsParser<<T as pallet_circuit_portal::Config>::EthVerifier>,
             >(
                 gateway_vendor,
+                value_abi_unsigned_type,
                 &Box::new(side_effect_interface.unwrap()),
                 confirmation.encoded_effect.clone(),
                 state_copy,
@@ -1228,6 +1229,7 @@ impl<T: Config> Pallet<T> {
         confirm_inclusion()?;
         confirm_execution(
             pallet_xdns::Pallet::<T>::best_available(side_effect.target)?.gateway_vendor,
+            pallet_xdns::Pallet::<T>::get_gateway_value_type_unsafe(side_effect.target),
             &local_ctx.local_state,
         )?;
 

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -103,7 +103,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                         phase: Phase::Initialization,
                         event: Event::Circuit(crate::Event::<Test>::XTransactionReadyForExec(
                             hex!(
-                                "7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6"
+                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
                             )
                             .into()
                         )),
@@ -116,7 +116,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                                 "0101010101010101010101010101010101010101010101010101010101010101"
                             )),
                             hex!(
-                                "7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6"
+                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
                             )
                             .into(),
                             vec![SideEffect {
@@ -145,7 +145,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                 ]
             );
             let xtx_id: sp_core::H256 =
-                hex!("7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6").into();
+                hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
             let side_effect_a_id =
                 valid_transfer_side_effect.generate_id::<crate::SystemHashing<Test>>();
 
@@ -164,7 +164,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
-                    steps_cnt: (1, 1),
+                    steps_cnt: (0, 1),
                 }
             );
 
@@ -268,7 +268,7 @@ fn on_extrinsic_trigger_emit_works_with_single_transfer_insured() {
                         phase: Phase::Initialization,
                         event: Event::Circuit(crate::Event::<Test>::XTransactionReceivedForExec(
                             hex!(
-                                "7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6"
+                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
                             )
                             .into()
                         )),
@@ -281,7 +281,7 @@ fn on_extrinsic_trigger_emit_works_with_single_transfer_insured() {
                                 "0101010101010101010101010101010101010101010101010101010101010101"
                             )),
                             hex!(
-                                "7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6"
+                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
                             )
                             .into(),
                             vec![SideEffect {
@@ -356,7 +356,7 @@ fn on_extrinsic_trigger_apply_works_with_single_transfer_insured() {
             ));
 
             let xtx_id: sp_core::H256 =
-                hex!("7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6").into();
+                hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
             let side_effect_a_id =
                 valid_transfer_side_effect.generate_id::<crate::SystemHashing<Test>>();
 
@@ -388,7 +388,7 @@ fn on_extrinsic_trigger_apply_works_with_single_transfer_insured() {
                     delay_steps_at: None,
                     status: CircuitStatus::PendingInsurance,
                     total_reward: Some(fee),
-                    steps_cnt: (1, 1)
+                    steps_cnt: (0, 1)
                 }
             );
 
@@ -443,7 +443,7 @@ fn circuit_handles_insurance_deposit_for_transfers() {
             ));
 
             let xtx_id: sp_core::H256 =
-                hex!("7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6").into();
+                hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
 
             let side_effect_a_id =
                 valid_transfer_side_effect.generate_id::<crate::SystemHashing<Test>>();
@@ -476,7 +476,7 @@ fn circuit_handles_insurance_deposit_for_transfers() {
                     delay_steps_at: None,
                     status: CircuitStatus::PendingInsurance,
                     total_reward: Some(fee),
-                    steps_cnt: (1, 1),
+                    steps_cnt: (0, 1),
                 }
             );
 
@@ -522,7 +522,7 @@ fn circuit_handles_insurance_deposit_for_transfers() {
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
-                    steps_cnt: (1, 1),
+                    steps_cnt: (0, 1),
                 }
             );
 
@@ -604,7 +604,7 @@ fn circuit_handles_dirty_swap_with_no_insurance() {
             ));
 
             let xtx_id: sp_core::H256 =
-                hex!("7ac563d872efac72c7a06e78a4489a759669a34becc7eb7900e161d1b7a978a6").into();
+                hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
 
             let side_effect_a_id =
                 valid_swap_side_effect.generate_id::<crate::SystemHashing<Test>>();
@@ -619,7 +619,7 @@ fn circuit_handles_dirty_swap_with_no_insurance() {
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
-                    steps_cnt: (1, 1),
+                    steps_cnt: (0, 1),
                 }
             );
 

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -387,7 +387,8 @@ pub mod pallet {
                 <XDNSRegistry<T>>::get(chain_id)
                     .unwrap()
                     .gateway_abi
-                    .value_type_size * 8,
+                    .value_type_size
+                    * 8,
             )
         }
     }

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -17,9 +17,7 @@ use sp_std::prelude::*;
 pub use t3rn_primitives::{
     abi::GatewayABIConfig, abi::Type, ChainId, GatewayGenesisConfig, GatewayType, GatewayVendor,
 };
-pub use t3rn_protocol::side_effects::protocol::{
-    SideEffectConfirmationProtocol, SideEffectProtocol,
-};
+pub use t3rn_protocol::side_effects::protocol::SideEffectProtocol;
 // Re-export pallet items so that they can be accessed from the crate namespace.
 pub use crate::pallet::*;
 
@@ -385,7 +383,12 @@ pub mod pallet {
         }
 
         pub fn get_gateway_value_unsigned_type_unsafe(chain_id: &ChainId) -> Type {
-            Type::Uint(<XDNSRegistry<T>>::get(chain_id).unwrap().gateway_abi.value_type_size)
+            Type::Uint(
+                <XDNSRegistry<T>>::get(chain_id)
+                    .unwrap()
+                    .gateway_abi
+                    .value_type_size * 8,
+            )
         }
     }
 }
@@ -433,5 +436,3 @@ impl SideEffectProtocol for SideEffectInterface {
         self.revert_events.clone()
     }
 }
-
-impl SideEffectConfirmationProtocol for SideEffectInterface {}

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -383,6 +383,10 @@ pub mod pallet {
         pub fn get_gateway_type_unsafe(chain_id: &ChainId) -> GatewayType {
             <XDNSRegistry<T>>::get(chain_id).unwrap().gateway_type
         }
+
+        pub fn get_gateway_value_unsigned_type_unsafe(chain_id: &ChainId) -> Type {
+            Type::Uint(<XDNSRegistry<T>>::get(chain_id).unwrap().gateway_abi.value_type_size)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
This is to support the removal of pallet ORML and Balances from t3rn protocol. 

Also, it loads the value type size allowing various gateway configs to be correctly validated. 

## Checklist
- [ ] replace original balances and orml_tokens events with local enum stubs
- [ ] make sure original balances and orml_tokens encode to the same values as stubs
- [ ] remove deps to balances and orml_tokens
- [ ] fix usage at protocol importers

## Please check that your PR completes the requirements as follows
- [ ] Tests have been added for bug fixes/features
- [ ] Acceptance criteria from the issue has been completed

## Screenshots (if applicable)
