### PR TITLE
fix: adjust compose file version and run against latest circuit

### DIFF
--- a/.github/workflows/collation-check.yml
+++ b/.github/workflows/collation-check.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '33 3 * * *'
 
+env:
+  COLLATOR_IMAGE: circuit-collator:update_v0.9.19
+
 jobs:
   collate-check:
     runs-on: self-hosted
@@ -14,6 +17,14 @@ jobs:
           ref: development
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
+
+      - name: 🐋 Rebuild fresh Circuit image
+        working-directory: ./docker/devnet
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker image rm -f ${{ env.COLLATOR_IMAGE }}
+          docker build -t ${{ env.COLLATOR_IMAGE }} -f t3rn.Dockerfile ../..
 
       - name: Up ⚡BI devnet
         working-directory: ./docker/devnet

--- a/docker/devnet/docker-compose.yml
+++ b/docker/devnet/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.3"
 
 networks:
   devnet:


### PR DESCRIPTION
## Context
Collation CI still [failing](https://github.com/t3rn/t3rn/runs/6640963777?check_suite_focus=true).

## Summary
Adjust the Docker Compose file version and adds a prep step that rebuilds the Circuit image on top of the latest development.