### PR TITLE
Enforce encoded arguments' length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,7 +3035,7 @@ name = "fp-evm"
 version = "3.0.0-dev"
 dependencies = [
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "parity-scale-codec 3.2.1",
  "serde",
  "sp-core",
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
  "evm",
  "frame-support",
@@ -6840,10 +6840,10 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6874,17 +6874,17 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
 ]
 
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "sp-core",
  "substrate-bn",
 ]
@@ -6892,18 +6892,18 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-curve25519"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
  "curve25519-dalek 4.0.0-pre.1",
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
 ]
 
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "frame-support",
  "pallet-evm 6.0.0-dev",
 ]
@@ -6911,36 +6911,36 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-ed25519"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
  "ed25519-dalek",
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
 ]
 
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "num",
 ]
 
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "tiny-keccak 2.0.2",
 ]
 
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
+source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27#32f9c7eaf5aa550191c90e14476b145e5d7833d7"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier.git?branch=polkadot-v0.9.27)",
+ "fp-evm 3.0.0-dev (git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.27)",
  "ripemd",
  "sp-io",
 ]
@@ -13055,9 +13055,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pallets/account-manager/src/manager.rs
+++ b/pallets/account-manager/src/manager.rs
@@ -621,6 +621,9 @@ mod tests {
                 execution_id, Outcome::UnexpectedFailure, None, None,
             ));
 
+            let test_one_percent_charge_amt = charge_amt.checked_div(100);
+            assert_ne!(test_one_percent_charge_amt, None);
+
             let one_percent_charge_amt = charge_amt.checked_div(100).unwrap();
             let fifty_percent_charge_amt = charge_amt
                 .checked_div(100)

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -1089,7 +1089,9 @@ impl<T: Config> Pallet<T> {
                 }
                 // ToDo: Introduce default delay
                 let (timeouts_at, delay_steps_at): (T::BlockNumber, Option<Vec<T::BlockNumber>>) = (
-                    T::XtxTimeoutDefault::get() + frame_system::Pallet::<T>::block_number(),
+                    T::XtxTimeoutDefault::get()
+                        .checked_add(&frame_system::Pallet::<T>::block_number())
+                        .unwrap(),
                     None,
                 );
 
@@ -1290,7 +1292,9 @@ impl<T: Config> Pallet<T> {
                 );
                 <PendingXtxBidsTimeoutsMap<T>>::insert::<XExecSignalId<T>, T::BlockNumber>(
                     local_ctx.xtx_id,
-                    T::SFXBiddingPeriod::get() + frame_system::Pallet::<T>::block_number(),
+                    T::SFXBiddingPeriod::get()
+                        .checked_add(&frame_system::Pallet::<T>::block_number())
+                        .unwrap(),
                 );
                 <XExecSignals<T>>::insert::<
                     XExecSignalId<T>,

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -2130,14 +2130,14 @@ fn insured_unrewarded_single_rococo_transfer() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
 
             // Read data from files
@@ -2165,14 +2165,14 @@ fn insured_unrewarded_single_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
 
             let confirm = read_file_and_set_height(
@@ -2214,25 +2214,25 @@ fn insured_unrewarded_single_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 9_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(9_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                10u128.pow(12)
+                10u128.checked_pow(12).unwrap_or(10_u128)
             );
 
             assert_ok!(confirm_side_effect(
@@ -2242,28 +2242,28 @@ fn insured_unrewarded_single_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
 
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }
@@ -2301,14 +2301,14 @@ fn insured_rewarded_single_rococo_transfer() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
 
             // Read data from files
@@ -2336,22 +2336,22 @@ fn insured_rewarded_single_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 9_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(9_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
 
             assert_eq!(Balances::reserved_balance(&CLI_DEFAULT), 10u128.pow(12));
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
 
             let post_bond = read_file_and_set_height(
@@ -2366,20 +2366,20 @@ fn insured_rewarded_single_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 9_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(9_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 9_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(9_u128)
             );
 
             assert_eq!(Balances::reserved_balance(&CLI_DEFAULT), 10u128.pow(12));
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                10u128.pow(12)
+                10u128.checked_pow(12).unwrap_or(10_u128)
             );
 
             let submit_header_2 =
@@ -2404,27 +2404,27 @@ fn insured_rewarded_single_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 9_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(9_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 11_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(11_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }
@@ -2472,14 +2472,14 @@ fn insured_rewarded_multi_rococo_transfer() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
 
             // Read data from files
@@ -2497,27 +2497,27 @@ fn insured_rewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 3_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(3_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
 
             let post_bond_1 = read_file_and_set_height(
@@ -2541,27 +2541,27 @@ fn insured_rewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 3_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(3_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 3_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(3_u128)
             );
 
             let submit_header_2 =
@@ -2594,27 +2594,27 @@ fn insured_rewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }
@@ -2662,14 +2662,14 @@ fn insured_unrewarded_multi_rococo_transfer() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
 
             // Read data from files
@@ -2697,27 +2697,27 @@ fn insured_unrewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
 
             let post_bond_1 = read_file_and_set_height(
@@ -2743,26 +2743,26 @@ fn insured_unrewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 3_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(3_u128)
             );
 
             let submit_header_2 =
@@ -2796,26 +2796,26 @@ fn insured_unrewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }
@@ -2866,14 +2866,14 @@ fn uninsured_unrewarded_multi_rococo_transfer() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128),
             ); // 10 trn
 
             // Read data from files
@@ -2901,26 +2901,26 @@ fn uninsured_unrewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
 
             let submit_header_2 =
@@ -2969,26 +2969,26 @@ fn uninsured_unrewarded_multi_rococo_transfer() {
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
                 10_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(10_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }
@@ -3095,14 +3095,14 @@ fn multi_mixed_rococo() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128),
             ); // 10 trn
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128),
             ); // 10 trn
 
             let register_roco =
@@ -3156,26 +3156,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
 
             let bond_insurance_1 = read_file_and_set_height(
@@ -3247,26 +3247,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             // ______Confirm insured step:________
@@ -3280,26 +3280,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             let confirm_2 = read_file_and_set_height(
@@ -3344,26 +3344,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             let submit_header_6 =
@@ -3380,26 +3380,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             let confirm_5 = read_file_and_set_height(
@@ -3425,26 +3425,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             let submit_header_8 =
@@ -3461,26 +3461,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 13_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(13_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 8_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(8_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 7_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(7_u128)
             );
 
             let confirm_6 = read_file_and_set_height(
@@ -3515,26 +3515,26 @@ fn multi_mixed_rococo() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 12_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(12_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 28_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(28_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }
@@ -3606,20 +3606,20 @@ fn insured_multi_rococo_multiple_executors() {
             let _ = Balances::deposit_creating(
                 &CLI_DEFAULT,
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128),
             );
             let _ = Balances::deposit_creating(
                 &EXECUTOR_DEFAULT,
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128),
             );
             let _ = Balances::deposit_creating(
                 &EXECUTOR_SECOND,
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap(),
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128),
             );
 
             let register_roco =
@@ -3673,38 +3673,38 @@ fn insured_multi_rococo_multiple_executors() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 15_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(15_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_SECOND),
                 20_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(20_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 5_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(5_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_SECOND),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
 
             // bslk bonds
@@ -3747,38 +3747,38 @@ fn insured_multi_rococo_multiple_executors() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 15_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(15_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 17_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(17_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_SECOND),
                 17_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(17_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 5_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(5_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 3_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(3_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_SECOND),
                 3_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(3_u128)
             );
 
             let submit_header_4 =
@@ -3841,38 +3841,38 @@ fn insured_multi_rococo_multiple_executors() {
             assert_eq!(
                 Balances::free_balance(CLI_DEFAULT),
                 15_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(15_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
                 23_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(23_u128)
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_SECOND),
                 22_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(22_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_SECOND),
                 0_u128
-                    .checked_mul(10_u128.checked_pow(12).unwrap())
-                    .unwrap()
+                    .checked_mul(10_u128.checked_pow(12).unwrap_or(10_u128))
+                    .unwrap_or(0_u128)
             );
         });
 }

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -2127,8 +2127,18 @@ fn insured_unrewarded_single_rococo_transfer() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
 
             // Read data from files
             let register_values =
@@ -2152,10 +2162,17 @@ fn insured_unrewarded_single_rococo_transfer() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 10u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let confirm = read_file_and_set_height(
@@ -2196,16 +2213,22 @@ fn insured_unrewarded_single_rococo_transfer() {
 
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                9u128 * 10u128.pow(12)
+                9_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
@@ -2218,21 +2241,29 @@ fn insured_unrewarded_single_rococo_transfer() {
             ));
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }
@@ -2267,8 +2298,18 @@ fn insured_rewarded_single_rococo_transfer() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
 
             // Read data from files
             let register_values =
@@ -2292,16 +2333,25 @@ fn insured_rewarded_single_rococo_transfer() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 9u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                9_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(Balances::reserved_balance(&CLI_DEFAULT), 10u128.pow(12));
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let post_bond = read_file_and_set_height(
@@ -2313,10 +2363,17 @@ fn insured_rewarded_single_rococo_transfer() {
                 post_bond[0].clone()
             ));
 
-            assert_eq!(Balances::free_balance(&CLI_DEFAULT), 9u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(&CLI_DEFAULT),
+                9_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                9u128 * 10u128.pow(12)
+                9_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(Balances::reserved_balance(&CLI_DEFAULT), 10u128.pow(12));
@@ -2344,19 +2401,30 @@ fn insured_rewarded_single_rococo_transfer() {
                 Origin::signed(EXECUTOR_DEFAULT),
                 confirm[0].clone()
             ));
-            assert_eq!(Balances::free_balance(&CLI_DEFAULT), 9u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(&CLI_DEFAULT),
+                9_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                11u128 * 10u128.pow(12)
+                11_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }
@@ -2401,8 +2469,18 @@ fn insured_rewarded_multi_rococo_transfer() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
 
             // Read data from files
             let register_values =
@@ -2416,19 +2494,30 @@ fn insured_rewarded_multi_rococo_transfer() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 7u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                3u128 * 10u128.pow(12)
+                3_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let post_bond_1 = read_file_and_set_height(
@@ -2449,19 +2538,30 @@ fn insured_rewarded_multi_rococo_transfer() {
                 post_bond_2[0].clone()
             ));
 
-            assert_eq!(Balances::free_balance(&CLI_DEFAULT), 7u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(&CLI_DEFAULT),
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                3u128 * 10u128.pow(12)
+                3_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                3u128 * 10u128.pow(12)
+                3_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let submit_header_2 =
@@ -2491,19 +2591,30 @@ fn insured_rewarded_multi_rococo_transfer() {
                 Origin::signed(EXECUTOR_DEFAULT),
                 confirm_1[0].clone()
             ));
-            assert_eq!(Balances::free_balance(&CLI_DEFAULT), 7u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(&CLI_DEFAULT),
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }
@@ -2548,8 +2659,18 @@ fn insured_unrewarded_multi_rococo_transfer() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
 
             // Read data from files
             let register_values =
@@ -2573,19 +2694,30 @@ fn insured_unrewarded_multi_rococo_transfer() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 10u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let post_bond_1 = read_file_and_set_height(
@@ -2610,19 +2742,27 @@ fn insured_unrewarded_multi_rococo_transfer() {
 
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                3u128 * 10u128.pow(12)
+                3_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let submit_header_2 =
@@ -2655,19 +2795,27 @@ fn insured_unrewarded_multi_rococo_transfer() {
             ));
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }
@@ -2715,8 +2863,18 @@ fn uninsured_unrewarded_multi_rococo_transfer() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 10 * 10u128.pow(12)); // 10 trn
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
 
             // Read data from files
             let register_values =
@@ -2740,18 +2898,29 @@ fn uninsured_unrewarded_multi_rococo_transfer() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 10u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let submit_header_2 =
@@ -2799,19 +2968,27 @@ fn uninsured_unrewarded_multi_rococo_transfer() {
             ));
             assert_eq!(
                 Balances::free_balance(&CLI_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(&EXECUTOR_DEFAULT),
-                10u128 * 10u128.pow(12)
+                10_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }
@@ -2915,8 +3092,18 @@ fn multi_mixed_rococo() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 20 * 10u128.pow(12)); // 10 trn
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 20 * 10u128.pow(12)); // 10 trn
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            ); // 10 trn
 
             let register_roco =
                 read_file_and_set_height(&(path.to_owned() + "1-register-roco.json"), false);
@@ -2966,18 +3153,29 @@ fn multi_mixed_rococo() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                20u128 * 10u128.pow(12)
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let bond_insurance_1 = read_file_and_set_height(
@@ -3046,18 +3244,29 @@ fn multi_mixed_rococo() {
             ));
 
             // Other executor can submit, but wont be rewarded once complete
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             // ______Confirm insured step:________
@@ -3068,18 +3277,29 @@ fn multi_mixed_rococo() {
                 confirm_1[0].clone()
             ));
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let confirm_2 = read_file_and_set_height(
@@ -3121,18 +3341,29 @@ fn multi_mixed_rococo() {
             ));
 
             //no rewards paid after step was confirmed
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let submit_header_6 =
@@ -3146,18 +3377,29 @@ fn multi_mixed_rococo() {
                 ));
             }
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let confirm_5 = read_file_and_set_height(
@@ -3180,18 +3422,29 @@ fn multi_mixed_rococo() {
                 ));
             }
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let submit_header_8 =
@@ -3205,18 +3458,29 @@ fn multi_mixed_rococo() {
                 ));
             }
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                13u128 * 10u128.pow(12)
+                13_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                8u128 * 10u128.pow(12)
+                8_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                7u128 * 10u128.pow(12)
+                7_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let confirm_6 = read_file_and_set_height(
@@ -3248,18 +3512,29 @@ fn multi_mixed_rococo() {
                 confirm_7[0].clone()
             ));
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 12u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                12_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                28u128 * 10u128.pow(12)
+                28_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }
@@ -3328,9 +3603,24 @@ fn insured_multi_rococo_multiple_executors() {
         .with_default_xdns_records()
         .build()
         .execute_with(|| {
-            let _ = Balances::deposit_creating(&CLI_DEFAULT, 20 * 10u128.pow(12));
-            let _ = Balances::deposit_creating(&EXECUTOR_DEFAULT, 20 * 10u128.pow(12));
-            let _ = Balances::deposit_creating(&EXECUTOR_SECOND, 20 * 10u128.pow(12));
+            let _ = Balances::deposit_creating(
+                &CLI_DEFAULT,
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            );
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_DEFAULT,
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            );
+            let _ = Balances::deposit_creating(
+                &EXECUTOR_SECOND,
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap(),
+            );
 
             let register_roco =
                 read_file_and_set_height(&(path.to_owned() + "1-register-roco.json"), false);
@@ -3380,26 +3670,41 @@ fn insured_multi_rococo_multiple_executors() {
                 Origin::signed(CLI_DEFAULT),
                 transfer[0].clone()
             ));
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 15u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                15_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                20u128 * 10u128.pow(12)
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_SECOND),
-                20u128 * 10u128.pow(12)
+                20_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                5u128 * 10u128.pow(12)
+                5_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_SECOND),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             // bslk bonds
@@ -3439,26 +3744,41 @@ fn insured_multi_rococo_multiple_executors() {
                 bond_insurance_1[0].clone()
             ));
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 15u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                15_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                17u128 * 10u128.pow(12)
+                17_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_SECOND),
-                17u128 * 10u128.pow(12)
+                17_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                5u128 * 10u128.pow(12)
+                5_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                3u128 * 10u128.pow(12)
+                3_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_SECOND),
-                3u128 * 10u128.pow(12)
+                3_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
 
             let submit_header_4 =
@@ -3518,26 +3838,41 @@ fn insured_multi_rococo_multiple_executors() {
                 confirm_3[0].clone()
             ));
 
-            assert_eq!(Balances::free_balance(CLI_DEFAULT), 15u128 * 10u128.pow(12));
+            assert_eq!(
+                Balances::free_balance(CLI_DEFAULT),
+                15_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
+            );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_DEFAULT),
-                23u128 * 10u128.pow(12)
+                23_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::free_balance(EXECUTOR_SECOND),
-                22u128 * 10u128.pow(12)
+                22_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&CLI_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_DEFAULT),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
             assert_eq!(
                 Balances::reserved_balance(&EXECUTOR_SECOND),
-                0u128 * 10u128.pow(12)
+                0_u128
+                    .checked_mul(10_u128.checked_pow(12).unwrap())
+                    .unwrap()
             );
         });
 }

--- a/pallets/executors/src/mock.rs
+++ b/pallets/executors/src/mock.rs
@@ -162,7 +162,11 @@ pub(crate) fn fast_forward_to(n: u64) {
         Treasury::on_finalize(System::block_number());
         Balances::on_finalize(System::block_number());
         System::on_finalize(System::block_number());
-        System::set_block_number(System::block_number().checked_add(1).unwrap());
+        System::set_block_number(if let Some(v) = System::block_number().checked_add(1) {
+            v
+        } else {
+            System::block_number()
+        });
         System::on_initialize(System::block_number());
         Balances::on_initialize(System::block_number());
         Executors::on_initialize(System::block_number());

--- a/pallets/executors/src/mock.rs
+++ b/pallets/executors/src/mock.rs
@@ -162,7 +162,7 @@ pub(crate) fn fast_forward_to(n: u64) {
         Treasury::on_finalize(System::block_number());
         Balances::on_finalize(System::block_number());
         System::on_finalize(System::block_number());
-        System::set_block_number(System::block_number() + 1);
+        System::set_block_number(System::block_number().checked_add(1).unwrap());
         System::on_initialize(System::block_number());
         Balances::on_initialize(System::block_number());
         Executors::on_initialize(System::block_number());

--- a/pallets/treasury/src/tests.rs
+++ b/pallets/treasury/src/tests.rs
@@ -77,20 +77,30 @@ fn hook_mints_for_each_past_round() {
         // fast forward two round begins
         fast_forward_to(<DefaultRoundTerm>::get() as u64);
         let first_round_issuance = Treasury::compute_round_issuance(total_active_executors_stake);
-        fast_forward_to((2 * <DefaultRoundTerm>::get() + 1) as u64);
+        fast_forward_to(
+            (2_u32
+                .checked_mul(<DefaultRoundTerm>::get())
+                .unwrap()
+                .checked_add(1)
+                .unwrap()) as u64,
+        );
 
         assert_last_n_events!(
             6,
             vec![
                 Event::NewRound {
                     round: 2,
-                    head: (<DefaultRoundTerm>::get() + 1) as u64,
+                    head: (<DefaultRoundTerm>::get().checked_add(1).unwrap()) as u64,
                 },
                 Event::BeneficiaryTokensIssued(dev, 527), //TODO
                 Event::RoundTokensIssued(1, first_round_issuance),
                 Event::NewRound {
                     round: 3,
-                    head: (2 * <DefaultRoundTerm>::get() + 1) as u64,
+                    head: (2_u32
+                        .checked_mul(<DefaultRoundTerm>::get())
+                        .unwrap()
+                        .checked_add(1)
+                        .unwrap()) as u64,
                 },
                 Event::BeneficiaryTokensIssued(dev, 526), //TODO
                 Event::RoundTokensIssued(
@@ -418,7 +428,7 @@ fn gradually_decreasing_to_perpetual_inflation() {
         );
 
         // after 3 yrs
-        fast_forward_to((BLOCKS_PER_YEAR * 3) as u64);
+        fast_forward_to((BLOCKS_PER_YEAR.checked_mul(3).unwrap()) as u64);
         assert_eq!(
             Treasury::inflation_config().annual,
             Range {
@@ -429,7 +439,7 @@ fn gradually_decreasing_to_perpetual_inflation() {
         );
 
         // after 6 yrs
-        fast_forward_to((BLOCKS_PER_YEAR * 6) as u64);
+        fast_forward_to((BLOCKS_PER_YEAR.checked_mul(6).unwrap()) as u64);
         assert_eq!(
             Treasury::inflation_config().annual,
             Range {

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -367,12 +367,17 @@ pub mod pallet {
 
         fn get_gateway_value_unsigned_type_unsafe(chain_id: &ChainId) -> Type {
             Type::Uint(
-                <XDNSRegistry<T>>::get(chain_id)
+                if let Some(v) = <XDNSRegistry<T>>::get(chain_id)
                     .unwrap()
                     .gateway_abi
                     .value_type_size
                     .checked_mul(8)
-                    .unwrap(),
+                {
+                    v
+                } else {
+                    // return default value
+                    0
+                },
             )
         }
 

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -371,7 +371,8 @@ pub mod pallet {
                     .unwrap()
                     .gateway_abi
                     .value_type_size
-                    * 8,
+                    .checked_mul(8)
+                    .unwrap(),
             )
         }
 


### PR DESCRIPTION
- refactor: update pallets account-manager src
- refactor: update circuit for safe math
- refactor: update executors for safe math
- refactor: update treasury for safe math
- refactor: update xdns for safe math
- test: update account-manager for safe math test
- chore: missed an update on circuit for safe math test
- chore: missed an update on treasury for safe math test
- fix: update safe math err handling
- chore: update safe math for err handling
- chore: update safe math for err handling in circuit
- chore: update safe math

When creating SideEffect, enforce encoded arguments' length as defined 
in GatewayABIConfig by checking that the (encoded) length matches the 
one in GatewayAbiConfig.

If the length check fails, a fitting error is returned in that function,
reverting the transaction.

Fixes #403
