### PR TITLE
fix: maybe install subkey while ./devnet/run.sh up

### DIFF
--- a/.github/workflows/collation-check.yml
+++ b/.github/workflows/collation-check.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   collate-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3

--- a/devnet/run.sh
+++ b/devnet/run.sh
@@ -2,7 +2,7 @@
 
 set -xEeo pipefail
 
-PDOT_BRANCH=release-v0.9.19
+PDOT_BRANCH=${PDOT_BRANCH:-release-v0.9.19}
 
 dir=$(git rev-parse --show-toplevel)/devnet
 
@@ -28,6 +28,13 @@ build_nodes() {
 }
 
 keygen() {
+  if ! cargo install --list | grep -Fq 'subkey v2.0.1'; then
+    echo "installing subkey v2.0.1..."
+    cargo install subkey \
+      --git https://github.com/paritytech/substrate \
+      --version 2.0.1 \
+      --force
+  fi
   ## gen custom node keys 4 the 2 parachains
   subkey generate --scheme Sr25519 > $dir/specs/circuita1.key
   subkey generate --scheme Sr25519 > $dir/specs/circuita2.key


### PR DESCRIPTION
## Summary
Installs `subkey` during `./devnet/run.sh up` if it is not present on the system. Should ultimately fix the collation check CI..

## Checklist
- [x] installs `subkey` if not available
- [x] env var `PDOT_BRANCH` can now be set from CLI, defaults to `release-v0.9.19`
- [x] bumps runner to `ubuntu-22.04`