### PR TITLE
Cancel Xtx after exceeding timeout - Closes #275

### DIFF
--- a/pallets/circuit-portal/src/lib.rs
+++ b/pallets/circuit-portal/src/lib.rs
@@ -212,7 +212,7 @@ pub mod pallet {
                 gateway_sys_props.clone(),
                 allowed_side_effects.clone(),
             )?;
-            let gtwy = scale_info::prelude::string::String::from_utf8_lossy(gateway_id.as_ref())
+            let _gtwy = scale_info::prelude::string::String::from_utf8_lossy(gateway_id.as_ref())
                 .into_owned();
             let res = match (gateway_abi.hasher, gateway_abi.block_number_type_size) {
                 (HasherAlgo::Blake2, 32) => init_bridge_instance::<T, DefaultPolkadotLikeGateway>(

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -413,7 +413,7 @@ pub mod pallet {
             // Setup: new xtx context
             let mut local_xtx_ctx: LocalXtxCtx<T> =
                 Self::setup(CircuitStatus::Requested, &requester, fee, None)?;
-            println!(
+            log::debug!(
                 "on_extrinsic_trigger -- finished setup -- xtx id {:?}",
                 local_xtx_ctx.xtx_id
             );

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -417,7 +417,6 @@ pub mod pallet {
                 "on_extrinsic_trigger -- finished setup -- xtx id {:?}",
                 local_xtx_ctx.xtx_id
             );
-
             // Validate: Side Effects
             Self::validate(&side_effects, &mut local_xtx_ctx, &requester, sequential)?;
             log::debug!("on_extrinsic_trigger -- finished validate");

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -600,6 +600,8 @@ pub mod pallet {
         XTransactionStepFinishedExec(XExecSignalId<T>),
         // Listeners - users + SDK + UI to know whether their request is accepted for exec and finished
         XTransactionXtxFinishedExecAllSteps(XExecSignalId<T>),
+        // Listeners - users + SDK + UI to know whether their request is accepted for exec and finished
+        XTransactionXtxRevertedAfterTimeOut(XExecSignalId<T>),
         // Listeners - executioners/relayers to know new challenges and perform offline risk/reward calc
         //  of whether side effect is worth picking up
         NewSideEffectsAvailable(
@@ -1079,6 +1081,8 @@ impl<T: Config> Pallet<T> {
                     Self::deposit_event(Event::XTransactionStepFinishedExec(xtx_id)),
                 CircuitStatus::FinishedAllSteps =>
                     Self::deposit_event(Event::XTransactionXtxFinishedExecAllSteps(xtx_id)),
+                CircuitStatus::RevertedTimedOut =>
+                    Self::deposit_event(Event::XTransactionXtxRevertedAfterTimeOut(xtx_id)),
                 _ => {},
             }
             if xtx.status >= CircuitStatus::PendingExecution {

--- a/pallets/circuit/src/mock.rs
+++ b/pallets/circuit/src/mock.rs
@@ -8,7 +8,7 @@ use pallet_babe::{EquivocationHandler, ExternalTrigger};
 use frame_support::{
     pallet_prelude::GenesisBuild,
     parameter_types,
-    traits::{ConstU32, Everything, KeyOwnerProofSystem, Nothing},
+    traits::{ConstU32, ConstU64, Everything, KeyOwnerProofSystem, Nothing},
 };
 use sp_runtime::{
     curve::PiecewiseLinear,
@@ -492,6 +492,8 @@ impl Config for Test {
     type SelfGatewayId = SelfGatewayId;
     type WeightInfo = ();
     type Xdns = XDNS;
+    type XtxTimeoutCheckInterval = ConstU64<10>;
+    type XtxTimeoutDefault = ConstU64<100>;
 }
 
 impl ExtBuilder {

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -1333,5 +1333,26 @@ fn circuit_cancels_xtx_after_timeout() {
             );
 
             assert_eq!(Circuit::get_active_timing_links(xtx_id), None);
+
+            // Emits event notifying about cancellation
+            let mut events = System::events();
+            assert_eq!(events.len(), 9);
+            assert_eq!(
+                events.pop(),
+                Some(EventRecord {
+                    phase: Phase::Initialization,
+                    event: Event::Circuit(
+                        crate::Event::<Test>::XTransactionXtxRevertedAfterTimeOut(
+                            hex!(
+                                "c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6"
+                            )
+                            .into()
+                        )
+                    ),
+                    topics: vec![]
+                }),
+            );
+
+            // Voids all associated side effects with Xtx by setting their confirmation to Err
         });
 }

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -42,7 +42,7 @@ fn set_ids(
     valid_side_effect: SideEffect<AccountId32, BlockNumber, BalanceOf>,
 ) -> (sp_core::H256, sp_core::H256) {
     let xtx_id: sp_core::H256 =
-        hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
+        hex!("c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6").into();
 
     let side_effect_a_id = valid_side_effect.generate_id::<crate::SystemHashing<Test>>();
 
@@ -125,7 +125,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                         phase: Phase::Initialization,
                         event: Event::Circuit(crate::Event::<Test>::XTransactionReadyForExec(
                             hex!(
-                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
+                                "c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6"
                             )
                             .into()
                         )),
@@ -138,7 +138,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                                 "0101010101010101010101010101010101010101010101010101010101010101"
                             )),
                             hex!(
-                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
+                                "c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6"
                             )
                             .into(),
                             vec![SideEffect {
@@ -167,7 +167,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                 ]
             );
             let xtx_id: sp_core::H256 =
-                hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
+                hex!("c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6").into();
             let side_effect_a_id =
                 valid_transfer_side_effect.generate_id::<crate::SystemHashing<Test>>();
 
@@ -182,7 +182,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_not_insured() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
@@ -290,7 +290,7 @@ fn on_extrinsic_trigger_emit_works_with_single_transfer_insured() {
                         phase: Phase::Initialization,
                         event: Event::Circuit(crate::Event::<Test>::XTransactionReceivedForExec(
                             hex!(
-                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
+                                "c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6"
                             )
                             .into()
                         )),
@@ -303,7 +303,7 @@ fn on_extrinsic_trigger_emit_works_with_single_transfer_insured() {
                                 "0101010101010101010101010101010101010101010101010101010101010101"
                             )),
                             hex!(
-                                "d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a"
+                                "c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6"
                             )
                             .into(),
                             vec![SideEffect {
@@ -403,7 +403,7 @@ fn on_extrinsic_trigger_apply_works_with_single_transfer_insured() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::PendingInsurance,
                     total_reward: Some(fee),
@@ -487,7 +487,7 @@ fn circuit_handles_insurance_deposit_for_transfers() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::PendingInsurance,
                     total_reward: Some(fee),
@@ -533,7 +533,7 @@ fn circuit_handles_insurance_deposit_for_transfers() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
@@ -630,7 +630,7 @@ fn circuit_handles_dirty_swap_with_no_insurance() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
@@ -752,7 +752,7 @@ fn circuit_handles_swap_with_insurance() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::PendingInsurance,
                     total_reward: Some(fee),
@@ -798,7 +798,7 @@ fn circuit_handles_swap_with_insurance() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
@@ -1003,7 +1003,7 @@ fn circuit_handles_add_liquidity_with_insurance() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::PendingInsurance,
                     total_reward: Some(fee),
@@ -1049,7 +1049,7 @@ fn circuit_handles_add_liquidity_with_insurance() {
                     requester: AccountId32::new(hex!(
                         "0101010101010101010101010101010101010101010101010101010101010101"
                     )),
-                    timeouts_at: None,
+                    timeouts_at: 100u64,
                     delay_steps_at: None,
                     status: CircuitStatus::Ready,
                     total_reward: Some(fee),
@@ -1157,7 +1157,7 @@ fn circuit_handles_transfer_and_swap() {
             assert_eq!(events.len(), 8);
 
             let xtx_id: sp_core::H256 =
-                hex!("d02e1b7d4ee308b8b0fad924fd35bb3688760fc986bc1b44e8f123f17aed8a7a").into();
+                hex!("c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6").into();
 
             // Confirmation start
             let encoded_balance_transfer_event = pallet_balances::Event::<Test>::Transfer {

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -1160,13 +1160,17 @@ fn circuit_handles_transfer_and_swap() {
                 hex!("c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6").into();
 
             // Confirmation start
-            let encoded_balance_transfer_event = pallet_balances::Event::<Test>::Transfer {
+            let mut encoded_balance_transfer_event = pallet_balances::Event::<Test>::Transfer {
                 from: hex!("0909090909090909090909090909090909090909090909090909090909090909")
                     .into(), // variant A
                 to: hex!("0606060606060606060606060606060606060606060606060606060606060606").into(), // variant B (dest)
                 amount: 1, // variant A
             }
             .encode();
+
+            // Adding 4 since Balances Pallet = 4 in construct_runtime! enum
+            let mut encoded_event = vec![4];
+            encoded_event.append(&mut encoded_balance_transfer_event);
 
             println!(
                 "full side effects before confirmation: {:?}",
@@ -1203,13 +1207,17 @@ fn circuit_handles_transfer_and_swap() {
             );
 
             // Confirmation start
-            let encoded_swap_transfer_event = orml_tokens::Event::<Test>::Transfer {
+            let mut encoded_swap_transfer_event = orml_tokens::Event::<Test>::Transfer {
                 currency_id: as_u32_le(&[0, 1, 2, 3]), // currency_id as u8 bytes [0,1,2,3] -> u32
                 from: BOB_RELAYER,                     // executor - Bob
                 to: hex!("0606060606060606060606060606060606060606060606060606060606060606").into(), // variant B (dest)
                 amount: 2u64, // amount - variant B
             }
             .encode();
+
+            // Adding 4 since Balances Pallet = 4 in construct_runtime! enum
+            let mut encoded_event = vec![4];
+            encoded_event.append(&mut encoded_swap_transfer_event);
 
             let confirmation_swap = ConfirmedSideEffect::<AccountId32, BlockNumber, BalanceOf> {
                 err: None,
@@ -1239,5 +1247,91 @@ fn circuit_handles_transfer_and_swap() {
                 None,
                 None,
             ));
+        });
+}
+
+#[test]
+fn circuit_cancels_xtx_after_timeout() {
+    let origin = Origin::signed(ALICE); // Only sudo access to register new gateways for now
+
+    let _origin_relayer_bob = Origin::signed(BOB_RELAYER); // Only sudo access to register new gateways for now
+
+    let transfer_protocol_box = ExtBuilder::get_transfer_protocol_box();
+    let _swap_protocol_box = ExtBuilder::get_swap_protocol_box();
+
+    let mut local_state = LocalState::new();
+    let valid_transfer_side_effect = produce_and_validate_side_effect(
+        vec![
+            (Type::Address(32), ArgVariant::A),
+            (Type::Address(32), ArgVariant::B),
+            (Type::Uint(64), ArgVariant::A),
+            (Type::Bytes(0), ArgVariant::A), // empty bytes instead of insurance
+        ],
+        &mut local_state,
+        transfer_protocol_box,
+    );
+
+    let side_effects = vec![valid_transfer_side_effect.clone()];
+    let fee = 1;
+    let sequential = false;
+
+    ExtBuilder::default()
+        .with_standard_side_effects()
+        .with_default_xdns_records()
+        .build()
+        .execute_with(|| {
+            let _ = Balances::deposit_creating(&ALICE, 10);
+
+            System::set_block_number(1);
+
+            assert_ok!(Circuit::on_extrinsic_trigger(
+                origin,
+                side_effects,
+                fee,
+                sequential,
+            ));
+
+            let events = System::events();
+            assert_eq!(events.len(), 8);
+
+            let xtx_id: sp_core::H256 =
+                hex!("c282160defd729da11b0cfcfed580278943723737b7017f56dbd32e695fc41e6").into();
+
+            // The tiemout links that will be checked at on_initialize are there
+            assert_eq!(Circuit::get_active_timing_links(xtx_id), Some(100u64));
+
+            assert_eq!(
+                Circuit::get_x_exec_signals(xtx_id),
+                Some(XExecSignal {
+                    requester: AccountId32::new(hex!(
+                        "0101010101010101010101010101010101010101010101010101010101010101"
+                    )),
+                    timeouts_at: 100u64,
+                    delay_steps_at: None,
+                    status: CircuitStatus::Ready,
+                    total_reward: Some(fee),
+                    steps_cnt: (0, 1),
+                })
+            );
+
+            System::set_block_number(100);
+
+            <Circuit as frame_support::traits::OnInitialize<u64>>::on_initialize(100);
+
+            assert_eq!(
+                Circuit::get_x_exec_signals(xtx_id),
+                Some(XExecSignal {
+                    requester: AccountId32::new(hex!(
+                        "0101010101010101010101010101010101010101010101010101010101010101"
+                    )),
+                    timeouts_at: 100u64,
+                    delay_steps_at: None,
+                    status: CircuitStatus::RevertedTimedOut,
+                    total_reward: Some(fee),
+                    steps_cnt: (0, 1),
+                })
+            );
+
+            assert_eq!(Circuit::get_active_timing_links(xtx_id), None);
         });
 }

--- a/runtime/parachain/src/circuit_config.rs
+++ b/runtime/parachain/src/circuit_config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use frame_support::{parameter_types, traits::ConstU64};
+use frame_support::{parameter_types, traits::ConstU32};
 use sp_core::H256;
 use sp_runtime::traits::*;
 use t3rn_primitives::bridges::runtime as bp_runtime;
@@ -65,8 +65,8 @@ impl pallet_circuit::Config for Runtime {
     type SelfGatewayId = SelfGatewayId;
     type WeightInfo = ();
     type Xdns = XDNS;
-    type XtxTimeoutCheckInterval = ConstU64<10>;
-    type XtxTimeoutDefault = ConstU64<100>;
+    type XtxTimeoutCheckInterval = ConstU32<10>;
+    type XtxTimeoutDefault = ConstU32<100>;
 }
 
 parameter_types! {

--- a/runtime/parachain/src/circuit_config.rs
+++ b/runtime/parachain/src/circuit_config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use frame_support::parameter_types;
+use frame_support::{parameter_types, traits::ConstU64};
 use sp_core::H256;
 use sp_runtime::traits::*;
 use t3rn_primitives::bridges::runtime as bp_runtime;
@@ -65,6 +65,8 @@ impl pallet_circuit::Config for Runtime {
     type SelfGatewayId = SelfGatewayId;
     type WeightInfo = ();
     type Xdns = XDNS;
+    type XtxTimeoutCheckInterval = ConstU64<10>;
+    type XtxTimeoutDefault = ConstU64<100>;
 }
 
 parameter_types! {

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use frame_support::{parameter_types, PalletId, traits::ConstU64};
+use frame_support::{parameter_types, traits::ConstU64, PalletId};
 use sp_core::H256;
 use sp_runtime::traits::*;
 use t3rn_primitives::bridges::runtime as bp_runtime;

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use frame_support::{parameter_types, PalletId};
+use frame_support::{parameter_types, PalletId, traits::ConstU64};
 use sp_core::H256;
 use sp_runtime::traits::*;
 use t3rn_primitives::bridges::runtime as bp_runtime;
@@ -65,6 +65,8 @@ impl pallet_circuit::Config for Runtime {
     type SelfGatewayId = SelfGatewayId;
     type WeightInfo = ();
     type Xdns = XDNS;
+    type XtxTimeoutCheckInterval = ConstU64<10>;
+    type XtxTimeoutDefault = ConstU64<100>;
 }
 
 parameter_types! {

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use frame_support::{parameter_types, traits::ConstU64, PalletId};
+use frame_support::{parameter_types, traits::ConstU32, PalletId};
 use sp_core::H256;
 use sp_runtime::traits::*;
 use t3rn_primitives::bridges::runtime as bp_runtime;
@@ -65,8 +65,8 @@ impl pallet_circuit::Config for Runtime {
     type SelfGatewayId = SelfGatewayId;
     type WeightInfo = ();
     type Xdns = XDNS;
-    type XtxTimeoutCheckInterval = ConstU64<10>;
-    type XtxTimeoutDefault = ConstU64<100>;
+    type XtxTimeoutCheckInterval = ConstU32<10>;
+    type XtxTimeoutDefault = ConstU32<100>;
 }
 
 parameter_types! {


### PR DESCRIPTION
## Summary
Cancel Xtx after exceeding timeout

## Checklist
- [ ] change ConfirmedSideEffect::error field from Option<Bytes> to Option<ConfirmationOutcome> that voids the future potential confirmations 

## Please check that your PR completes the requirements as follows
- [ ] Tests have been added for bug fixes/features
- [ ] Acceptance criteria from the issue has been completed

## Screenshots (if applicable)
