### PR TITLE
fix: grandpa-ranger decoder deps

### DIFF
--- a/client/grandpa-ranger/justification-decoder/Cargo.toml
+++ b/client/grandpa-ranger/justification-decoder/Cargo.toml
@@ -6,11 +6,11 @@ version = "0.1.0"
 [workspace]
 
 [dependencies]
-codec               = { package = "parity-scale-codec", version = "3", default-features = true, features = [ "derive" ] }
+codec               = { package = "parity-scale-codec", version = "2.2.0", default-features = true, features = [ "derive" ] }
 finality-grandpa    = { version = "0.14.0", default-features = true }
 frame-support       = { default-features = true, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.19' }
 hex                 = "0.4.3"
-scale-info          = { version = "2", default-features = true, features = [ "derive" ] }
+scale-info          = { version = "1.0", default-features = true, features = [ "derive" ] }
 serde               = { version = "1.0.105", features = [ "derive" ] }
 serde_json          = "1.0.50"
 sp-core             = { git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.19', default-features = true }


### PR DESCRIPTION
## Summary
Reverts updates to `codec` and `scale-info` to allow justification decoding.
