### PR TITLE
Adds github action for generating and deploying rust docs

### DIFF
--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -6,9 +6,7 @@ name: update rust docs
 on:
   # Triggers the workflow on push or pull request events but only for the development branch
   push:
-    branches: [ add_docs ]
-  pull_request:
-    branches: [ add_docs ]
+    branches: [ development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: update rust docs 
+name: update rust docs
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -25,8 +25,16 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 #        run: git submodule deinit --all && git submodule init && git submodule update
+      - name: ⚙️Get nightly rust toolchain with wasm target
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-11-01
+          profile: minimal
+          components: rustfmt
+          override: true
       - name: Generate Docs
         uses: actions-rs/cargo@v1
+        continue-on-error: false
         with:
           command: doc
           args: --no-deps --workspace --exclude t3rn-protocol

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: update rust docs
+name: update rust docs 
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: UPDATE_RUST_DOCS
+name: update rust docs
 
 # Controls when the workflow will run
 on:
@@ -55,4 +55,4 @@ jobs:
       - name: Adding Known Hosts
         run: ssh-keyscan -H ${{ secrets.ATLAS_IP }} >> ~/.ssh/known_hosts
       - name: Deploy with rsync
-        run: rsync -avz ./target/doc ${{ secrets.RUSTDOCS_SSH_USER }}@${{ secrets.ATLAS_IP }}:/home/${{ secrets.RUSTDOCS_SSH_USER }}/docs
+        run: rsync -avz ./target/doc ${{ secrets.RUSTDOCS_SSH_USER }}@${{ secrets.ATLAS_IP }}:/home/${{ secrets.RUSTDOCS_SSH_USER }}/

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   docs:
-    runs-on: ubunutu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: ☁️Checkout git repo
         uses: actions/checkout@v2

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -32,6 +32,15 @@ jobs:
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
           override: true
+      - name: 🕒 Cache Rust binaries and packages
+        uses: actions/cache@v2
+        id: cache-rust
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Generate Docs
         uses: actions-rs/cargo@v1
         continue-on-error: false

--- a/.github/workflows/update_dev_docs.yml
+++ b/.github/workflows/update_dev_docs.yml
@@ -25,12 +25,12 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 #        run: git submodule deinit --all && git submodule init && git submodule update
-      - name: ⚙️Get nightly rust toolchain with wasm target
+      - name: ⚙️ Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-11-01
-          profile: minimal
-          components: rustfmt
+          target: wasm32-unknown-unknown
+          components: rustfmt, clippy
           override: true
       - name: Generate Docs
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Summary
Adds a github action for generating rustdocs on each development merge. The docs are then sent to atlas, where they are served from via nginx. Protocol is not included.
