### PR TITLE
Refactor the collator docker image to incl. all runtime deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-**/target/
-**/node_modules/
-*Dockerfile
+**/target
+**/node_modules
+!target/release/circuit-collator

--- a/collator.Dockerfile
+++ b/collator.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:21.04
 LABEL org.opencontainers.image.source https://github.com/t3rn/t3rn
 
 ENV RELAYCHAIN_NAME=rococo

--- a/collator.Dockerfile
+++ b/collator.Dockerfile
@@ -1,7 +1,8 @@
-FROM phusion/baseimage:jammy-1.0.0
+FROM ubuntu:22.04
+LABEL org.opencontainers.image.source https://github.com/t3rn/t3rn
 
-ARG RELAYCHAIN_NAME=rococo
-ARG PARACHAIN_NAME=t0rn
+ENV RELAYCHAIN_NAME=rococo
+ENV PARACHAIN_NAME=t0rn
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /node runner && \
     mkdir /node/data && \
@@ -12,8 +13,8 @@ COPY --chown=runner target/release/circuit-collator /usr/local/bin/circuit-colla
 COPY --chown=runner specs/$RELAYCHAIN_NAME.raw.json /node/specs/$RELAYCHAIN_NAME.raw.json
 COPY --chown=runner specs/$PARACHAIN_NAME.raw.json /node/specs/$PARACHAIN_NAME.raw.json
 
-VOLUME /node/data
-
 USER runner
+VOLUME /node/data
+EXPOSE 33333 1833 1933 7003
 
 ENTRYPOINT ["/usr/local/bin/circuit-collator"]


### PR DESCRIPTION
## Summary
The docker image was missing `libssl` shared objects etc. so just runnning with a full blown ubuntu for now.
