### PR TITLE
Only access reserved bond when other SFX exist when slashing

### DIFF
--- a/pallets/circuit/src/optimistic/mod.rs
+++ b/pallets/circuit/src/optimistic/mod.rs
@@ -133,13 +133,18 @@ impl<T: Config> Optimistic<T> {
             local_ctx,
             SecurityLvl::Optimistic,
         );
+
         // Slash loop
         for fsx in optimistic_fsx_in_step {
             // Look for invalid FSX cases to slash
             if !fsx.is_successfully_confirmed() && fsx.is_bid_resolved() {
                 let sfx_bid = fsx.expect_sfx_bid();
-                let (insurance, reserved_bond) =
-                    (*sfx_bid.get_insurance(), *sfx_bid.expect_reserved_bond());
+                let insurance = *sfx_bid.get_insurance();
+                let reserved_bond = if let Some(bond) = sfx_bid.get_reserved_bond() {
+                    *bond
+                } else {
+                    Zero::zero()
+                };
 
                 // First slash executor
                 slashed_reserve += insurance + reserved_bond;

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -1574,6 +1574,124 @@ fn circuit_handles_transfer_dirty_and_optimistic_and_swap() {
 }
 
 #[test]
+fn circuit_cancels_xtx_with_bids_after_timeout() {
+    let origin = Origin::signed(ALICE); // Only sudo access to register new gateways for now
+
+    let _origin_relayer_bob = Origin::signed(BOB_RELAYER); // Only sudo access to register new gateways for now
+
+    let transfer_protocol_box =
+        Box::new(t3rn_protocol::side_effects::standards::get_transfer_interface());
+    let _swap_protocol_box = Box::new(t3rn_protocol::side_effects::standards::get_swap_interface());
+
+    let mut local_state = LocalState::new();
+    let valid_transfer_side_effect = produce_and_validate_side_effect(
+        vec![
+            (Type::Address(32), ArgVariant::A),
+            (Type::Address(32), ArgVariant::B),
+            (Type::Uint(128), ArgVariant::A),
+            (Type::OptionalInsurance, ArgVariant::A),
+        ],
+        &mut local_state,
+        transfer_protocol_box,
+        FIRST_REQUESTER_NONCE,
+    );
+
+    let side_effects = vec![valid_transfer_side_effect.clone()];
+    let fee = 1;
+    let sequential = false;
+
+    ExtBuilder::default()
+        .with_standard_side_effects()
+        .with_default_xdns_records()
+        .build()
+        .execute_with(|| {
+            let _ = Balances::deposit_creating(&ALICE, 1_000_000);
+
+            System::set_block_number(1);
+            brute_seed_block_1([0, 0, 0, 0]);
+
+            assert_ok!(Circuit::on_extrinsic_trigger(
+                origin,
+                side_effects,
+                fee,
+                sequential,
+            ));
+
+            let _events = System::events();
+            // assert_eq!(events.len(), 8);
+
+            let xtx_id: sp_core::H256 =
+                hex!("9946104f0d553532303b8a763d5828d75ed4493c585c948d10b7e9317ade6331").into();
+
+            // The tiemout links that will be checked at on_initialize are there
+            assert_eq!(Circuit::get_active_timing_links(xtx_id), Some(401u32)); // 100 offset + current block height 1 = 101
+
+            assert_eq!(
+                Circuit::get_x_exec_signals(xtx_id),
+                Some(XExecSignal {
+                    requester: AccountId32::new(hex!(
+                        "0101010101010101010101010101010101010101010101010101010101010101"
+                    )),
+                    timeouts_at: 401u32, // 400 offset + current block height 1 = 101
+                    delay_steps_at: None,
+                    status: CircuitStatus::PendingBidding,
+                    total_reward: Some(fee),
+                    requester_nonce: FIRST_REQUESTER_NONCE,
+                    steps_cnt: (0, 1),
+                })
+            );
+
+            let sfx_id = valid_transfer_side_effect
+                .generate_id::<circuit_runtime_pallets::pallet_circuit::SystemHashing<Runtime>>(
+            );
+            place_winning_bid_and_advance_3_blocks(ALICE, xtx_id, sfx_id, 1);
+
+            System::set_block_number(410);
+
+            <Circuit as frame_support::traits::OnInitialize<BlockNumber>>::on_initialize(410);
+
+            assert_eq!(
+                Circuit::get_x_exec_signals(xtx_id),
+                Some(XExecSignal {
+                    requester: AccountId32::new(hex!(
+                        "0101010101010101010101010101010101010101010101010101010101010101"
+                    )),
+                    timeouts_at: 401u32,
+                    delay_steps_at: None,
+                    status: CircuitStatus::RevertTimedOut,
+                    total_reward: Some(fee),
+                    requester_nonce: FIRST_REQUESTER_NONCE,
+                    steps_cnt: (0, 1),
+                })
+            );
+
+            assert_eq!(Circuit::get_active_timing_links(xtx_id), None);
+
+            // Emits event notifying about cancellation
+            let mut events = System::events();
+            // assert_eq!(events.len(), 9);
+            assert_eq!(
+                events.pop(),
+                Some(
+                    EventRecord {
+                        phase: Phase::Initialization,
+                        event: Event::Circuit(circuit_runtime_pallets::pallet_circuit::Event::<
+                            Runtime,
+                        >::XTransactionXtxRevertedAfterTimeOut(
+                            hex!(
+                                "9946104f0d553532303b8a763d5828d75ed4493c585c948d10b7e9317ade6331"
+                            )
+                            .into()
+                        )),
+                        topics: vec![]
+                    }
+                ),
+            );
+            // Voids all associated side effects with Xtx by setting their confirmation to Err
+        });
+}
+
+#[test]
 fn circuit_cancels_xtx_after_timeout() {
     let origin = Origin::signed(ALICE); // Only sudo access to register new gateways for now
 
@@ -1682,7 +1800,6 @@ fn circuit_cancels_xtx_after_timeout() {
                     }
                 ),
             );
-
             // Voids all associated side effects with Xtx by setting their confirmation to Err
         });
 }

--- a/primitives/src/side_effect/mod.rs
+++ b/primitives/src/side_effect/mod.rs
@@ -76,6 +76,10 @@ impl<AccountId, BalanceOf> SFXBid<AccountId, BalanceOf> {
             .expect("Accessed reserved_bond and expected it to be a part of SFXBid")
     }
 
+    pub fn get_reserved_bond(&self) -> &Option<BalanceOf> {
+        &self.reserved_bond
+    }
+
     pub fn get_insurance(&self) -> &BalanceOf {
         &self.insurance
     }


### PR DESCRIPTION
## Summary
Only access reserved bond when other SFX exist when slashing

Fixes #497 

## Checklist
- [ ] insert any notable changes, in order of commit

## Please check that your PR completes the requirements as follows
- [ ] Tests have been added for bug fixes/features
- [ ] Acceptance criteria from the issue has been completed

## Screenshots (if applicable)
