### PR TITLE
Speed up devnet

### DIFF
--- a/devnet/run.sh
+++ b/devnet/run.sh
@@ -190,13 +190,13 @@ onboard() {
     $(<$dir/specs/circuita.genesis) \
     $(<$dir/specs/circuita.wasm) \
   > $d/circuita.params
-  npx @polkadot/api-cli@beta \
+  npx --yes @polkadot/api-cli@beta \
     --ws ws://localhost:1944 \
     --sudo \
     --seed //Alice \
     --params $d/circuita.params \
     tx.parasSudoWrapper.sudoScheduleParaInitialize
-  npx @polkadot/api-cli@beta \
+  npx --yes @polkadot/api-cli@beta \
     --ws ws://localhost:1944 \
     --seed //Alice \
     tx.registrar.reserve
@@ -206,7 +206,7 @@ onboard() {
     $(<$dir/specs/circuitb.genesis) \
     $(<$dir/specs/circuitb.wasm) \
   > $d/circuitb.params
-  npx @polkadot/api-cli@beta \
+  npx --yes @polkadot/api-cli@beta \
     --ws ws://localhost:1944 \
     --sudo \
     --seed //Alice \
@@ -316,8 +316,8 @@ devnet() {
   build_para_wasm_runtimes
   rm -rf $dir/data/*
   start_nodes
-  npx --yes wait-port -t 13000 localhost:1933
-  npx wait-port -t 13000 localhost:1944
+  npx --yes wait-port -t 33000 localhost:1933
+  npx --yes wait-port -t 33000 localhost:1944
   set_keys
   onboard
 }

--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -514,7 +514,7 @@ pub fn local_testnet_config() -> ChainSpec {
                 PARACHAIN_ID.into(),
                 // Sudo account
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
-                seed_xdns_registry().unwrap_or_default(),
+                vec![],
                 standard_side_effects(),
                 vec![],
                 // initial_gateways(vec![&POLKADOT_CHAIN_ID, &KUSAMA_CHAIN_ID, &ROCOCO_CHAIN_ID])


### PR DESCRIPTION
## Summary
Speeds up devnet runs by removing dangling XDNS preseeds for rococo-local.
Also, increases node startup timeouts to allow smooth runs on weak machines.