### PR TITLE
Prepare continous collator deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/target/
+**/node_modules/
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 **/target/
 **/node_modules/
-Dockerfile
+*Dockerfile

--- a/.github/workflows/circuit-collator-release.yml
+++ b/.github/workflows/circuit-collator-release.yml
@@ -7,15 +7,15 @@ on:
 
 env:
   PARACHAIN_NAME: t0rn
-  RUST_BACKTRACE: 1
+  RUST_BACKTRACE: full
   CARGO_TERM_COLOR: always
 
 jobs:
   build-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: ☁ Checkout git repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
@@ -23,7 +23,7 @@ jobs:
       - name: ⚙️ Get nightly rust toolchain with wasm target
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-11-01
+          toolchain: nightly-2022-06-16
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
           override: true
@@ -64,13 +64,13 @@ jobs:
       - name: 🏷️ Get the version tag
         run: echo "PUSHED_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
-      - name: Login to Docker Hub
+      - name: 🐋 Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and publish the Docker image
+      - name: 🐳 Build and publish the Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -82,7 +82,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
   release-on-github:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-release
     steps:
       - name: ☁ Checkout git repo

--- a/.github/workflows/circuit-collator-release.yml
+++ b/.github/workflows/circuit-collator-release.yml
@@ -53,6 +53,34 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  publish-docker-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+
+      - name: 🏷️ Get the version tag
+        run: echo "PUSHED_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and publish the Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: t3rn/circuit-collator:${{ env.PUSHED_TAG }}
+          platforms: linux/amd64
+          file: collator.Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
   release-on-github:
     runs-on: ubuntu-20.04
     needs: build-release

--- a/.github/workflows/circuit-collator-release.yml
+++ b/.github/workflows/circuit-collator-release.yml
@@ -71,11 +71,12 @@ jobs:
       - name: 🏷️ Get the version tag
         run: echo "PUSHED_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
-      - name: 🐋 Login to Docker Hub
+      - name: 🐋 Login to the GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐳 Build and publish the Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/circuit-collator-release.yml
+++ b/.github/workflows/circuit-collator-release.yml
@@ -55,11 +55,18 @@ jobs:
 
   publish-docker-image:
     runs-on: ubuntu-22.04
+    needs: build-release
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
+
+      - name: 📥 Download circuit collator
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.sha }}-collator-release-artifacts
+          path: ./target/release/
 
       - name: 🏷️ Get the version tag
         run: echo "PUSHED_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV

--- a/.github/workflows/circuit-collator-release.yml
+++ b/.github/workflows/circuit-collator-release.yml
@@ -153,3 +153,19 @@ jobs:
           asset_path: ./target/release/circuit-collator.gz
           asset_name: ${{ env.PARACHAIN_NAME }}-circuit-collator-${{ env.PUSHED_TAG }}-x86_64-unknown-linux-gnu.gz
           asset_content_type: application/gzip
+
+  trigger-downstream:
+    runs-on: ubuntu-22.04
+    needs: release-on-github
+    steps:
+      - name: 🏷️ Get the version tag
+        run: echo "PUSHED_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: 🔫 Trigger chainops downstream
+        run: |
+          curl -XPOST /
+            -u ${{ secrets.GH_PAT }} /
+            -H "Accept:application/vnd.github" /
+            -H "Content-Type:application/json" /
+            https://api.github.com/repos/t3rn/chainops/cd.yml/dispatches /
+            --data "{\"action\":\"xtrigger\",\"tag\":\"${{ env.PUSHED_TAG }}\"}"

--- a/collator.Dockerfile
+++ b/collator.Dockerfile
@@ -1,10 +1,12 @@
 FROM phusion/baseimage:jammy-1.0.0
 
-COPY --from=factory /factory/target/release/circuit-collator /usr/local/bin
-
 RUN useradd -m -u 1000 -U -s /bin/sh -d /node runner && \
     mkdir /node/data
 
 COPY --chown=runner target/release/circuit-collator /usr/local/bin/circuit-collator
+
+VOLUME /node/data
+
+USER runner
 
 ENTRYPOINT ["/usr/local/bin/circuit-collator"]

--- a/collator.Dockerfile
+++ b/collator.Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:buster as factory
+
+WORKDIR /factory
+
+RUN apt-get update && \
+    apt-get upgrade && \
+    apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew" && \
+    apt-get install -y cmake pkg-config libssl-dev git clang libclang-dev
+
+RUN rustup default nightly-2022-06-16 && \
+	rustup target add wasm32-unknown-unknown --toolchain nightly-2022-06-16
+
+COPY . .
+
+RUN cargo build --manifest-path ./node/parachain/Cargo.toml --release --locked
+
+FROM phusion/baseimage:jammy-1.0.0
+
+COPY --from=factory /factory/target/release/circuit-collator /usr/local/bin
+
+RUN useradd -m -u 1000 -U -s /bin/sh -d /node runner && \
+    mkdir /node/data && \
+    rm -rf /usr/lib/python* /usr/bin /usr/sbin /usr/share/man
+
+USER runner
+
+ENTRYPOINT ["/usr/local/bin/circuit-collator"]

--- a/collator.Dockerfile
+++ b/collator.Dockerfile
@@ -1,27 +1,10 @@
-FROM rust:buster as factory
-
-WORKDIR /factory
-
-RUN apt-get update && \
-    apt-get upgrade && \
-    apt-get dist-upgrade -y -o Dpkg::Options::="--force-confnew" && \
-    apt-get install -y cmake pkg-config libssl-dev git clang libclang-dev
-
-RUN rustup default nightly-2022-06-16 && \
-	rustup target add wasm32-unknown-unknown --toolchain nightly-2022-06-16
-
-COPY . .
-
-RUN cargo build --manifest-path ./node/parachain/Cargo.toml --release --locked
-
 FROM phusion/baseimage:jammy-1.0.0
 
 COPY --from=factory /factory/target/release/circuit-collator /usr/local/bin
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /node runner && \
-    mkdir /node/data && \
-    rm -rf /usr/lib/python* /usr/bin /usr/sbin /usr/share/man
+    mkdir /node/data
 
-USER runner
+COPY --chown=runner target/release/circuit-collator /usr/local/bin/circuit-collator
 
 ENTRYPOINT ["/usr/local/bin/circuit-collator"]


### PR DESCRIPTION
## Summary
Reintroduces a collator release pipeline step that publishes a collator Docker image to the GitHub container registry. Additionally, the pipeline now triggers a continuous deployment pipeline in our chainops repo.