### PR TITLE
chore: enable collator telemetry

### DIFF
--- a/scripts/run-rococo-collators.sh
+++ b/scripts/run-rococo-collators.sh
@@ -88,7 +88,8 @@ ExecStart=$collator_binary \
   --rpc-cors all \
   --execution Wasm \
   --pruning=archive \
-  --no-prometheus \
+  --prometheus-port 7001 \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit 1' \
   -- \
   --chain $artifacts_dir/rococo.raw.json \
   --bootnodes \"$rococo_boot_nodes\" \
@@ -141,7 +142,8 @@ ExecStart=$collator_binary \
   --rpc-cors all \
   --execution Wasm \
   --pruning=archive \
-  --no-prometheus \
+  --prometheus-port 7002 \
+  --telemetry-url 'wss://telemetry.polkadot.io/submit 1' \
   -- \
   --chain $artifacts_dir/rococo.raw.json \
   --bootnodes \"$rococo_boot_nodes\" \


### PR DESCRIPTION
## Summary

Should enable sending metrics to the collective Substrate telemetry system.
Metrics include:

```
system.connected
system.interval
block.import
notify.finalized
afg.authority_set
```

## Checklist
- [x] Sets collator node's telemetry target `--telemetry-url`
- [x] Assins the include prometheus exporter a non-random port for traceability

## Screenshots

Ultimately we just want our collators to show up here..

![tv](https://user-images.githubusercontent.com/22937570/185357661-ad89c46c-4542-4359-96f1-837dd143c3d0.png)