### PR TITLE
Rococo launch preparation

### DIFF
--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -31,7 +31,10 @@ use log::info;
 use std::{
     convert::TryFrom,
     io::{Error, ErrorKind},
+    str::FromStr,
 };
+
+const PARACHAIN_ID: u32 = 3333_u32;
 
 /// Helper function that fetches metadata from live networks and generates an XdnsRecord
 fn fetch_xdns_record_from_rpc(
@@ -300,13 +303,6 @@ pub type ChainSpec =
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
-/// Helper function to generate a crypto pair from seed
-pub fn get_public_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
-}
-
 /// The extensions for the [`ChainSpec`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
 #[serde(deny_unknown_fields)]
@@ -326,6 +322,13 @@ impl Extensions {
 
 type AccountPublic = <Signature as Verify>::Signer;
 
+/// Helper function to generate a crypto pair from seed.
+pub fn get_public_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(&format!("//{}", seed), None)
+        .expect("static values are valid; qed")
+        .public()
+}
+
 /// Generate collator keys from seed.
 ///
 /// This function's return type must always match the session keys of the chain in tuple format.
@@ -333,12 +336,32 @@ pub fn get_collator_keys_from_seed(seed: &str) -> AuraId {
     get_public_from_seed::<AuraId>(seed)
 }
 
-/// Helper function to generate an account ID from seed
+/// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
     AccountPublic: From<<TPublic::Pair as Pair>::Public>,
 {
     AccountPublic::from(get_public_from_seed::<TPublic>(seed)).into_account()
+}
+
+/// Helper function to derive an account ID from a SS58 address.
+pub fn get_account_id_from_adrs(adrs: &str) -> AccountId {
+    AccountId::from_str(adrs).expect("account id from SS58 address")
+}
+
+/// Helper function to derive a public key from a SS58 address.
+pub fn get_public_from_adrs<TPublic: Public>(adrs: &str) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(adrs, None)
+        .expect("keypair from SS58 address")
+        .public()
+}
+
+/// Derive an Aura id from a SS58 address.
+///
+/// This function's return type must always match the session keys of the chain in tuple format.
+pub fn get_aura_id_from_adrs(adrs: &str) -> AuraId {
+    use sp_core::crypto::Ss58Codec;
+    AuraId::from_string(adrs).expect("aura id from SS58 address")
 }
 
 /// Generate the session keys from individual elements.
@@ -388,7 +411,7 @@ pub fn development_config() -> ChainSpec {
                     get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
-                3333_u32.into(),
+                PARACHAIN_ID.into(),
                 // Sudo account
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 seed_xdns_registry().unwrap_or_default(),
@@ -404,7 +427,7 @@ pub fn development_config() -> ChainSpec {
         None,
         Extensions {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-            para_id: 3333_u32,                  // You MUST set this correctly!
+            para_id: PARACHAIN_ID,              // You MUST set this correctly!
         },
     )
 }
@@ -449,7 +472,7 @@ pub fn local_testnet_config() -> ChainSpec {
                     get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
-                3333_u32.into(),
+                PARACHAIN_ID.into(),
                 // Sudo account
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 seed_xdns_registry().unwrap_or_default(),
@@ -471,7 +494,76 @@ pub fn local_testnet_config() -> ChainSpec {
         // Extensions
         Extensions {
             relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-            para_id: 3333_u32,                  // You MUST set this correctly!
+            para_id: PARACHAIN_ID,              // You MUST set this correctly!
+        },
+    )
+}
+
+pub fn rococo_config() -> ChainSpec {
+    let mut properties = sc_chain_spec::Properties::new();
+    properties.insert("tokenSymbol".into(), "T0RN".into());
+    properties.insert("tokenDecimals".into(), 12.into());
+    properties.insert("ss58Format".into(), 42.into());
+
+    ChainSpec::from_genesis(
+        // Name
+        "t0rn",
+        // Id
+        "t0rn_testnet",
+        ChainType::Live,
+        move || {
+            testnet_genesis(
+                // Invulnerable collators
+                vec![
+                    (
+                        get_account_id_from_adrs(
+                            "5FKjxoi5Yfjwa1aXesFWRXMpvs4vJMXFeG2ydFPyNwUn4qiW",
+                        ),
+                        get_aura_id_from_adrs("5FKjxoi5Yfjwa1aXesFWRXMpvs4vJMXFeG2ydFPyNwUn4qiW"),
+                    ),
+                    (
+                        get_account_id_from_adrs(
+                            "5DcyZrktqRvmpHQGLJEucnYM6qwJpG8HN8zaL8dvGUsBb67v",
+                        ),
+                        get_aura_id_from_adrs("5DcyZrktqRvmpHQGLJEucnYM6qwJpG8HN8zaL8dvGUsBb67v"),
+                    ),
+                ],
+                // Prefunded accounts
+                vec![
+                    get_account_id_from_adrs("5D333eBb5VugHioFoU5nGMbUaR2uYcoyk5qZj9tXRA5ers7A"),
+                    get_account_id_from_adrs("5CAYyLZxG4oYQP8CGTYgPPhkoT42NyMvi2J3hKPCLGyKHAC4"),
+                    get_account_id_from_adrs("5GducktTqf8KKeatpex4kwkg1PZZimY1xUDUFoBZ2s5EDfVf"),
+                    get_account_id_from_adrs("5CqRUh9fiVgzMftXmacNSNMXF4TDfkUXCTZvXfuYXA33knRC"),
+                    get_account_id_from_adrs("5DXBQResSqHCGijMH1UtpQNZzpjdCqHtad14FUnwaSA7xmRL"),
+                    get_account_id_from_adrs("5HomG74gKivcZfCLixXyZbuGg57Bc8ZR55BkAX2jus2dSYS1"),
+                    get_account_id_from_adrs("5FQpivNZCVw3LQWoQwrF44CLeP1g5j8RSAtcR4kURbZwXgXg"),
+                    get_account_id_from_adrs("5GLMuTmTvNCWkYCYc2DNPWjTMKa2nKW6yYH8xKqeiPHgcLNs"),
+                    get_account_id_from_adrs("5DWyim48gMrAhoHz9pjb6qu5Q8paDmeWhisALuV9cS8NvScG"),
+                    get_account_id_from_adrs("5FU77XnhRuBD6VSA8ZvwqB6BSjyYEGtS4HPwMMU6WwqpVmmV"),
+                ],
+                PARACHAIN_ID.into(),
+                // Sudo
+                get_account_id_from_adrs("5D333eBb5VugHioFoU5nGMbUaR2uYcoyk5qZj9tXRA5ers7A"),
+                seed_xdns_registry().unwrap_or_default(),
+                standard_side_effects(),
+                initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
+                    .expect("initial gateways"),
+            )
+        },
+        // Bootnodes
+        Vec::new(),
+        // Telemetry
+        None,
+        // Protocol ID
+        Some("t0rn"),
+        // Fork ID
+        None,
+        // Properties
+        Some(properties),
+        // Extensions
+        Extensions {
+            relay_chain: "rococo".into(), // You MUST set this to the correct network!
+            para_id: PARACHAIN_ID,        // You MUST set this correctly!
         },
     )
 }

--- a/node/parachain/src/command.rs
+++ b/node/parachain/src/command.rs
@@ -24,8 +24,8 @@ use std::{io::Write, net::SocketAddr};
 fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
     Ok(match id {
         "dev" => Box::new(chain_spec::development_config()),
-        "template-rococo" => Box::new(chain_spec::local_testnet_config()),
-        "" | "local" => Box::new(chain_spec::local_testnet_config()),
+        "" | "local" | "rococo-local" => Box::new(chain_spec::local_testnet_config()),
+        "rococo" | "rococo-live" => Box::new(chain_spec::rococo_config()),
         path => Box::new(chain_spec::ChainSpec::from_json_file(
             std::path::PathBuf::from(path),
         )?),
@@ -34,7 +34,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, St
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Circuit Collator".into()
     }
 
     fn impl_version() -> String {
@@ -42,7 +42,7 @@ impl SubstrateCli for Cli {
     }
 
     fn description() -> String {
-        "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+        "Circuit Collator\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		parachain-collator <parachain-args> -- <relay-chain-args>"
@@ -72,7 +72,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
     fn impl_name() -> String {
-        "Parachain Collator Template".into()
+        "Circuit Collator".into()
     }
 
     fn impl_version() -> String {
@@ -80,7 +80,7 @@ impl SubstrateCli for RelayChainCli {
     }
 
     fn description() -> String {
-        "Parachain Collator Template\n\nThe command-line arguments provided first will be \
+        "Circuit Collator\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
 		parachain-collator <parachain-args> -- <relay-chain-args>"

--- a/runtime/parachain/src/lib.rs
+++ b/runtime/parachain/src/lib.rs
@@ -175,8 +175,8 @@ impl_opaque_keys! {
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("circuit-parachain"),
-    impl_name: create_runtime_str!("circuit-parachain"),
+    spec_name: create_runtime_str!("t0rn"),
+    impl_name: create_runtime_str!("Circuit Collator"),
     authoring_version: 1,
     spec_version: 1,
     impl_version: 0,

--- a/scripts/get-rococo-artifacts.sh
+++ b/scripts/get-rococo-artifacts.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -Ee
+
+if [[ -z $1 || -z $2 ]]; then
+  echo "usage: $0 't0rn collator one adrs' 't0rn collator two adrs'"
+  # fx: ssh alibaba@000.00.00.00 'bash -s' < ./get-rococo-artifacts.sh 'adrs one' 'adrs two'
+  exit 1
+fi
+
+t0rn_collator_one_adrs=$1
+t0rn_collator_two_adrs=$2
+root_dir=$(git rev-parse --show-toplevel)
+collator_binary=$root_dir/target/release/circuit-collator
+output_dir=$root_dir/specs
+
+# build the collator
+cargo build \
+  --locked \
+  --release \
+  --manifest-path $root_dir/node/parachain/Cargo.toml
+
+# gen the collator chain spec blueprint
+$collator_binary build-spec \
+  --chain rococo \
+  --disable-default-bootnode \
+> $output_dir/t0rn.json
+
+# reset the collators node addresses - replacing alice and bob
+sed "s/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY/$t0rn_collator_one_adrs/g" \
+  -i $output_dir/t0rn.json
+sed "s/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty/$t0rn_collator_two_adrs/g" \
+  -i $output_dir/t0rn.json
+
+# gen the raw collator chain spec
+$collator_binary \
+  build-spec \
+  --chain $output_dir/t0rn.json \
+  --disable-default-bootnode \
+  --raw \
+> $output_dir/t0rn.raw.json
+
+# gen the collator genesis state
+$collator_binary \
+  export-genesis-state \
+  --chain $output_dir/t0rn.raw.json \
+> $output_dir/t0rn.genesis
+
+# gen the collator genesis wasm
+$collator_binary export-genesis-wasm > $output_dir/t0rn.wasm
+
+# fetch rococo chain spec
+curl -fsSL \
+  -o $output_dir/rococo.raw.json \
+  https://paritytech.github.io/chainspecs/rococo/relaychain/chainspec.json
+
+# reporting
+echo "📦 all artifacts stored at $output_dir..."
+ls $output_dir
+
+echo "commit, tag, and push these artifacts, wait for the pipeline to release the prebuilt collator, then ssh alibaba@000.00.00.00 'bash -s' < ./run-rococo-collators.sh v0.0.0-roco \"'secret one'\" \"'secret two'\""

--- a/scripts/run-rococo-collators.sh
+++ b/scripts/run-rococo-collators.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+set -xEe
+
+if [[ -z $1 || -z "$2" || -z "$3" ]]; then
+  echo "usage: $0 \$tag \"'t0rn collator one secret'\" \"'t0rn collator two secret'\""
+  # fx: ssh alibaba@000.00.00.00 'bash -s' < ./run-rococo-collators.sh v0.0.0-roco "'secret one'" "'secret two'"
+  exit 1
+fi
+
+tag=$1
+t0rn_collator_one_secret="$2"
+t0rn_collator_two_secret="$3"
+collator_binary=/home/atlas/rococo/circuit-collator
+sleep_binary=$(which sleep)
+artifacts_dir=/home/atlas/rococo/specs
+t0rn_collator_one_home=/home/atlas/rococo/t0rn-collator-one
+t0rn_collator_two_home=/home/atlas/rococo/t0rn-collator-two
+systemd_user_service_dir=/home/atlas/.config/systemd/user
+
+# prep permanent locations
+mkdir -p \
+  /home/atlas/rococo \
+  $t0rn_collator_one_home \
+  $t0rn_collator_two_home \
+  $artifacts_dir \
+  $systemd_user_service_dir
+
+# pull a prebuilt circuit collator binary
+curl -sSfL \
+  https://github.com/t3rn/t3rn/releases/download/$tag/t0rn-circuit-collator-$tag-x86_64-unknown-linux-gnu.gz \
+| \
+gunzip \
+> $collator_binary
+chmod +x $collator_binary
+
+# copy semi static chain specs
+curl -sSfL \
+  -o $artifacts_dir/rococo.raw.json \
+  https://raw.githubusercontent.com/t3rn/t3rn/$tag/specs/rococo.raw.json
+
+curl -sSfL \
+  -o $artifacts_dir/t0rn.genesis \
+  https://raw.githubusercontent.com/t3rn/t3rn/$tag/specs/t0rn.genesis
+
+curl -sSfL \
+  -o $artifacts_dir/t0rn.json \
+  https://raw.githubusercontent.com/t3rn/t3rn/$tag/specs/t0rn.json
+
+curl -sSfL \
+  -o $artifacts_dir/t0rn.raw.json \
+  https://raw.githubusercontent.com/t3rn/t3rn/$tag/specs/t0rn.raw.json
+
+curl -sSfL \
+  -o $artifacts_dir/t0rn.wasm \
+  https://raw.githubusercontent.com/t3rn/t3rn/$tag/specs/t0rn.wasm
+
+# boot node(s) - FIXME: gt 1; space/comma-separated list not valid
+rococo_boot_nodes="$(jq -r .bootNodes[0] $artifacts_dir/rococo.raw.json)"
+
+# define the t0rn-collator-one systemd service
+echo "
+[Unit]
+Description=t0rn-collator-one
+After=network.target
+StartLimitIntervalSec=1d
+StartLimitBurst=5
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStartPre=$collator_binary \
+  purge-chain \
+  -y \
+  --base-path $t0rn_collator_one_home \
+  --chain $artifacts_dir/t0rn.raw.json
+ExecStart=$collator_binary \
+  --collator \
+  --name t0rn-collator-one \
+  --base-path $t0rn_collator_one_home \
+  --chain $artifacts_dir/t0rn.raw.json \
+  --discover-local \
+  --port 33333 \
+  --rpc-port 8833 \
+  --ws-port 9933 \
+  --rpc-methods=Safe \
+  --rpc-cors http://localhost,https://polkadot.js.org,https://t3rn.vercel.app,https://t3rn-alice.vercel.app \
+  --execution Wasm \
+  --pruning=archive \
+  --no-prometheus \
+  -- \
+  --chain $artifacts_dir/rococo.raw.json \
+  --bootnodes \"$rococo_boot_nodes\" \
+  --port 10001 \
+  --rpc-port 8001 \
+  --ws-port 9001 \
+  --execution Wasm \
+  --no-prometheus
+ExecStartPost=$sleep_binary 33s
+ExecStartPost=$collator_binary \
+  key \
+  insert \
+  --base-path $t0rn_collator_one_home \
+  --chain $artifacts_dir/t0rn.raw.json \
+  --scheme Sr25519 \
+  --suri \"$t0rn_collator_one_secret\" \
+  --key-type aura
+
+[Install]
+WantedBy=multi-user.target
+" > $systemd_user_service_dir/t0rn-collator-one.service
+
+# define the t0rn-collator-two systemd service
+echo "
+[Unit]
+Description=t0rn-collator-two
+After=network.target
+StartLimitIntervalSec=1d
+StartLimitBurst=5
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10s
+ExecStartPre=$collator_binary \
+  purge-chain \
+  -y \
+  --base-path $t0rn_collator_two_home \
+  --chain $artifacts_dir/t0rn.raw.json
+ExecStart=$collator_binary \
+  --collator \
+  --name t0rn-collator-two \
+  --base-path $t0rn_collator_two_home \
+  --chain $artifacts_dir/t0rn.raw.json \
+  --discover-local \
+  --port 33332 \
+  --rpc-port 8832 \
+  --ws-port 9932 \
+  --rpc-methods=Safe \
+  --rpc-cors http://localhost,https://polkadot.js.org,https://t3rn.vercel.app,https://t3rn-alice.vercel.app \
+  --execution Wasm \
+  --pruning=archive \
+  --no-prometheus \
+  -- \
+  --chain $artifacts_dir/rococo.raw.json \
+  --bootnodes \"$rococo_boot_nodes\" \
+  --port 10002 \
+  --rpc-port 8002 \
+  --ws-port 9002 \
+  --execution Wasm \
+  --no-prometheus
+ExecStartPost=$sleep_binary 33s
+ExecStartPost=$collator_binary \
+  key \
+  insert \
+  --base-path $t0rn_collator_two_home \
+  --chain $artifacts_dir/t0rn.raw.json \
+  --scheme Sr25519 \
+  --suri \"$t0rn_collator_two_secret\" \
+  --key-type aura
+
+[Install]
+WantedBy=multi-user.target
+" > $systemd_user_service_dir/t0rn-collator-two.service
+
+# start the collators...
+systemctl --user enable t0rn-collator-one.service
+systemctl --user enable t0rn-collator-two.service
+systemctl --user start t0rn-collator-one.service
+systemctl --user start t0rn-collator-two.service


### PR DESCRIPTION
## Summary
Bundles a wild set of changes in preparation and required for launching on Rococo.

## Checklist
- [x] adds a top level `scripts` dir
- [x]  a script that generates all required artifacts for obboarding t0rn on Rococo
- [x] defines two user space systemd services for our collators in reproducible scripts
- [x] adjusts chain spec contents, fx `RuntimeVersion.spec_name` balances, collators, sudo, etc...

Once this is merged I will need to tag development, to have chain spec changes aligned with the prebuilt collator binaries we are running and the `polkadot-js/apps` config changes I been staging.
