### PR TITLE
fix: rm path typo 2 docker file

### DIFF
--- a/docker/devnet/docker-compose.yml
+++ b/docker/devnet/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       --unsafe-rpc-external
       --chain /pdot/rococo-local.raw.json
       --execution Wasm
-      -lruntime=debug,parachain::pvf-checker=debug
+      -lruntime=debug
 
   bob:
     image: polkadot:release-v0.9.17
@@ -76,7 +76,7 @@ services:
       --unsafe-rpc-external
       --chain /pdot/rococo-local.raw.json
       --execution Wasm
-      -lruntime=debug,parachain::pvf-checker=debug
+      -lruntime=debug
 
   charlie:
     image: polkadot:release-v0.9.17
@@ -114,7 +114,7 @@ services:
       --unsafe-rpc-external
       --chain /pdot/rococo-local.raw.json
       --execution Wasm
-      -lruntime=debug,parachain::pvf-checker=debug
+      -lruntime=debug
 
   dave:
     image: polkadot:release-v0.9.17
@@ -199,7 +199,7 @@ services:
     image: circuit-collator:update_v0.9.17
     build:
       context: ../..
-      dockerfile: docker/xcm-devnet/t3rn.Dockerfile
+      dockerfile: docker/devnet/t3rn.Dockerfile
     networks:
       - devnet
     ports:
@@ -254,7 +254,7 @@ services:
     image: circuit-collator:update_v0.9.17
     build:
       context: ../..
-      dockerfile: docker/xcm-devnet/t3rn.Dockerfile
+      dockerfile: docker/devnet/t3rn.Dockerfile
     networks:
       - devnet
     ports:
@@ -414,113 +414,3 @@ services:
       --rpc-port 4407
       --ws-port 4418
       --execution Wasm
-
-  # acala1:
-  #   image: acala:release-acala-2.4.0
-  #   build:
-  #     context: .
-  #     dockerfile: acala.Dockerfile
-  #   networks:
-  #     - devnet
-  #   ports:
-  #     - "44444:44444"
-  #     - "4488:4488"
-  #     - "4499:4499"
-  #     - "44443:44443"
-  #     - "4487:4487"
-  #     - "4498:4498"
-  #   volumes:
-  #     - type: bind
-  #       source: ./specs/rococo-local.raw.json
-  #       target: /acala/rococo-local.raw.json
-  #       read_only: true
-  #     - type: bind
-  #       source: ./specs/acala.raw.json
-  #       target: /acala/acala.raw.json
-  #       read_only: true
-  #     - type: bind
-  #       source: ./data/acala1
-  #       target: /acala/data
-  #       read_only: false
-  #   container_name: acala1
-  #   depends_on:
-  #     - alice
-  #     - bob
-  #     - charlie
-  #     - dave
-  #     - eve
-  #   command: >
-  #     --port 44444
-  #     --rpc-port 4488
-  #     --ws-port 4499
-  #     --base-path /acala/data
-  #     --collator
-  #     --rpc-cors all
-  #     --unsafe-ws-external
-  #     --unsafe-rpc-external
-  #     --execution Wasm
-  #     -lruntime=debug
-  #     --chain /acala/acala.raw.json
-  #     --name acala1
-  #     --
-  #     --chain /acala/rococo-local.raw.json
-  #     --discover-local
-  #     --port 44443
-  #     --rpc-port 4487
-  #     --ws-port 4498
-  #     --execution Wasm
-
-  # acala2:
-  #   image: acala:release-acala-2.4.0
-  #   build:
-  #     context: .
-  #     dockerfile: acala.Dockerfile
-  #   networks:
-  #     - devnet
-  #   ports:
-  #     - "44404:44404"
-  #     - "4408:4408"
-  #     - "4409:4409"
-  #     - "44403:44403"
-  #     - "4407:4407"
-  #     - "4418:4418"
-  #   volumes:
-  #     - type: bind
-  #       source: ./specs/rococo-local.raw.json
-  #       target: /acala/rococo-local.raw.json
-  #       read_only: true
-  #     - type: bind
-  #       source: ./specs/acala.raw.json
-  #       target: /acala/acala.raw.json
-  #       read_only: true
-  #     - type: bind
-  #       source: ./data/acala2
-  #       target: /acala/data
-  #       read_only: false
-  #   container_name: acala2
-  #   depends_on:
-  #     - alice
-  #     - bob
-  #     - charlie
-  #     - dave
-  #     - eve
-  #   command: >
-  #     --port 44404
-  #     --rpc-port 4408
-  #     --ws-port 4409
-  #     --base-path /acala/data
-  #     --collator
-  #     --rpc-cors all
-  #     --unsafe-ws-external
-  #     --unsafe-rpc-external
-  #     --execution Wasm
-  #     -lruntime=debug
-  #     --chain /acala/acala.raw.json
-  #     --name acala2
-  #     --
-  #     --chain /acala/rococo-local.raw.json
-  #     --discover-local
-  #     --port 44403
-  #     --rpc-port 4407
-  #     --ws-port 4418
-  #     --execution Wasm

--- a/docker/devnet/run.sh
+++ b/docker/devnet/run.sh
@@ -185,8 +185,8 @@ set_keys() {
 
 onboard() {
   npx --yes @polkadot/api-cli@beta \
-    --ws 'ws://localhost:9944' \
-    --seed '//Alice' \
+    --ws ws://localhost:9944 \
+    --seed //Alice \
     tx.registrar.reserve
   printf \
     "%d {\"genesisHead\":\"%s\",\"validationCode\":\"%s\",\"parachain\":true}" \
@@ -195,14 +195,14 @@ onboard() {
     $(<./specs/t3rn.wasm) \
   > /tmp/t3rn.params
   npx @polkadot/api-cli@beta \
-    --ws 'ws://localhost:9944' \
+    --ws ws://localhost:9944 \
     --sudo \
-    --seed '//Alice' \
+    --seed //Alice \
     --params /tmp/t3rn.params \
     tx.parasSudoWrapper.sudoScheduleParaInitialize
   npx @polkadot/api-cli@beta \
-    --ws 'ws://localhost:9944' \
-    --seed '//Alice' \
+    --ws ws://localhost:9944 \
+    --seed //Alice \
     tx.registrar.reserve
   printf \
     "%d {\"genesisHead\":\"%s\",\"validationCode\":\"%s\",\"parachain\":true}" \
@@ -211,24 +211,24 @@ onboard() {
     $(<./specs/pchain.wasm) \
   > /tmp/pchain.params
   npx @polkadot/api-cli@beta \
-    --ws 'ws://localhost:9944' \
+    --ws ws://localhost:9944 \
     --sudo \
-    --seed '//Alice' \
+    --seed //Alice \
     --params /tmp/pchain.params \
     tx.parasSudoWrapper.sudoScheduleParaInitialize
 }
 
 channel() {
   npx @polkadot/api-cli@beta \
-    --ws 'ws://localhost:9944' \
+    --ws ws://localhost:9944 \
     --sudo \
-    --seed '//Alice' \
+    --seed //Alice \
     tx.parasSudoWrapper.sudoEstablishHrmpChannel \
     3333 3334 8 1024
   npx @polkadot/api-cli@beta \
-    --ws 'ws://localhost:9944' \
+    --ws ws://localhost:9944 \
     --sudo \
-    --seed '//Alice' \
+    --seed //Alice \
     tx.parasSudoWrapper.sudoEstablishHrmpChannel \
     3334 3333 8 1024
 }


### PR DESCRIPTION
## Summary
Fixes a path typo that would prevent building the docker images from scratch. And removes unused code.