### PR TITLE
fix: collation check ci pipeline points to development explicitly

### DIFF
--- a/.github/workflows/collation-check.yml
+++ b/.github/workflows/collation-check.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: ☁ Checkout git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: development
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 
@@ -21,7 +22,7 @@ jobs:
       - name: 🧱 Check Circuit's collations
         run: |
           finalized_head(){
-            block_hash=$( \
+            printf $( \
               curl \
                 -sSfH "content-type: application/json" \
                 -d '{"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]}' \
@@ -29,16 +30,15 @@ jobs:
                 | \
                 jq -r .result \
             )
-            printf $block_hash
           }
-          genesis=$(finalized_head)
-          block_hash=$genesis
+          start_hash=$(finalized_head)
+          block_hash=$start_hash
           i=$((0))
-          echo "genesis $genesis"
-          while [[ $block_hash -eq $genesis ]]; do
+          echo "start_hash $start_hash"
+          while [[ $block_hash -eq $start_hash ]]; do
             sleep 6s
             block_hash=$(finalized_head)
-            echo "block_hash $block_hash"
+            echo "$i block_hash $block_hash"
             i=$((i+1))
             if (( $i == 34 )); then
               echo "circuit not producing collations" >&2


### PR DESCRIPTION
## Summary
Attempt to fix ENOENT 4 `pchain.Dockerfile` by pointing 2 up2date `development`.
