### PR TITLE
Github Actions using new runners

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -11,10 +11,11 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  RUSTC_WRAPPER: sccache
 
 jobs:
   format:
-    runs-on: self-hosted
+    runs-on: [self-hosted, test]
     steps:
       - name: ☁️Checkout git repo
         uses: actions/checkout@v2
@@ -35,7 +36,7 @@ jobs:
           args: --all -- --check
 
   lint:
-    runs-on: self-hosted
+    runs-on: [self-hosted, test]
     steps:
       - name: ☁️Checkout git repo
         uses: actions/checkout@v2
@@ -49,14 +50,6 @@ jobs:
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
           override: true
-      - name: 🕒 Cache Rust binaries and packages
-        uses: Swatinem/rust-cache@v2
-        with:
-          # A cache key that is used instead of the automatic `job`-based key,
-          # and is stable over multiple jobs.
-          # default: empty
-          shared-key: cargo
-          cache-on-failure: "true"
       - name: 📑 Lint code (standalone+parachain)
         uses: actions-rs/cargo@v1
         with:
@@ -64,7 +57,7 @@ jobs:
           args: --all
 
   build-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, test]
     needs: [format, lint]
     steps:
       - name: ☁ Checkout git repo
@@ -79,14 +72,6 @@ jobs:
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
           override: true
-      - name: 🕒 Cache Rust binaries and packages
-        uses: Swatinem/rust-cache@v2
-        with:
-          # A cache key that is used instead of the automatic `job`-based key,
-          # and is stable over multiple jobs.
-          # default: empty
-          shared-key: cargo
-          cache-on-failure: "true"
       - name: 🏭 Build circuit (standalone+parachain)
         uses: actions-rs/cargo@v1
         continue-on-error: false

--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   format:
-    runs-on: [self-hosted, test]
+    runs-on: [self-hosted, rust]
     steps:
       - name: ☁️Checkout git repo
         uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
           args: --all -- --check
 
   lint:
-    runs-on: [self-hosted, test]
+    runs-on: [self-hosted, rust]
     steps:
       - name: ☁️Checkout git repo
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
           args: --all
 
   build-test:
-    runs-on: [self-hosted, test]
+    runs-on: [self-hosted, rust]
     needs: [format, lint]
     steps:
       - name: ☁ Checkout git repo

--- a/.github/workflows/zombienet-test.yml
+++ b/.github/workflows/zombienet-test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: [self-hosted, test]    
+    runs-on: [self-hosted, rust]
     steps:
       - name: ☁️ Checkout git repo
         uses: actions/checkout@v2

--- a/.github/workflows/zombienet-test.yml
+++ b/.github/workflows/zombienet-test.yml
@@ -3,9 +3,6 @@ name: Perform zombienet tests
 env:
   RUST_BACKTRACE: full
   RUSTC_WRAPPER: sccache
-  SCCACHE_CACHE_SIZE: 5G
-  SCCACHE_DIR: /home/sysi-epyc/.cache/sccache # Linux runner only, shouldnt affect this workflow
-  # SCCACHE_RECACHE: 1 # Uncomment this to clear cache, then comment it back out
 on:
   pull_request:
     paths:
@@ -19,7 +16,7 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ["self-hosted", "ep1c"]
+    runs-on: [self-hosted, test]    
     steps:
       - name: ☁️ Checkout git repo
         uses: actions/checkout@v2
@@ -35,34 +32,6 @@ jobs:
           components: rustfmt, clippy
           override: true
 
-      - name: 🕒 Cache Rust binaries and packages
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "true"
-
-      - name: 🕒 Cache binaries
-        uses: actions/cache@v2
-        id: cache-bin
-        with:
-          path: |
-            bin
-          key: ${{ runner.os }}-bin-${{ hashFiles('tests/zombienet/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-bin-
-
-      - name: 🕒 Save sccache
-        uses: actions/cache@v2
-        continue-on-error: false
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-sccache-
-
-      - name: Start sccache server
-        working-directory: tests/zombienet
-        run: make start-sccache
-
       - name: 📼 Run zombienet tests
         continue-on-error: false
         working-directory: tests/zombienet
@@ -71,7 +40,3 @@ jobs:
       - name: Print sccache stats
         working-directory: tests/zombienet
         run: make print-sccache
-
-      - name: Stop sccache server
-        working-directory: tests/zombienet
-        run: make stop-sccache

--- a/.github/workflows/zombienet-test.yml
+++ b/.github/workflows/zombienet-test.yml
@@ -32,6 +32,15 @@ jobs:
           components: rustfmt, clippy
           override: true
 
+      - name: Print sccache stats
+        working-directory: tests/zombienet
+        run: sccache --show-stats
+
+      - name: 📼 Setup zombienet tests
+        continue-on-error: false
+        working-directory: tests/zombienet
+        run: make setup
+
       - name: 📼 Run zombienet tests
         continue-on-error: false
         working-directory: tests/zombienet
@@ -39,4 +48,4 @@ jobs:
 
       - name: Print sccache stats
         working-directory: tests/zombienet
-        run: make print-sccache
+        run: sccache --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ members = [
   'types',
   'finality-verifiers/grandpa',
 ]
-

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This concludes the process of generating weights for the pallet.
 ## License
 
 ---
-Copyright 2020 t3rn Ltd.
+Copyright 2020-2022 t3rn Ltd.
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/node/README.md
+++ b/node/README.md
@@ -39,7 +39,7 @@ A crate that hosts common definitions that are relevant for the Circuit.
 ## License
 
 ---
-Copyright 2020 Maciej Baj.
+Copyright 2020-2022 Maciej Baj.
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/zombienet/Makefile
+++ b/tests/zombienet/Makefile
@@ -8,8 +8,6 @@ root_dir := $(shell git rev-parse --show-toplevel)
 bin_dir := $(root_dir)/bin
 arch := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 polkadot_tmp_dir := /tmp/polkadot
-SCCACHE_VERSION := v0.3.1
-SCCACHE_FILE := sccache-$(SCCACHE_VERSION)-x86_64-unknown-linux-musl
 
 export PATH := $(shell echo $$PATH):$(bin_dir)
 
@@ -27,22 +25,9 @@ clean:
 $(bin_dir): 
 	@mkdir -p $(bin_dir)
 
-${bin_dir}/sccache:
-	@if [ $(machine) = "macos" ]; then \
-        brew update; \
-		brew install -qf sccache | true; \
-		cp -n /opt/homebrew/bin/sccache $(bin_dir)/sccache; \
-	elif [ $(machine) = "linux" ]; then \
-		tmp_dir=$(shell mktemp -d); \
-		curl -fL https://github.com/mozilla/sccache/releases/download/$(SCCACHE_VERSION)/$(SCCACHE_FILE).tar.gz | tar xzvf - -C $(bin_dir)/; \
-		mv $(bin_dir)/$(SCCACHE_FILE)/sccache $(bin_dir)/; \
-		sudo chmod +x $(bin_dir)/sccache; \
-	fi
-	
 ${bin_dir}/zombienet:
 	curl -fL -o $(bin_dir)/zombienet https://github.com/paritytech/zombienet/releases/download/$(zombienet_version)/zombienet-$(machine)
-	# echo "#### Need sudo access for zombienet executable, make will drop this sudo access after this cmd ####"
-	sudo chmod +x $(bin_dir)/zombienet
+	chmod +x $(bin_dir)/zombienet
 
 ${bin_dir}/polkadot:
 	@if [ ! -f $(polkadot_tmp_dir)/$(pdot_branch)/target/release/polkadot ]; then \
@@ -60,19 +45,8 @@ ${bin_dir}/t3rn-collator: $(wildcard $(root_dir)/*/t3rn-parachain/src/*.rs) $(ro
 	cargo build --manifest-path $(root_dir)/node/t3rn-parachain/Cargo.toml --release --locked
 	cp -f $(root_dir)/target/release/t3rn-collator $(bin_dir)/
 
-setup: $(bin_dir) ${bin_dir}/sccache ${bin_dir}/zombienet ${bin_dir}/polkadot ${bin_dir}/t0rn-collator ${bin_dir}/t3rn-collator
+setup: $(bin_dir) ${bin_dir}/zombienet ${bin_dir}/polkadot ${bin_dir}/t0rn-collator ${bin_dir}/t3rn-collator
 
-# ====================== Caching ======================
-
-start-sccache: $(bin_dir) ${bin_dir}/sccache
-	sccache --start-server || true
-
-stop-sccache: ${bin_dir}/sccache
-	sccache --stop-server || true
-	
-print-sccache: ${bin_dir}/sccache
-	sccache --show-stats
-	
 # ====================== Testing ======================
 
 test-smoke: setup
@@ -108,7 +82,7 @@ test-upgrade: setup bump-versions
 # NOTE: this does not modify the versions as to provide a true representation of the runtime upgrade
 # NOTE: this probably will only work on linux since we only release linux binaries and they aren't musl, so strictly this works for CI.
 # TODO[Optimisation]: get last tag and build in a fake directory instead
-test-real-upgrade: $(bin_dir) ${bin_dir}/sccache ${bin_dir}/zombienet ${bin_dir}/polkadot ${bin_dir}/$(parachain)-collator 
+test-real-upgrade: $(bin_dir) ${bin_dir}/zombienet ${bin_dir}/polkadot ${bin_dir}/$(parachain)-collator 
 	@echo "Testing real upgrade for parachain: $(parachain)"
 
 	@if [ $(machine) = "macos" ]; then \

--- a/tests/zombienet/Makefile
+++ b/tests/zombienet/Makefile
@@ -49,7 +49,7 @@ setup: $(bin_dir) ${bin_dir}/zombienet ${bin_dir}/polkadot ${bin_dir}/t0rn-colla
 
 # ====================== Testing ======================
 
-test-smoke: setup
+test-smoke: 
 	# TODO[Optimisation]: loop through directory and test all
 	# TODO[Optimisation, NotImplemented]: when zombienet can run on a pre-existing network, run it
 	$(bin_dir)/zombienet --provider=$(provider) test ./smoke/0001-is_up_and_registered.feature
@@ -69,7 +69,7 @@ bump-versions:
 
 # This isnt quite the entire runtime-upgrade, only that we can bump the versions and upgrade
 # The real approach to runtime upgrades are below where we deploy with an old binary and use a new runtime
-test-upgrade: setup bump-versions
+test-upgrade: bump-versions
 	
 	# build new blobs
 	cargo build --manifest-path $(root_dir)/node/t0rn-parachain/Cargo.toml --release --locked


### PR DESCRIPTION
This PR is changing how jobs are executed by our runners and how cache layer is used.

- ep1c worker reconfigured to use cache from memory
- new worker on AWS
- github actions caching removed from jobs to not slow down build process
- Makefile for zombienet test changed to separate `setup` and `test` stage

Those changes reduce time of:
- `lint` job from 7m to ~2m
- `build and test` job from 20m to 6:50
- `zombienet test` job from 30m to 28m (where blockchain tests take around 20m and can't be sped up)