### PR TITLE
WIP: Seed the XDNS registry with all Rococo parachains

### DIFF
--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -22,7 +22,14 @@ use t3rn_primitives::{
     abi::Type,
     bridges::{
         header_chain::InitializationData,
-        runtime::{KUSAMA_CHAIN_ID, POLKADOT_CHAIN_ID, ROCOCO_CHAIN_ID},
+        runtime::{
+            BASILISK_CHAIN_ID, BITGREEN_CHAIN_ID, CATALYST_CHAIN_ID, DALI_CHAIN_ID,
+            DOLPHIN_CHAIN_ID, GENSHIRO_CHAIN_ID, KUSAMA_CHAIN_ID, PANGOLIN_CHAIN_ID,
+            POLKADOT_CHAIN_ID, ROBONOMICS_CHAIN_ID, ROCFINITY_CHAIN_ID, ROCOCO_CHAIN_ID,
+            ROCOCO_ENCOINTER_CHAIN_ID, ROCOCO_IMBUE_CHAIN_ID, ROCOCO_INTEGRITEE_CHAIN_ID,
+            ROCOCO_LITENTRY_CHAIN_ID, ROCOCO_NODLE_CHAIN_ID, ROCOCO_ORIGINTRAIL_CHAIN_ID,
+            ROCOCO_TURING_CHAIN_ID, ROCOCO_VIRTO_CHAIN_ID, SNOWBLINK_CHAIN_ID, SOONSOCIAL_CHAIN_ID,
+        },
     },
     side_effect::interface::SideEffectInterface,
     xdns::XdnsRecord,
@@ -31,15 +38,20 @@ use t3rn_primitives::{
 
 const PARACHAIN_ID: u32 = 3333_u32;
 
-/// Helper function that fetches metadata from live networks and generates an XdnsRecord
+/// Helper function that fetches metadata from live networks and generates a XdnsRecord.
 fn fetch_xdns_record_from_rpc(
-    params: &ConnectionParams,
+    provider_host: &str,
     chain_id: t3rn_primitives::ChainId,
 ) -> Result<XdnsRecord<AccountId>, Error> {
     async_std::task::block_on(async move {
-        let client = create_rpc_client(params).await.unwrap();
+        let params = ConnectionParams {
+            host: String::from(provider_host),
+            port: 443,
+            secure: true,
+        };
 
-        let _runtime_version = client.clone().runtime_version().await.unwrap();
+        let client = create_rpc_client(&params).await.unwrap();
+
         let metadata = get_metadata(&client.clone()).await.unwrap();
 
         let gateway_sys_props = GatewaySysProps::try_from(&chain_id)
@@ -66,39 +78,109 @@ fn fetch_xdns_record_from_rpc(
                 genesis_hash: client.genesis_hash.0.to_vec(),
             },
             gateway_sys_props,
-            vec![],
+            vec![*b"tran"],
         ))
     })
 }
 
-/// Helper function to generate Polkadot and Kusama XdnsRecords from RPC
+/// Helper function to generate XdnsRecords from RPC.
 fn seed_xdns_registry() -> Result<Vec<XdnsRecord<AccountId>>, Error> {
-    let polkadot_connection_params: ConnectionParams = ConnectionParams {
-        host: String::from("rpc.polkadot.io"),
-        port: 443,
-        secure: true,
-    };
-
-    let kusama_connection_params: ConnectionParams = ConnectionParams {
-        host: String::from("kusama-rpc.polkadot.io"),
-        port: 443,
-        secure: true,
-    };
-
-    let rococo_connection_params: ConnectionParams = ConnectionParams {
-        host: String::from("rococo-rpc.polkadot.io"),
-        port: 443,
-        secure: true,
-    };
-
-    let polkadot_xdns = fetch_xdns_record_from_rpc(&polkadot_connection_params, POLKADOT_CHAIN_ID)
+    // Relaychains
+    let polkadot_xdns = fetch_xdns_record_from_rpc("rpc.polkadot.io", POLKADOT_CHAIN_ID)
         .expect("fetching polkadot xdns info failed");
-    let kusama_xdns = fetch_xdns_record_from_rpc(&kusama_connection_params, KUSAMA_CHAIN_ID)
+    let kusama_xdns = fetch_xdns_record_from_rpc("kusama-rpc.polkadot.io", KUSAMA_CHAIN_ID)
         .expect("fetching kusama xdns info failed");
-    let rococo_xdns = fetch_xdns_record_from_rpc(&rococo_connection_params, ROCOCO_CHAIN_ID)
+    let rococo_xdns = fetch_xdns_record_from_rpc("rococo-rpc.polkadot.io", ROCOCO_CHAIN_ID)
         .expect("fetching rococo xdns info failed");
 
-    Ok(vec![polkadot_xdns, kusama_xdns, rococo_xdns])
+    // Rococo parachains...
+    let encointer_xdns =
+        fetch_xdns_record_from_rpc("rococo.api.encointer.org", ROCOCO_ENCOINTER_CHAIN_ID)
+            .expect("fetching encointer xdns info failed");
+    let basilisk_xdns =
+        fetch_xdns_record_from_rpc("rpc-01.basilisk-rococo.hydradx.io", BASILISK_CHAIN_ID)
+            .expect("fetching basilisk xdns info failed");
+    let bitgreen_xdns =
+        fetch_xdns_record_from_rpc("rococobitgreen.abhath-labs.com", BITGREEN_CHAIN_ID)
+            .expect("fetching bitgreen xdns info failed");
+    let catalyst_xdns =
+        fetch_xdns_record_from_rpc("fullnode.catalyst.cntrfg.com", CATALYST_CHAIN_ID)
+            .expect("fetching catalyst xdns info failed");
+    let dali_xdns = fetch_xdns_record_from_rpc("rpc.composablefinance.ninja", DALI_CHAIN_ID)
+        .expect("fetching dali xdns info failed");
+    let dolphin_xdns =
+        fetch_xdns_record_from_rpc("ws.rococo.dolphin.engineering", DOLPHIN_CHAIN_ID)
+            .expect("fetching dolphin xdns info failed");
+    let rocfinity_xdns = fetch_xdns_record_from_rpc("rpc.rococo.efinity.io", ROCFINITY_CHAIN_ID)
+        .expect("fetching rocfinity xdns info failed");
+    let genshiro_xdns = fetch_xdns_record_from_rpc(
+        "parachain-testnet.equilab.io/rococo/collator/node1/wss",
+        GENSHIRO_CHAIN_ID,
+    )
+    .expect("fetching genshiro xdns info failed");
+    let imbue_xdns = fetch_xdns_record_from_rpc("rococo.imbue.network", ROCOCO_IMBUE_CHAIN_ID)
+        .expect("fetching imbue xdns info failed");
+    let integritee_xdns =
+        fetch_xdns_record_from_rpc("rococo.api.integritee.network", ROCOCO_INTEGRITEE_CHAIN_ID)
+            .expect("fetching integritee xdns info failed");
+    let litentry_xdns = fetch_xdns_record_from_rpc(
+        "rpc.rococo-parachain-sg.litentry.io",
+        ROCOCO_LITENTRY_CHAIN_ID,
+    )
+    .expect("fetching litentry xdns info failed");
+    let nodle_xdns = fetch_xdns_record_from_rpc(
+        "node-6913072722034561024.lh.onfinality.io/ws?apikey=84d77e2e-3793-4785-8908-5096cffea77a",
+        ROCOCO_NODLE_CHAIN_ID,
+    )
+    .expect("fetching nodle xdns info failed");
+    let origintrail_xdns = fetch_xdns_record_from_rpc(
+        "parachain-testnet-rpc.origin-trail.network",
+        ROCOCO_ORIGINTRAIL_CHAIN_ID,
+    )
+    .expect("fetching origintrail xdns info failed");
+    let pangolin_xdns =
+        fetch_xdns_record_from_rpc("pangolin-parachain-rpc.darwinia.network", PANGOLIN_CHAIN_ID)
+            .expect("fetching pangolin xdns info failed");
+    let robonomics_xdns =
+        fetch_xdns_record_from_rpc("rococo.rpc.robonomics.network", ROBONOMICS_CHAIN_ID)
+            .expect("fetching robonomics xdns info failed");
+    let snowblink_xdns =
+        fetch_xdns_record_from_rpc("rococo-rpc.snowbridge.network", SNOWBLINK_CHAIN_ID)
+            .expect("fetching snowbridge xdns info failed");
+    let soonsocial_xdns =
+        fetch_xdns_record_from_rpc("rco-para.subsocial.network", SOONSOCIAL_CHAIN_ID)
+            .expect("fetching soonsocial xdns info failed");
+    let turing_xdns =
+        fetch_xdns_record_from_rpc("rpc.turing-staging.oak.tech", ROCOCO_TURING_CHAIN_ID)
+            .expect("fetching turing xdns info failed");
+    let virto_xdns = fetch_xdns_record_from_rpc("rococo.virtonetwork.xyz", ROCOCO_VIRTO_CHAIN_ID)
+        .expect("fetching virto xdns info failed");
+    // ...Rococo parachains
+
+    Ok(vec![
+        polkadot_xdns,
+        kusama_xdns,
+        rococo_xdns,
+        encointer_xdns,
+        basilisk_xdns,
+        bitgreen_xdns,
+        catalyst_xdns,
+        dali_xdns,
+        dolphin_xdns,
+        rocfinity_xdns,
+        genshiro_xdns,
+        imbue_xdns,
+        integritee_xdns,
+        litentry_xdns,
+        nodle_xdns,
+        origintrail_xdns,
+        pangolin_xdns,
+        robonomics_xdns,
+        snowblink_xdns,
+        soonsocial_xdns,
+        turing_xdns,
+        virto_xdns,
+    ])
 }
 
 fn standard_side_effects() -> Vec<SideEffectInterface> {
@@ -412,8 +494,9 @@ pub fn development_config() -> ChainSpec {
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 seed_xdns_registry().unwrap_or_default(),
                 standard_side_effects(),
-                initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
-                    .expect("initial gateways"),
+                vec![],
+                // initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
+                //     .expect("initial gateways"),
             )
         },
         Vec::new(),
@@ -473,8 +556,9 @@ pub fn local_testnet_config() -> ChainSpec {
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 seed_xdns_registry().unwrap_or_default(),
                 standard_side_effects(),
-                initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
-                    .expect("initial gateways"),
+                vec![],
+                // initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
+                //     .expect("initial gateways"),
             )
         },
         // Bootnodes
@@ -542,8 +626,9 @@ pub fn rococo_config() -> ChainSpec {
                 get_account_id_from_adrs("5D333eBb5VugHioFoU5nGMbUaR2uYcoyk5qZj9tXRA5ers7A"),
                 seed_xdns_registry().unwrap_or_default(),
                 standard_side_effects(),
-                initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
-                    .expect("initial gateways"),
+                vec![],
+                // initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
+                //     .expect("initial gateways"),
             )
         },
         // Bootnodes

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -21,7 +21,14 @@ use t3rn_primitives::{
     abi::Type,
     bridges::{
         header_chain::InitializationData,
-        runtime::{KUSAMA_CHAIN_ID, POLKADOT_CHAIN_ID, ROCOCO_CHAIN_ID},
+        runtime::{
+            BASILISK_CHAIN_ID, BITGREEN_CHAIN_ID, CATALYST_CHAIN_ID, DALI_CHAIN_ID,
+            DOLPHIN_CHAIN_ID, GENSHIRO_CHAIN_ID, KUSAMA_CHAIN_ID, PANGOLIN_CHAIN_ID,
+            POLKADOT_CHAIN_ID, ROBONOMICS_CHAIN_ID, ROCFINITY_CHAIN_ID, ROCOCO_CHAIN_ID,
+            ROCOCO_ENCOINTER_CHAIN_ID, ROCOCO_IMBUE_CHAIN_ID, ROCOCO_INTEGRITEE_CHAIN_ID,
+            ROCOCO_LITENTRY_CHAIN_ID, ROCOCO_NODLE_CHAIN_ID, ROCOCO_ORIGINTRAIL_CHAIN_ID,
+            ROCOCO_TURING_CHAIN_ID, ROCOCO_VIRTO_CHAIN_ID, SNOWBLINK_CHAIN_ID, SOONSOCIAL_CHAIN_ID,
+        },
     },
     side_effect::interface::SideEffectInterface,
     xdns::XdnsRecord,
@@ -66,15 +73,20 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 // 	)
 // }
 
-/// Helper function that fetches metadata from live networks and generates an XdnsRecord
+/// Helper function that fetches metadata from live networks and generates a XdnsRecord.
 fn fetch_xdns_record_from_rpc(
-    params: &ConnectionParams,
+    provider_host: &str,
     chain_id: t3rn_primitives::ChainId,
 ) -> Result<XdnsRecord<AccountId>, Error> {
     async_std::task::block_on(async move {
-        let client = create_rpc_client(params).await.unwrap();
+        let params = ConnectionParams {
+            host: String::from(provider_host),
+            port: 443,
+            secure: true,
+        };
 
-        let _runtime_version = client.clone().runtime_version().await.unwrap();
+        let client = create_rpc_client(&params).await.unwrap();
+
         let metadata = get_metadata(&client.clone()).await.unwrap();
 
         let gateway_sys_props = GatewaySysProps::try_from(&chain_id)
@@ -106,34 +118,104 @@ fn fetch_xdns_record_from_rpc(
     })
 }
 
-/// Helper function to generate Polkadot and Kusama XdnsRecords from RPC
+/// Helper function to generate XdnsRecords from RPC.
 fn seed_xdns_registry() -> Result<Vec<XdnsRecord<AccountId>>, Error> {
-    let polkadot_connection_params: ConnectionParams = ConnectionParams {
-        host: String::from("rpc.polkadot.io"),
-        port: 443,
-        secure: true,
-    };
-
-    let kusama_connection_params: ConnectionParams = ConnectionParams {
-        host: String::from("kusama-rpc.polkadot.io"),
-        port: 443,
-        secure: true,
-    };
-
-    let rococo_connection_params: ConnectionParams = ConnectionParams {
-        host: String::from("rococo-rpc.polkadot.io"),
-        port: 443,
-        secure: true,
-    };
-
-    let polkadot_xdns = fetch_xdns_record_from_rpc(&polkadot_connection_params, POLKADOT_CHAIN_ID)
+    // Relaychains
+    let polkadot_xdns = fetch_xdns_record_from_rpc("rpc.polkadot.io", POLKADOT_CHAIN_ID)
         .expect("fetching polkadot xdns info failed");
-    let kusama_xdns = fetch_xdns_record_from_rpc(&kusama_connection_params, KUSAMA_CHAIN_ID)
+    let kusama_xdns = fetch_xdns_record_from_rpc("kusama-rpc.polkadot.io", KUSAMA_CHAIN_ID)
         .expect("fetching kusama xdns info failed");
-    let _rococo_xdns = fetch_xdns_record_from_rpc(&rococo_connection_params, ROCOCO_CHAIN_ID)
+    let rococo_xdns = fetch_xdns_record_from_rpc("rococo-rpc.polkadot.io", ROCOCO_CHAIN_ID)
         .expect("fetching rococo xdns info failed");
 
-    Ok(vec![polkadot_xdns, kusama_xdns /*rococo_xdns*/])
+    // Rococo parachains...
+    let encointer_xdns =
+        fetch_xdns_record_from_rpc("rococo.api.encointer.org", ROCOCO_ENCOINTER_CHAIN_ID)
+            .expect("fetching encointer xdns info failed");
+    let basilisk_xdns =
+        fetch_xdns_record_from_rpc("rpc-01.basilisk-rococo.hydradx.io", BASILISK_CHAIN_ID)
+            .expect("fetching basilisk xdns info failed");
+    let bitgreen_xdns =
+        fetch_xdns_record_from_rpc("rococobitgreen.abhath-labs.com", BITGREEN_CHAIN_ID)
+            .expect("fetching bitgreen xdns info failed");
+    let catalyst_xdns =
+        fetch_xdns_record_from_rpc("fullnode.catalyst.cntrfg.com", CATALYST_CHAIN_ID)
+            .expect("fetching catalyst xdns info failed");
+    let dali_xdns = fetch_xdns_record_from_rpc("rpc.composablefinance.ninja", DALI_CHAIN_ID)
+        .expect("fetching dali xdns info failed");
+    let dolphin_xdns =
+        fetch_xdns_record_from_rpc("ws.rococo.dolphin.engineering", DOLPHIN_CHAIN_ID)
+            .expect("fetching dolphin xdns info failed");
+    let rocfinity_xdns = fetch_xdns_record_from_rpc("rpc.rococo.efinity.io", ROCFINITY_CHAIN_ID)
+        .expect("fetching rocfinity xdns info failed");
+    let genshiro_xdns = fetch_xdns_record_from_rpc(
+        "parachain-testnet.equilab.io/rococo/collator/node1/wss",
+        GENSHIRO_CHAIN_ID,
+    )
+    .expect("fetching genshiro xdns info failed");
+    let imbue_xdns = fetch_xdns_record_from_rpc("rococo.imbue.network", ROCOCO_IMBUE_CHAIN_ID)
+        .expect("fetching imbue xdns info failed");
+    let integritee_xdns =
+        fetch_xdns_record_from_rpc("rococo.api.integritee.network", ROCOCO_INTEGRITEE_CHAIN_ID)
+            .expect("fetching integritee xdns info failed");
+    let litentry_xdns = fetch_xdns_record_from_rpc(
+        "rpc.rococo-parachain-sg.litentry.io",
+        ROCOCO_LITENTRY_CHAIN_ID,
+    )
+    .expect("fetching litentry xdns info failed");
+    let nodle_xdns = fetch_xdns_record_from_rpc(
+        "node-6913072722034561024.lh.onfinality.io/ws?apikey=84d77e2e-3793-4785-8908-5096cffea77a",
+        ROCOCO_NODLE_CHAIN_ID,
+    )
+    .expect("fetching nodle xdns info failed");
+    let origintrail_xdns = fetch_xdns_record_from_rpc(
+        "parachain-testnet-rpc.origin-trail.network",
+        ROCOCO_ORIGINTRAIL_CHAIN_ID,
+    )
+    .expect("fetching origintrail xdns info failed");
+    let pangolin_xdns =
+        fetch_xdns_record_from_rpc("pangolin-parachain-rpc.darwinia.network", PANGOLIN_CHAIN_ID)
+            .expect("fetching pangolin xdns info failed");
+    let robonomics_xdns =
+        fetch_xdns_record_from_rpc("rococo.rpc.robonomics.network", ROBONOMICS_CHAIN_ID)
+            .expect("fetching robonomics xdns info failed");
+    let snowblink_xdns =
+        fetch_xdns_record_from_rpc("rococo-rpc.snowbridge.network", SNOWBLINK_CHAIN_ID)
+            .expect("fetching snowbridge xdns info failed");
+    let soonsocial_xdns =
+        fetch_xdns_record_from_rpc("rco-para.subsocial.network", SOONSOCIAL_CHAIN_ID)
+            .expect("fetching soonsocial xdns info failed");
+    let turing_xdns =
+        fetch_xdns_record_from_rpc("rpc.turing-staging.oak.tech", ROCOCO_TURING_CHAIN_ID)
+            .expect("fetching turing xdns info failed");
+    let virto_xdns = fetch_xdns_record_from_rpc("rococo.virtonetwork.xyz", ROCOCO_VIRTO_CHAIN_ID)
+        .expect("fetching virto xdns info failed");
+    // ...Rococo parachains
+
+    Ok(vec![
+        polkadot_xdns,
+        kusama_xdns,
+        rococo_xdns,
+        encointer_xdns,
+        basilisk_xdns,
+        bitgreen_xdns,
+        catalyst_xdns,
+        dali_xdns,
+        dolphin_xdns,
+        rocfinity_xdns,
+        genshiro_xdns,
+        imbue_xdns,
+        integritee_xdns,
+        litentry_xdns,
+        nodle_xdns,
+        origintrail_xdns,
+        pangolin_xdns,
+        robonomics_xdns,
+        snowblink_xdns,
+        soonsocial_xdns,
+        turing_xdns,
+        virto_xdns,
+    ])
 }
 
 fn standard_side_effects() -> Vec<SideEffectInterface> {
@@ -351,7 +433,6 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 seed_xdns_registry().unwrap_or_default(),
                 standard_side_effects(),
                 vec![],
-                // FIXME
                 // initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
                 //     .expect("initial gateways"),
                 true,
@@ -408,7 +489,6 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                 seed_xdns_registry().unwrap_or_default(),
                 standard_side_effects(),
                 vec![],
-                // FIXME
                 // initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])
                 //     .expect("initial gateways"),
                 true,

--- a/pallets/circuit-portal/src/lib.rs
+++ b/pallets/circuit-portal/src/lib.rs
@@ -217,6 +217,7 @@ pub mod pallet {
                 gateway_genesis,
                 gateway_sys_props.clone(),
                 allowed_side_effects.clone(),
+                true, // force ~ overwrite existing XDNS record
             )?;
 
             let res = match (gateway_abi.hasher, gateway_abi.block_number_type_size) {

--- a/pallets/multi-finality-verifier/src/lib.rs
+++ b/pallets/multi-finality-verifier/src/lib.rs
@@ -970,6 +970,7 @@ mod tests {
             Default::default(),
             gateway_sys_props,
             vec![],
+            false,
         );
 
         Pallet::<TestRuntime>::initialize_single(origin, init_data.clone()).map(|_| init_data)

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -120,6 +120,7 @@ pub mod pallet {
             gateway_genesis: GatewayGenesisConfig,
             gateway_sys_props: GatewaySysProps,
             allowed_side_effects: Vec<AllowedSideEffect>,
+            force: bool,
         ) -> DispatchResultWithPostInfo {
             <Self as Xdns<T>>::add_new_xdns_record(
                 origin,
@@ -132,6 +133,7 @@ pub mod pallet {
                 gateway_genesis,
                 gateway_sys_props,
                 allowed_side_effects,
+                force,
             )?;
             Ok(().into())
         }
@@ -321,11 +323,12 @@ pub mod pallet {
             gateway_genesis: GatewayGenesisConfig,
             gateway_sys_props: GatewaySysProps,
             allowed_side_effects: Vec<AllowedSideEffect>,
+            force: bool,
         ) -> DispatchResult {
             ensure_root(origin)?;
 
             // early exit if record already exists in storage
-            if <XDNSRegistry<T>>::contains_key(&gateway_id) {
+            if <XDNSRegistry<T>>::contains_key(&gateway_id) && !force {
                 return Err(Error::<T>::XdnsRecordAlreadyExists.into())
             }
 

--- a/pallets/xdns/src/tests.rs
+++ b/pallets/xdns/src/tests.rs
@@ -52,6 +52,7 @@ fn should_add_a_new_xdns_record_if_it_doesnt_exist() {
             Default::default(),
             Default::default(),
             vec![],
+            false
         ));
         assert_eq!(XDNSRegistry::<Test>::iter().count(), 1);
         assert!(XDNSRegistry::<Test>::get(b"test").is_some());
@@ -191,6 +192,7 @@ fn should_not_add_a_new_xdns_record_if_it_already_exists() {
                     Default::default(),
                     Default::default(),
                     vec![],
+                    false
                 ),
                 crate::pallet::Error::<Test>::XdnsRecordAlreadyExists
             );

--- a/primitives/src/bridges/runtime/mod.rs
+++ b/primitives/src/bridges/runtime/mod.rs
@@ -63,6 +63,63 @@ pub const GATEWAY_CHAIN_ID: ChainId = *b"gate";
 /// Bridge-with-Wococo instance id.
 pub const CIRCUIT_CHAIN_ID: ChainId = *b"circ";
 
+/// Encointer
+pub const ROCOCO_ENCOINTER_CHAIN_ID: ChainId = *b"renc";
+
+/// Basilisk
+pub const BASILISK_CHAIN_ID: ChainId = *b"basi";
+
+/// Bitgreen
+pub const BITGREEN_CHAIN_ID: ChainId = *b"bitg";
+
+/// Catalyst
+pub const CATALYST_CHAIN_ID: ChainId = *b"cata";
+
+/// Dali
+pub const DALI_CHAIN_ID: ChainId = *b"dali";
+
+/// Dolphin
+pub const DOLPHIN_CHAIN_ID: ChainId = *b"dolp";
+
+/// Genshiro
+pub const GENSHIRO_CHAIN_ID: ChainId = *b"gens";
+
+/// Imbue
+pub const ROCOCO_IMBUE_CHAIN_ID: ChainId = *b"rimb";
+
+/// Integritee
+pub const ROCOCO_INTEGRITEE_CHAIN_ID: ChainId = *b"rint";
+
+/// Litentry
+pub const ROCOCO_LITENTRY_CHAIN_ID: ChainId = *b"rite";
+
+/// Nodle
+pub const ROCOCO_NODLE_CHAIN_ID: ChainId = *b"rnod";
+
+/// OriginTrail
+pub const ROCOCO_ORIGINTRAIL_CHAIN_ID: ChainId = *b"rori";
+
+/// Pangolin
+pub const PANGOLIN_CHAIN_ID: ChainId = *b"pang";
+
+/// Robonomics
+pub const ROBONOMICS_CHAIN_ID: ChainId = *b"rrob";
+
+/// Rocfinity
+pub const ROCFINITY_CHAIN_ID: ChainId = *b"rocf";
+
+/// Snowbridge
+pub const SNOWBLINK_CHAIN_ID: ChainId = *b"snwb";
+
+/// SoonSocial
+pub const SOONSOCIAL_CHAIN_ID: ChainId = *b"soon";
+
+/// Turing
+pub const ROCOCO_TURING_CHAIN_ID: ChainId = *b"rtur";
+
+/// Virto
+pub const ROCOCO_VIRTO_CHAIN_ID: ChainId = *b"rvir";
+
 /// Call-dispatch module prefix.
 pub const CALL_DISPATCH_MODULE_PREFIX: &[u8] = b"pallet-bridge/dispatch";
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,7 +18,14 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use crate::bridges::runtime::{KUSAMA_CHAIN_ID, POLKADOT_CHAIN_ID, ROCOCO_CHAIN_ID};
+use crate::bridges::runtime::{
+    BASILISK_CHAIN_ID, BITGREEN_CHAIN_ID, CATALYST_CHAIN_ID, DALI_CHAIN_ID, DOLPHIN_CHAIN_ID,
+    GENSHIRO_CHAIN_ID, KUSAMA_CHAIN_ID, PANGOLIN_CHAIN_ID, POLKADOT_CHAIN_ID, ROBONOMICS_CHAIN_ID,
+    ROCFINITY_CHAIN_ID, ROCOCO_CHAIN_ID, ROCOCO_ENCOINTER_CHAIN_ID, ROCOCO_IMBUE_CHAIN_ID,
+    ROCOCO_INTEGRITEE_CHAIN_ID, ROCOCO_LITENTRY_CHAIN_ID, ROCOCO_NODLE_CHAIN_ID,
+    ROCOCO_ORIGINTRAIL_CHAIN_ID, ROCOCO_TURING_CHAIN_ID, ROCOCO_VIRTO_CHAIN_ID, SNOWBLINK_CHAIN_ID,
+    SOONSOCIAL_CHAIN_ID,
+};
 use codec::{Decode, Encode};
 use frame_support::traits::{ReservableCurrency, Time};
 use scale_info::TypeInfo;
@@ -144,7 +151,9 @@ impl TryFrom<&ChainId> for GatewaySysProps {
 
     /// Maps a chain id to its system properties.
     ///
-    /// Based on https://wiki.polkadot.network/docs/build-ss58-registry.
+    /// Source of truth for Substrate parachains system properties is the
+    /// corresponding chain's metadata tab in the polkadot apps browser ui:
+    /// https://polkadot.js.org/apps/?rpc=${PROVIDER}#/settings/metadata.
     fn try_from(chain_id: &ChainId) -> Result<Self, Self::Error> {
         match chain_id {
             b"circ" => Ok(GatewaySysProps {
@@ -170,6 +179,101 @@ impl TryFrom<&ChainId> for GatewaySysProps {
             &ROCOCO_CHAIN_ID => Ok(GatewaySysProps {
                 ss58_format: 42,
                 token_symbol: Encode::encode("ROC"),
+                token_decimals: 12,
+            }),
+            &ROCOCO_ENCOINTER_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 2,
+                token_symbol: Encode::encode("ROC"), // notatypo
+                token_decimals: 12,
+            }),
+            &BASILISK_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 10041,
+                token_symbol: Encode::encode("BSX"),
+                token_decimals: 12,
+            }),
+            &BITGREEN_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 42,
+                token_symbol: Encode::encode("BBB"),
+                token_decimals: 18,
+            }),
+            &CATALYST_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 36,
+                token_symbol: Encode::encode("NCFG"),
+                token_decimals: 18,
+            }),
+            &DALI_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 49,
+                token_symbol: Encode::encode("DALI"),
+                token_decimals: 12,
+            }),
+            &DOLPHIN_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 78,
+                token_symbol: Encode::encode("DOL"),
+                token_decimals: 18,
+            }),
+            &ROCFINITY_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 195,
+                token_symbol: Encode::encode("RFI"),
+                token_decimals: 18,
+            }),
+            &GENSHIRO_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 67,
+                token_symbol: Encode::encode("Token"),
+                token_decimals: 9,
+            }),
+            &ROCOCO_IMBUE_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 42,
+                token_symbol: Encode::encode("IMBU"),
+                token_decimals: 12,
+            }),
+            &ROCOCO_INTEGRITEE_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 13,
+                token_symbol: Encode::encode("TEER"),
+                token_decimals: 12,
+            }),
+            &ROCOCO_LITENTRY_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 131,
+                token_symbol: Encode::encode("LIT"),
+                token_decimals: 12,
+            }),
+            &ROCOCO_NODLE_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 37,
+                token_symbol: Encode::encode("notNODL"),
+                token_decimals: 11,
+            }),
+            &ROCOCO_ORIGINTRAIL_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 101,
+                token_symbol: Encode::encode("OTP"),
+                token_decimals: 12,
+            }),
+            &PANGOLIN_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 42,
+                token_symbol: Encode::encode("PRING"),
+                token_decimals: 18,
+            }),
+            &ROBONOMICS_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 32,
+                token_symbol: Encode::encode("XRT"),
+                token_decimals: 9,
+            }),
+            &SNOWBLINK_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 42,
+                token_symbol: Encode::encode("SNO"),
+                token_decimals: 12,
+            }),
+            &SOONSOCIAL_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 28,
+                token_symbol: Encode::encode("SUB"),
+                token_decimals: 10,
+            }),
+            &ROCOCO_TURING_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 51,
+                token_symbol: Encode::encode("TUR"),
+                token_decimals: 10,
+            }),
+            &ROCOCO_VIRTO_CHAIN_ID => Ok(GatewaySysProps {
+                ss58_format: 42,
+                token_symbol: Encode::encode("Unit"),
                 token_decimals: 12,
             }),
             _ => Err("unknown chain id"),

--- a/primitives/src/xdns.rs
+++ b/primitives/src/xdns.rs
@@ -155,6 +155,7 @@ pub trait Xdns<T: frame_system::Config> {
         gateway_genesis: GatewayGenesisConfig,
         gateway_sys_props: GatewaySysProps,
         allowed_side_effects: Vec<AllowedSideEffect>,
+        force: bool,
     ) -> DispatchResult;
 
     fn allowed_side_effects(gateway_id: &ChainId)


### PR DESCRIPTION
## Summary
Seeds the XDNS registry with all live Rococo parachains.

## Checklist
- [x] `add_new_xdns_record()` now got a `force: bool` param
- [x] `register_gateway()` now overwrites possibly existing XDNS records
- [x] adds records for all running Rococo parachains

## Please check that your PR completes the requirements as follows
- [x] Tests have been added for bug fixes/features
- [x] Acceptance criteria from the issue has been completed
