### PR TITLE
Increase mainnet collator candidacy bond

### DIFF
--- a/node/t0rn-parachain/src/chain_spec.rs
+++ b/node/t0rn-parachain/src/chain_spec.rs
@@ -1,6 +1,4 @@
-use circuit_parachain_runtime::{
-    AccountId, AuraId, EvmConfig, Signature, SudoConfig, XDNSConfig, EXISTENTIAL_DEPOSIT,
-};
+use circuit_parachain_runtime::{AccountId, AuraId, EvmConfig, Signature, SudoConfig, XDNSConfig};
 use cumulus_primitives_core::ParaId;
 use jsonrpc_runtime_client::{
     create_rpc_client, get_gtwy_init_data, get_metadata, get_parachain_id, ConnectionParams,
@@ -26,6 +24,7 @@ use t3rn_primitives::{
             SOONSOCIAL_CHAIN_ID,
         },
     },
+    monetary::TRN,
     side_effect::interface::SideEffectInterface,
     xdns::{Parachain, XdnsRecord},
     ChainId, GatewayGenesisConfig, GatewaySysProps, GatewayType, GatewayVendor, Header,
@@ -502,7 +501,7 @@ fn testnet_genesis(
         parachain_info: circuit_parachain_runtime::ParachainInfoConfig { parachain_id: id },
         collator_selection: circuit_parachain_runtime::CollatorSelectionConfig {
             invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
-            candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
+            candidacy_bond: (TRN as u128) * 10_u128,
             ..Default::default()
         },
         session: circuit_parachain_runtime::SessionConfig {

--- a/node/t3rn-parachain/src/chain_spec.rs
+++ b/node/t3rn-parachain/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use circuit_parachain_runtime::{AccountId, AuraId, Signature, SudoConfig, EXISTENTIAL_DEPOSIT};
+use circuit_parachain_runtime::{AccountId, AuraId, Signature, SudoConfig};
 use cumulus_primitives_core::ParaId;
 
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
@@ -9,6 +9,7 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::str::FromStr;
 use t3rn_primitives::{
     bridges::runtime::{KUSAMA_CHAIN_ID, POLKADOT_CHAIN_ID, ROCOCO_CHAIN_ID},
+    monetary::TRN,
     ChainId,
 };
 
@@ -102,7 +103,7 @@ pub fn session_keys(keys: AuraId) -> circuit_parachain_runtime::SessionKeys {
 
 pub fn polkadot_config() -> ChainSpec {
     let mut properties = sc_chain_spec::Properties::new();
-    properties.insert("tokenSymbol".into(), "T3RN".into());
+    properties.insert("tokenSymbol".into(), "TRN".into());
     properties.insert("tokenDecimals".into(), 12.into());
     properties.insert("ss58Format".into(), 42.into());
 
@@ -184,7 +185,7 @@ fn polkadot_genesis(
         parachain_info: circuit_parachain_runtime::ParachainInfoConfig { parachain_id: id },
         collator_selection: circuit_parachain_runtime::CollatorSelectionConfig {
             invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
-            candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
+            candidacy_bond: (TRN as u128) * 10_000_u128,
             ..Default::default()
         },
         session: circuit_parachain_runtime::SessionConfig {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -165,12 +165,12 @@ impl TryFrom<&ChainId> for GatewaySysProps {
         match chain_id {
             b"circ" => Ok(GatewaySysProps {
                 ss58_format: 1333,
-                token_symbol: Encode::encode("T3RN"),
+                token_symbol: Encode::encode("TRN"),
                 token_decimals: 12,
             }),
             b"gate" => Ok(GatewaySysProps {
                 ss58_format: 1333,
-                token_symbol: Encode::encode("T3RN"),
+                token_symbol: Encode::encode("TRN"),
                 token_decimals: 12,
             }),
             &POLKADOT_CHAIN_ID => Ok(GatewaySysProps {

--- a/primitives/src/monetary.rs
+++ b/primitives/src/monetary.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use sp_runtime::{traits::CheckedAdd, Perbill, RuntimeDebug};
 
 pub const DECIMALS: u8 = 12;
-pub const MILLIT3RN: u64 = 1_000_000_000;
-pub const T3RN: u64 = 1_000_000_000_000;
+pub const MILLITRN: u64 = 1_000_000_000;
+pub const TRN: u64 = 1_000_000_000_000;
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]

--- a/runtime/mock/src/lib.rs
+++ b/runtime/mock/src/lib.rs
@@ -103,7 +103,7 @@ impl ExtBuilder {
             Default::default(),
             GatewaySysProps {
                 ss58_format: 1333,
-                token_symbol: Encode::encode("T3RN"),
+                token_symbol: Encode::encode("TRN"),
                 token_decimals: 12,
             },
             vec![],
@@ -123,7 +123,7 @@ impl ExtBuilder {
             Default::default(),
             GatewaySysProps {
                 ss58_format: 1333,
-                token_symbol: Encode::encode("T3RN"),
+                token_symbol: Encode::encode("TRN"),
                 token_decimals: 12,
             },
             vec![],
@@ -152,7 +152,7 @@ impl ExtBuilder {
             Default::default(),
             GatewaySysProps {
                 ss58_format: 1333,
-                token_symbol: Encode::encode("T3RN"),
+                token_symbol: Encode::encode("TRN"),
                 token_decimals: 12,
             },
             vec![],
@@ -184,7 +184,7 @@ impl ExtBuilder {
             Default::default(),
             GatewaySysProps {
                 ss58_format: 1333,
-                token_symbol: Encode::encode("T3RN"),
+                token_symbol: Encode::encode("TRN"),
                 token_decimals: 12,
             },
             vec![],


### PR DESCRIPTION
## Summary
Bumps our mainnet collator candidacy bond from `0.016TRN` to `10000TRN`.

## Checklist
- [x] Adjusted the testnet candidacy bond to `10T0RN` which equals 1 faucet drip
- [x] Also corrects some leftover `T3RN` currency symbols witin the codebase
