### PR TITLE
Commit Linting during pipeline execution

### DIFF
--- a/.github/workflows/conventional_changelog.yml
+++ b/.github/workflows/conventional_changelog.yml
@@ -1,0 +1,14 @@
+name: Create Changelog of Conventional Commits
+on:
+ push:
+    tags:
+      - 'v*'
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Conventional Changelog Action
+        uses: TriPSs/conventional-changelog-action@v3.14.0

--- a/.github/workflows/lint_commits.yml
+++ b/.github/workflows/lint_commits.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4

--- a/.github/workflows/lint_commits.yml
+++ b/.github/workflows/lint_commits.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: wagoid/commitlint-github-action@v5.0.2

--- a/.github/workflows/pr-alert.yml
+++ b/.github/workflows/pr-alert.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Await checks
-        uses: fountainhead/action-wait-for-check
+        uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-build-test
         with:
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
Feat: Adds linting to commits, grouping them on release, and ensuring commit messages fit the conventional commits standard
Fix: Adds version number to the Pull Request alert GH Workflow step, as specific versioning is required

