### PR TITLE
Remove dangling justification decoder ref

### DIFF
--- a/client/xtx/run.sh
+++ b/client/xtx/run.sh
@@ -14,9 +14,7 @@ fi
 
 set -xEeu
 
-## build the custom justification decoder and standalone circuit
-cargo build \
-  --manifest-path ./justification-decoder/Cargo.toml
+## build the standalone circuit
 cargo build \
   --manifest-path ../../node/standalone/Cargo.toml
 


### PR DESCRIPTION
## Summary
Fix xtx setup script by removing obsolete justification decoder ref.

## Checklist
- [x] `./client/xtx/run.sh` starts up without errors