### PR TITLE
Fix devnet by unpinning subkey

### DIFF
--- a/devnet/run.sh
+++ b/devnet/run.sh
@@ -28,11 +28,10 @@ build_nodes() {
 }
 
 keygen() {
-  if ! cargo install --list | grep -Fq 'subkey v2.0.1'; then
-    echo "installing subkey v2.0.1..."
+  if ! cargo install --list | grep -Fq subkey; then
+    echo "installing subkey..."
     cargo install subkey \
       --git https://github.com/paritytech/substrate \
-      --version 2.0.1 \
       --force
   fi
   ## gen custom node keys 4 the 2 parachains


### PR DESCRIPTION
## Summary

Unpins `subkey` within `./devnet/run.sh` since the `2.0.1` version got purged.

Should also fix the collation pipeline.

Closes [#412](https://github.com/t3rn/t3rn/issues/412)
