### PR TITLE
Prevent replay attack when confirming side effect - Closes #366

### DIFF
--- a/pallets/circuit-portal/src/lib.rs
+++ b/pallets/circuit-portal/src/lib.rs
@@ -448,10 +448,16 @@ impl<T: Config> CircuitPortal<T> for Pallet<T> {
     fn confirm_event_inclusion(
         gateway_id: [u8; 4],
         encoded_event: Vec<u8>,
-        _encoded_submission_target_height: Vec<u8>,
+        encoded_submission_target_height: Vec<u8>,
         maybe_proof: Option<Vec<Vec<u8>>>,
         maybe_block_hash: Option<Vec<u8>>,
     ) -> Result<(), &'static str> {
+        Self::read_cmp_latest_target_height(
+            gateway_id,
+            None,
+            Some(encoded_submission_target_height),
+        )?;
+
         let gateway_xdns_record = <T as Config>::Xdns::best_available(gateway_id)?;
 
         match gateway_xdns_record.gateway_vendor {
@@ -487,7 +493,6 @@ impl<T: Config> CircuitPortal<T> for Pallet<T> {
                 }?;
 
                 // StorageKey for System_Events
-
                 let key: Vec<u8> = [
                     38, 170, 57, 78, 234, 86, 48, 224, 124, 72, 174, 12, 149, 88, 206, 247, 128,
                     212, 30, 94, 22, 5, 103, 101, 188, 132, 97, 133, 16, 114, 201, 215,

--- a/pallets/circuit/src/escrow/mod.rs
+++ b/pallets/circuit/src/escrow/mod.rs
@@ -180,6 +180,7 @@ pub mod test {
     use t3rn_protocol::side_effects::test_utils::*;
 
     use crate::mock::*;
+    use crate::tests::brute_seed_block_1_to_grandpa_mfv;
 
     #[test]
     fn escrow_transfer_execute_and_commit_work() {
@@ -212,7 +213,7 @@ pub mod test {
             .execute_with(|| {
                 let _ = Balances::deposit_creating(&ALICE, 1 + 2 + 1); // Alice should have at least: fee (1) + insurance reward (2)(for VariantA)
                 System::set_block_number(1);
-
+                brute_seed_block_1_to_grandpa_mfv([3, 3, 3, 3]);
                 // Submit for execution first
                 assert_ok!(Circuit::on_extrinsic_trigger(
                     origin,
@@ -292,6 +293,7 @@ pub mod test {
             .execute_with(|| {
                 let _ = Balances::deposit_creating(&ALICE, 1 + 2 + 1); // Alice should have at least: fee (1) + insurance reward (2)(for VariantA)
                 System::set_block_number(1);
+                brute_seed_block_1_to_grandpa_mfv([3, 3, 3, 3]);
 
                 // Submit for execution first
                 assert_ok!(Circuit::on_extrinsic_trigger(

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -1738,10 +1738,21 @@ impl<T: Config> Pallet<T> {
                     ),
                 ));
 
+                println!(" IF BEFORE submission_target_height ");
+
+                let submission_target_height = T::CircuitPortal::read_cmp_latest_target_height(
+                    side_effect.target,
+                    None,
+                    None,
+                )?;
+
+                println!("submission_target_height = {:?}", submission_target_height);
+
                 full_side_effects.push(FullSideEffect {
                     input: side_effect.clone(),
                     confirmed: None,
                     security_lvl: SecurityLvl::Optimistic,
+                    submission_target_height,
                 })
             } else {
                 fn determine_dirty_vs_escrowed_lvl<T: Config>(
@@ -1761,10 +1772,25 @@ impl<T: Config> Pallet<T> {
                     }
                     SecurityLvl::Dirty
                 }
+
+                println!(" ELSE BEFORE submission_target_height ");
+
+                let submission_target_height = T::CircuitPortal::read_cmp_latest_target_height(
+                    side_effect.target,
+                    None,
+                    None,
+                )?;
+
+                println!(
+                    " ELSE submission_target_height = {:?}",
+                    submission_target_height
+                );
+
                 full_side_effects.push(FullSideEffect {
                     input: side_effect.clone(),
                     confirmed: None,
                     security_lvl: determine_dirty_vs_escrowed_lvl::<T>(side_effect),
+                    submission_target_height,
                 });
             }
         }
@@ -1814,13 +1840,18 @@ impl<T: Config> Pallet<T> {
         inclusion_proof: Option<Vec<Vec<u8>>>,
         block_hash: Option<Vec<u8>>,
     ) -> Result<(), &'static str> {
-        let confirm_inclusion = || {
+        let confirm_inclusion = |fsfx: FullSideEffect<
+            <T as frame_system::Config>::AccountId,
+            <T as frame_system::Config>::BlockNumber,
+            EscrowedBalanceOf<T, T::Escrowed>,
+        >| {
             // ToDo: Remove below after testing inclusion
             // Temporarily allow skip inclusion if proofs aren't provided
             if !(block_hash.is_none() && inclusion_proof.is_none()) {
                 <T as Config>::CircuitPortal::confirm_event_inclusion(
                     side_effect.target,
                     confirmation.encoded_effect.clone(),
+                    fsfx.submission_target_height,
                     inclusion_proof,
                     block_hash,
                 )
@@ -1880,10 +1911,18 @@ impl<T: Config> Pallet<T> {
                     EscrowedBalanceOf<T, T::Escrowed>,
                 >,
             >],
-        ) -> Result<bool, &'static str> {
+        ) -> Result<
+            FullSideEffect<
+                <T as frame_system::Config>::AccountId,
+                <T as frame_system::Config>::BlockNumber,
+                EscrowedBalanceOf<T, T::Escrowed>,
+            >,
+            &'static str,
+        > {
             // ToDo: Extract as a separate function and migrate tests from Xtx
             let input_side_effect_id = side_effect.generate_id::<SystemHashing<T>>();
             let mut unconfirmed_step_no: Option<usize> = None;
+
             for (i, step) in full_side_effects.iter_mut().enumerate() {
                 // Double check there are some side effects for that Xtx - should have been checked at API level tho already
                 if step.is_empty() {
@@ -1903,7 +1942,7 @@ impl<T: Config> Pallet<T> {
                         {
                             // We found the side effect to confirm from inside the unconfirmed step.
                             full_side_effect.confirmed = Some(confirmation.clone());
-                            Ok(true)
+                            Ok(full_side_effect.clone())
                         } else {
                             Err("Attempt to confirm side effect from the next step, \
                                     but there still is at least one unfinished step")
@@ -1911,15 +1950,11 @@ impl<T: Config> Pallet<T> {
                     }
                 }
             }
+            Err("Unable to find matching Side Effect in given Xtx to confirm")
+        }
 
-            Ok(false)
-        }
-        if !confirm_order::<T>(side_effect, confirmation, &mut local_ctx.full_side_effects)? {
-            return Err(
-                "Side effect confirmation wasn't matched with full side effects order from state",
-            )
-        }
-        confirm_inclusion()?;
+        let fsfx = confirm_order::<T>(side_effect, confirmation, &mut local_ctx.full_side_effects)?;
+        confirm_inclusion(fsfx)?;
         confirm_execution(
             <T as Config>::Xdns::best_available(side_effect.target)?.gateway_vendor,
             <T as Config>::Xdns::get_gateway_value_unsigned_type_unsafe(&side_effect.target),
@@ -1988,7 +2023,7 @@ impl<T: Config> Pallet<T> {
                     // apply has 2
                     processed_weight += db_weight.reads_writes(2 as Weight, 1 as Weight);
                 },
-                Err(err) => {
+                Err(_err) => {
                     log::error!("Could not handle signal");
                     // Slide the erroneous signal to the back
                     queue.slide(0, queue.len());

--- a/pallets/multi-finality-verifier/src/lib.rs
+++ b/pallets/multi-finality-verifier/src/lib.rs
@@ -454,7 +454,7 @@ pub mod pallet {
     /// Map of hashes of the best finalized header.
     #[pallet::storage]
     #[pallet::getter(fn get_bridged_block_hash)]
-    pub(super) type BestFinalizedMap<T: Config<I>, I: 'static = ()> =
+    pub type BestFinalizedMap<T: Config<I>, I: 'static = ()> =
         StorageMap<_, Blake2_256, ChainId, BridgedBlockHash<T, I>>;
 
     /// A ring buffer of imported hashes. Ordered by the insertion time.

--- a/primitives/src/circuit_portal.rs
+++ b/primitives/src/circuit_portal.rs
@@ -7,7 +7,14 @@ pub trait CircuitPortal<T: frame_system::Config> {
     fn confirm_event_inclusion(
         gateway_id: [u8; 4],
         encoded_event: Vec<u8>,
+        encoded_submission_target_height: Vec<u8>,
         maybe_proof: Option<Vec<Vec<u8>>>,
         maybe_block_hash: Option<Vec<u8>>,
     ) -> Result<(), &'static str>;
+
+    fn read_cmp_latest_target_height(
+        gateway_id: [u8; 4],
+        gateway_block_hash: Option<Vec<u8>>,
+        maybe_cmp_height: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, &'static str>;
 }

--- a/primitives/src/side_effect/mod.rs
+++ b/primitives/src/side_effect/mod.rs
@@ -29,6 +29,7 @@ pub struct FullSideEffect<AccountId, BlockNumber, BalanceOf> {
     pub input: SideEffect<AccountId, BlockNumber, BalanceOf>,
     pub confirmed: Option<ConfirmedSideEffect<AccountId, BlockNumber, BalanceOf>>,
     pub security_lvl: SecurityLvl,
+    pub submission_target_height: Bytes,
 }
 
 impl<


### PR DESCRIPTION
## Summary
- [ ] Expose read and compare best available height from Portal
- [ ] Store submission_target_height in encoded form to FullSideEffect at validation 
- [ ] Compare submission with confirmation height at confirmation
- [ ] Brute seed block height 1 to circuit unit tests mock GRANDPA Finality Verifier 

## Please check that your PR completes the requirements as follows
- [x] Tests have been added for bug fixes/features
- [x] Acceptance criteria from the issue has been completed
