### PR TITLE
fix: unpin purged subkey version for devnet runs

### DIFF
--- a/devnet/run.sh
+++ b/devnet/run.sh
@@ -28,12 +28,10 @@ build_nodes() {
 }
 
 keygen() {
-  if ! cargo install --list | grep -Fq 'subkey v2.0.1'; then
-    echo "installing subkey v2.0.1..."
+  if ! cargo install --list | grep -Fq subkey; then
+    echo "installing subkey"
     cargo install subkey \
-      --git https://github.com/paritytech/substrate \
-      --version 2.0.1 \
-      --force
+      --git https://github.com/paritytech/substrate
   fi
   ## gen custom node keys 4 the 2 parachains
   subkey generate --scheme Sr25519 > $dir/specs/circuita1.key


### PR DESCRIPTION
## Summary
`subkey` no longer has a tag `2.0.1`.

## Checklist
- [x] `./devnet/run.sh` just installs the latest version if not present on the machine