### PR TITLE
chore: pin types pkg deps

### DIFF
--- a/client/types/package.json
+++ b/client/types/package.json
@@ -43,13 +43,12 @@
     "email": "team@t3rn.io"
   },
   "homepage": "https://github.com/t3rn/t3rn",
-  "devDependencies": {
-    "typescript": "^4.4.4"
-  },
   "dependencies": {
-    "@polkadot/typegen": "^7.15.1",
-    "prettier": "^2.5.1",
-    "prettier-plugin-jsdoc": "^0.3.31",
-    "rimraf": "^3.0.2"
+    "@polkadot/typegen": "8.4.2",
+    "prettier": "2.5.1",
+    "prettier-plugin-jsdoc": "0.3.31",
+    "rimraf": "3.0.2",
+    "ts-node": "10.7.0",
+    "typescript": "4.4.4"
   }
 }


### PR DESCRIPTION
## Summary
Pins `@t3rn/types` package dependencies to avoid breakage and/or old/resolved errors from creeping back up.

## Checklist
- [x] all deps in `package.json` refer to solely one specific version
- [x] `@polkadot/typegen@8.4.2` includes Zannis' short-vec-fix
- [x] `yarn generate && yarn build` work and produce artifacts
