### PR TITLE
Connect XDNS RPC to standalone and parachain nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,7 @@ dependencies = [
  "pallet-contracts-rpc",
  "pallet-transaction-payment-rpc",
  "pallet-xdns",
+ "pallet-xdns-rpc",
  "parity-scale-codec 2.3.1",
  "polkadot-cli",
  "polkadot-parachain",
@@ -1184,6 +1185,7 @@ dependencies = [
  "pallet-wasm-contracts",
  "pallet-xcm",
  "pallet-xdns",
+ "pallet-xdns-rpc-runtime-api",
  "parachain-info",
  "parity-scale-codec 2.3.1",
  "polkadot-parachain",
@@ -1226,6 +1228,7 @@ dependencies = [
  "pallet-contracts-rpc",
  "pallet-transaction-payment-rpc",
  "pallet-xdns",
+ "pallet-xdns-rpc",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
@@ -7029,6 +7032,22 @@ dependencies = [
  "sp-version",
  "t3rn-primitives",
  "t3rn-protocol",
+]
+
+[[package]]
+name = "pallet-xdns-rpc"
+version = "1.0.0-alpha.0"
+dependencies = [
+ "jsonrpc-core 18.0.0",
+ "jsonrpc-core-client 18.0.0",
+ "jsonrpc-derive",
+ "pallet-xdns-rpc-runtime-api",
+ "parity-scale-codec 2.3.1",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/node/parachain/Cargo.toml
+++ b/node/parachain/Cargo.toml
@@ -24,6 +24,7 @@ serde        = { version = "1.0", features = [ "derive" ] }
 circuit-parachain-runtime = { path = "../../runtime/parachain" }
 pallet-3vm-contracts-rpc  = { path = "../../3vm/pallets/wasm-contracts/rpc", package = "pallet-contracts-rpc" }
 pallet-xdns               = { path = "../../pallets/xdns" }
+pallet-xdns-rpc           = { path = "../../pallets/xdns/rpc" }
 t3rn-primitives           = { path = "../../primitives" }
 
 # Extras

--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -27,7 +27,6 @@ use t3rn_primitives::{
     ChainId, GatewayGenesisConfig, GatewaySysProps, GatewayType, GatewayVendor, Header,
 };
 
-use log::info;
 use std::{
     convert::TryFrom,
     io::{Error, ErrorKind},

--- a/node/parachain/src/rpc.rs
+++ b/node/parachain/src/rpc.rs
@@ -9,6 +9,7 @@ use circuit_parachain_runtime::{
     opaque::Block, AccountId, Balance, BlockNumber, Hash, Index as Nonce,
 };
 use pallet_3vm_contracts_rpc::{Contracts, ContractsApi};
+use pallet_xdns_rpc::{Xdns, XdnsApi};
 use sc_client_api::AuxStore;
 pub use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};
 use sc_transaction_pool_api::TransactionPool;
@@ -43,7 +44,9 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api:
         pallet_3vm_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
+    C::Api: pallet_xdns_rpc::XdnsRuntimeApi<Block, AccountId>,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
+    C::Api: pallet_xdns_rpc::XdnsRuntimeApi<Block, AccountId>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + Sync + Send + 'static,
 {
@@ -65,6 +68,7 @@ where
     io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
         client.clone(),
     )));
+    io.extend_with(XdnsApi::to_delegate(Xdns::new(client.clone())));
     io.extend_with(ContractsApi::to_delegate(Contracts::new(client)));
 
     io

--- a/node/parachain/src/service.rs
+++ b/node/parachain/src/service.rs
@@ -194,6 +194,7 @@ where
         + cumulus_primitives_core::CollectCollationInfo<Block>
         + pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
         + pallet_3vm_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>
+        + pallet_xdns_rpc::XdnsRuntimeApi<Block, AccountId>
         + substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
     sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
     Executor: sc_executor::NativeExecutionDispatch + 'static,

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -60,6 +60,7 @@ frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", 
 circuit-standalone-runtime = { path = "../../runtime/standalone" }
 pallet-3vm-contracts-rpc   = { path = "../../3vm/pallets/wasm-contracts/rpc", package = "pallet-contracts-rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
+pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }
 t3rn-primitives            = { path = "../../primitives" }
 
 [build-dependencies]

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -21,7 +21,6 @@ use t3rn_primitives::{
     ChainId, GatewayGenesisConfig, GatewaySysProps, GatewayType, GatewayVendor, Header,
 };
 
-use log::info;
 use std::{
     convert::TryFrom,
     io::{Error, ErrorKind},

--- a/node/standalone/src/rpc.rs
+++ b/node/standalone/src/rpc.rs
@@ -7,6 +7,7 @@
 
 use circuit_standalone_runtime::{opaque::Block, AccountId, Balance, BlockNumber, Hash, Index};
 use pallet_3vm_contracts_rpc::{Contracts, ContractsApi};
+use pallet_xdns_rpc::{Xdns, XdnsApi};
 pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
@@ -34,6 +35,7 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api:
         pallet_3vm_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber, Hash>,
+    C::Api: pallet_xdns_rpc::XdnsRuntimeApi<Block, AccountId>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {
@@ -56,6 +58,7 @@ where
         client.clone(),
     )));
     io.extend_with(ContractsApi::to_delegate(Contracts::new(client.clone())));
+    io.extend_with(XdnsApi::to_delegate(Xdns::new(client.clone())));
 
     io
 }

--- a/pallets/xdns/rpc/Cargo.toml
+++ b/pallets/xdns/rpc/Cargo.toml
@@ -14,9 +14,9 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 
 [dependencies]
 codec               = { package = "parity-scale-codec", version = "2.2.0", default-features = false }
-jsonrpc-core        = "15.1.0"
-jsonrpc-core-client = "15.1.0"
-jsonrpc-derive      = "15.1.0"
+jsonrpc-core        = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive      = "18.0.0"
 
 pallet-xdns-rpc-runtime-api = { path = "runtime-api" }
 sp-api                      = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.17' }

--- a/pallets/xdns/rpc/src/lib.rs
+++ b/pallets/xdns/rpc/src/lib.rs
@@ -11,8 +11,10 @@ pub use pallet_xdns_rpc_runtime_api::XdnsRuntimeApi;
 use pallet_xdns_rpc_runtime_api::{ChainId, FetchXdnsRecordsResponse, GatewayABIConfig};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
-use sp_runtime::generic::BlockId;
-use sp_runtime::traits::{Block as BlockT, MaybeDisplay};
+use sp_runtime::{
+    generic::BlockId,
+    traits::{Block as BlockT, MaybeDisplay},
+};
 
 const RUNTIME_ERROR: i64 = 1;
 const NO_KNOWN_RECORDS: i64 = 2;
@@ -47,7 +49,7 @@ impl<C, Block, AccountId> XdnsApi<AccountId> for Xdns<C, Block>
 where
     AccountId: Codec + MaybeDisplay,
     Block: BlockT,
-    C: 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+    C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: XdnsRuntimeApi<Block, AccountId>,
 {
     fn fetch_records(&self) -> Result<FetchXdnsRecordsResponse<AccountId>> {

--- a/runtime/parachain/Cargo.toml
+++ b/runtime/parachain/Cargo.toml
@@ -90,6 +90,7 @@ pallet-3vm-contracts-rpc-runtime-api  = { path = "../../3vm/pallets/wasm-contrac
 pallet-contracts-registry             = { path = "../../pallets/contracts-registry", default-features = false }
 pallet-mfv                            = { path = "../../pallets/multi-finality-verifier", package = "pallet-multi-finality-verifier", default-features = false }
 pallet-xdns                           = { path = "../../pallets/xdns", default-features = false }
+pallet-xdns-rpc-runtime-api           = { path = "../../pallets/xdns/rpc/runtime-api", default-features = false }
 
 [features]
 default = [ "std" ]
@@ -150,6 +151,7 @@ std = [
   "t3rn-protocol/std",
   # t3rn pallets
   "pallet-xdns/std",
+  "pallet-xdns-rpc-runtime-api/std",
   "pallet-mfv/std",
   "pallet-contracts-registry/std",
   "pallet-circuit-portal/std",

--- a/runtime/parachain/src/lib.rs
+++ b/runtime/parachain/src/lib.rs
@@ -21,6 +21,7 @@ use sp_runtime::{
     ApplyExtrinsicResult, MultiSignature,
 };
 
+use pallet_xdns_rpc_runtime_api::{ChainId, FetchXdnsRecordsResponse, GatewayABIConfig};
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -504,7 +505,7 @@ construct_runtime!(
 
         // Circuit
         RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage} = 200,
-       // t3rn pallets
+        // t3rn pallets
         XDNS: pallet_xdns::{Pallet, Call, Config<T>, Storage, Event<T>} = 100,
         MultiFinalityVerifierPolkadotLike: pallet_mfv::<Instance1>::{
             Pallet, Call, Storage, Config<T, I>
@@ -690,6 +691,21 @@ impl_runtime_apis! {
             key: [u8; 32],
         ) -> pallet_3vm_contracts_primitives::GetStorageResult {
             Contracts::get_storage(address, key)
+        }
+    }
+
+    impl pallet_xdns_rpc_runtime_api::XdnsRuntimeApi<Block, AccountId> for Runtime {
+        fn fetch_records() -> FetchXdnsRecordsResponse<AccountId> {
+             FetchXdnsRecordsResponse {
+                xdns_records: <XDNS as t3rn_primitives::xdns::Xdns<Runtime>>::fetch_records()
+            }
+        }
+
+        fn fetch_abi(chain_id: ChainId) -> Option<GatewayABIConfig> {
+            match <XDNS as t3rn_primitives::xdns::Xdns<Runtime>>::get_abi(chain_id) {
+                Ok(abi) => Some(abi),
+                Err(_) => None,
+            }
         }
     }
 

--- a/runtime/standalone/Cargo.toml
+++ b/runtime/standalone/Cargo.toml
@@ -112,6 +112,7 @@ std = [
   "orml-tokens/std",
   "orml-traits/std",
   "pallet-xdns/std",
+  "pallet-xdns-rpc-runtime-api/std",
   "pallet-circuit/std",
   #"volatile-vm/std",
   # native contracts VMs

--- a/runtime/standalone/src/lib.rs
+++ b/runtime/standalone/src/lib.rs
@@ -9,6 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use pallet_grandpa::{
     fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
+use pallet_xdns_rpc_runtime_api::{ChainId, FetchXdnsRecordsResponse, GatewayABIConfig};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -536,6 +537,21 @@ impl_runtime_apis! {
             key: [u8; 32],
         ) -> pallet_3vm_contracts_primitives::GetStorageResult {
             Contracts::get_storage(address, key)
+        }
+    }
+
+    impl pallet_xdns_rpc_runtime_api::XdnsRuntimeApi<Block, AccountId> for Runtime {
+        fn fetch_records() -> FetchXdnsRecordsResponse<AccountId> {
+             FetchXdnsRecordsResponse {
+                xdns_records: <XDNS as t3rn_primitives::xdns::Xdns<Runtime>>::fetch_records()
+            }
+        }
+
+        fn fetch_abi(chain_id: ChainId) -> Option<GatewayABIConfig> {
+            match <XDNS as t3rn_primitives::xdns::Xdns<Runtime>>::get_abi(chain_id) {
+                Ok(abi) => Some(abi),
+                Err(_) => None,
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Reconnects XDNS RPC to standalone and parachain nodes.

## Checklist
- [x] XDNS RPC exposed by standalone node
- [x] XDNS RPC exposed by parachain node

## Please check that your PR completes the requirements as follows
- [ ] Tests have been added for bug fixes/features
- [x] Acceptance criteria from the issue has been completed

## Snippet

Fetch records from a local standalone node:

``` bash
curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
     "jsonrpc":"2.0",
      "id":1,
      "method":"xdns_fetchRecords",
      "params": []
    }'
```