### PR TITLE
fix: unhalt the pallet and any preregistered gateways

### DIFF
--- a/pallets/multi-finality-verifier/src/lib.rs
+++ b/pallets/multi-finality-verifier/src/lib.rs
@@ -579,9 +579,12 @@ pub mod pallet {
             }
 
             if let Some(init_data) = self.init_data.clone() {
-                for gtwy in init_data {
-                    initialize_single_bridge::<T, I>(gtwy);
+                for gateway in init_data {
+                    let gateway_id = gateway.gateway_id;
+                    initialize_single_bridge::<T, I>(gateway);
+                    <IsHaltedMap<T, I>>::insert(gateway_id, false);
                 }
+                <IsHalted<T, I>>::put(false);
             } else {
                 // Since the bridge hasn't been initialized we shouldn't allow anyone to perform
                 // transactions.


### PR DESCRIPTION
## Summary
Fixes a bug in mfv regarding to gateway preregistration. The mfv pallet and any preregistered gateways are now unhalted right from initialization.

## Checklist
- [x] unhalts preregistered gateways
- [x] unhalts mfv pallet as a whole 

## Screenshots (if applicable)
how mfv interaction it fails:
![halted](https://user-images.githubusercontent.com/22937570/166219066-590e18a0-3b8e-4e8f-96de-a2bc015f91e0.png)

