### PR TITLE
tests: retrofit zombienet to t0rn

### DIFF
--- a/.github/workflows/release-t0rn.yml
+++ b/.github/workflows/release-t0rn.yml
@@ -226,19 +226,40 @@ jobs:
           asset_name: ${{ env.PARACHAIN_NAME }}-parachain-runtime-${{ env.PUSHED_TAG }}.compact.compressed.wasm
           asset_content_type: text/plain
 
+  run-smoke-tests:
+    runs-on: ["self-hosted", "rust"]
+    needs: release-on-github
+    steps:
+      - name: ☁ Checkout git repo
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+      - name: ⚙️ Get nightly rust toolchain with wasm target
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2022-06-16
+          target: wasm32-unknown-unknown
+          components: rustfmt, clippy
+          override: true
+      - name: 📼 Run zombienet runtime upgrade test
+        continue-on-error: false
+        working-directory: tests/zombienet
+        run: make test-upgrade parachain=t0rn
+
   deploy-to-rococo-dry-run:
     runs-on: self-hosted
     needs: release-on-github
     steps:
       - name: 🏷️ Get the version tag
         run: echo "PUSHED_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-  
+
       - name: 📥 Download runtime WASM
         uses: actions/download-artifact@v2
         with:
           name: ${{ github.sha }}-${{ env.PARACHAIN_NAME }}_parachain_runtime.compact.compressed.wasm
           path: ./target/release/
-  
+
       - name: 📥 Download runtime WASM hash blake2_256
         uses: actions/download-artifact@v2
         with:

--- a/tests/zombienet/Makefile
+++ b/tests/zombienet/Makefile
@@ -1,0 +1,111 @@
+.EXPORT_ALL_VARIABLES:
+
+provider := native
+zombienet_version := v1.3.17
+runtime := t3rn
+pdot_branch := release-v0.9.27
+root_dir := $(shell git rev-parse --show-toplevel)
+bin_dir := $(root_dir)/bin
+arch := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+polkadot_tmp_dir := /tmp/polkadot
+SCCACHE_VERSION := v0.3.1
+SCCACHE_FILE := sccache-$(SCCACHE_VERSION)-x86_64-unknown-linux-musl
+
+export PATH := $(shell echo $$PATH):$(bin_dir)
+
+ifneq ($(findstring Darwin,$(arch)),)
+	machine := macos
+else ifneq ($(findstring Linux,$(arch)),)
+	machine := linux
+endif
+
+# ====================== Setup ======================
+
+clean:
+	rm -rf $(bin_dir)/*
+
+$(bin_dir): 
+	@mkdir -p $(bin_dir)
+
+${bin_dir}/zombienet:
+	curl -fL -o $(bin_dir)/zombienet https://github.com/paritytech/zombienet/releases/download/$(zombienet_version)/zombienet-$(machine)
+	chmod +x $(bin_dir)/zombienet
+
+${bin_dir}/polkadot:
+	@if [ ! -f $(polkadot_tmp_dir)/$(pdot_branch)/target/release/polkadot ]; then \
+		mkdir -p $(polkadot_tmp_dir); \
+		git clone --branch $(pdot_branch) --depth 1 https://github.com/paritytech/polkadot $(polkadot_tmp_dir)/$(pdot_branch); \
+		cargo build --manifest-path $(polkadot_tmp_dir)/$(pdot_branch)/Cargo.toml --features fast-runtime --release --locked; \
+	fi
+	cp $(polkadot_tmp_dir)/$(pdot_branch)/target/release/polkadot $(bin_dir)/polkadot
+
+setup: $(bin_dir) ${bin_dir}/zombienet ${bin_dir}/polkadot
+
+# ====================== Caching ======================
+#
+# sccache is already present on Github Action workers, no need to set it up
+#
+${bin_dir}/sccache:
+	@if [ $(machine) = "macos" ]; then \
+        brew update; \
+		brew install -qf sccache | true; \
+		cp -n /opt/homebrew/bin/sccache $(bin_dir)/sccache; \
+	elif [ $(machine) = "linux" ]; then \
+		tmp_dir=$(shell mktemp -d); \
+		curl -fL https://github.com/mozilla/sccache/releases/download/$(SCCACHE_VERSION)/$(SCCACHE_FILE).tar.gz | tar xzvf - -C $(bin_dir)/; \
+		mv $(bin_dir)/$(SCCACHE_FILE)/sccache $(bin_dir)/; \
+		sudo chmod +x $(bin_dir)/sccache; \
+	fi
+	
+start-sccache: $(bin_dir) ${bin_dir}/sccache
+	sccache --start-server || true
+
+stop-sccache: ${bin_dir}/sccache
+	sccache --stop-server || true
+	
+print-sccache: ${bin_dir}/sccache
+	sccache --show-stats
+	
+# ====================== Testing ======================
+
+test-smoke: setup
+
+	@echo "Testing real upgrade for parachain: $(parachain)"
+
+	@if [ $(machine) = "macos" ]; then \
+        echo "You're on macos, this is for CI :< - it uses previously built binaries from this machine only"; \
+		exit 1; \
+	fi
+
+	@echo get last release binary from github
+	git fetch --all --tags -f || true
+
+	@echo get last binary
+	./download_previous_collator.sh $(parachain)
+	
+	# TODO[Optimisation]: loop through directory and test all
+	# TODO[Optimisation, NotImplemented]: when zombienet can run on a pre-existing network, run it
+	$(bin_dir)/zombienet --provider=$(provider) test ./smoke/0001-is_up_and_registered.feature
+
+test-upgrade: $(bin_dir) ${bin_dir}/zombienet ${bin_dir}/polkadot
+	@echo "Testing real upgrade for parachain: $(parachain)"
+
+	@if [ $(machine) = "macos" ]; then \
+        echo "You're on macos, this is for CI :< - it uses previously built binaries from this machine only"; \
+		exit 1; \
+	fi
+
+	@echo get last release binary from github
+	git fetch --all --tags -f || true
+
+	./download.sh $(parachain)
+
+	@echo "deploy with test (ensuring old binary, new blob)"
+	zombienet --provider=$(provider) test ./smoke/9999-runtime_upgrade.feature
+
+spawn: setup
+	$(bin_dir)/zombienet --help
+	$(bin_dir)/zombienet --provider=$(provider) spawn ./zombienet.toml
+
+# TODO: do we want to just do this on PR's and not pre release?
+test: test-smoke

--- a/tests/zombienet/download.sh
+++ b/tests/zombienet/download.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+new_version=$(($2+1))
+bin_dir=../../bin
+
+case "$1" in
+  t0rn*)
+    echo "=========== T0RN ==========="
+    tags_list=$(git tag --list --sort=-version:refname "v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*" | head -n 2)
+    echo Tags:
+    echo "$tags_list"
+
+    SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
+    IFS=$'\n' 
+    tags_list=($tags_list) # split to array
+    old_version=${tags_list[1]}
+    echo Old version: "$old_version"
+    new_version=${tags_list[0]}
+    echo New version: "$new_version"
+
+    tag_version="$old_version"
+    echo Version: "$tag_version"
+
+    ./download_previous_collator.sh "$old_version"
+    ./download_latest_wasm_blob.sh "$new_version"
+    ;;
+  t3rn*)
+    echo "=========== T3RN ==========="
+    tags_list=$(git tag --list --sort=-version:refname "v[0-9]*.[0-9].[0-9]" | head -n 2)
+    echo Tags: "$tags_list"
+
+    SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
+    IFS=$'\n' 
+    tags_list=($tags_list) # split to array
+    old_version=${tags_list[1]}
+    echo Old version: "$old_version"
+    new_version=${tags_list[0]}
+    echo New version: "$new_version"
+
+    tag_version="$old_version"
+    echo Version: "$tag_version"
+
+    ./download_previous_collator.sh "$old_version"
+    ./download_latest_wasm_blob.sh "$new_version"
+    ;;
+  *)        
+  exit 1;;
+esac

--- a/tests/zombienet/download_latest_wasm_blob.sh
+++ b/tests/zombienet/download_latest_wasm_blob.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+bin_dir=../../bin
+
+echo "Downloading wasm for tag $1"
+
+export url=$(curl -s https://api.github.com/repos/t3rn/t3rn/releases/tags/"$1" | jq -r '.assets[] | select(.name | endswith ("compact.compressed.wasm")).browser_download_url')
+echo Url: $url
+
+[ "$url" ] || exit 1
+curl -L -o - "$url" > ${bin_dir}/parachain_runtime.compact.compressed.wasm

--- a/tests/zombienet/download_previous_collator.sh
+++ b/tests/zombienet/download_previous_collator.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+bin_dir=../../bin
+
+echo "Downloading collator for tag $1"
+
+export url=$(curl -s https://api.github.com/repos/t3rn/t3rn/releases/tags/"$1" | jq -r '.assets[] | select(.name | endswith ("unknown-linux-gnu.gz")).browser_download_url')
+echo Url: $url
+
+[ "$url" ] || exit 1
+curl -L -o - "$url" | gunzip -c > ${bin_dir}/collator-old && chmod +x ${bin_dir}/collator-old

--- a/tests/zombienet/increment.sh
+++ b/tests/zombienet/increment.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+new_version=$(($2+1))
+
+case "$(uname -s)" in
+  Linux*)   sed -i "s/$3: $2/$3: $new_version/g" "$(git rev-parse --show-toplevel)"/runtime/"$1"-parachain/src/lib.rs;;
+  Darwin*)  sed -i '' "s/$3: $2/$3: $new_version/g" "$(git rev-parse --show-toplevel)"/runtime/"$1"-parachain/src/lib.rs;;
+  *)        exit 1;;
+esac

--- a/tests/zombienet/mainnet.toml
+++ b/tests/zombienet/mainnet.toml
@@ -1,0 +1,32 @@
+[relaychain]
+chain   = "rococo-local"
+command = "polkadot"
+
+[[relaychain.nodes]]
+name    = "alice"
+ws_port = 9900
+
+[[relaychain.node_groups]]
+count = 4
+name  = "bob"
+
+[[parachains]]
+chain         = "polkadot"
+cumulus_based = true
+id            = 2100
+
+[[parachains.collators]]
+command  = "t3rn-collator"
+name     = "t3rn-collator01"
+rpc_port = 8840
+ws_port  = 9940
+
+[[parachains.collators]]
+command  = "t3rn-collator"
+name     = "t3rn-collator02"
+rpc_port = 8841
+ws_port  = 9941
+
+[types.Header]
+number = "u64"
+weight = "u64"

--- a/tests/zombienet/smoke/0001-is_up_and_registered.feature
+++ b/tests/zombienet/smoke/0001-is_up_and_registered.feature
@@ -1,0 +1,14 @@
+Description: Smoke test - parachains are up and registered
+Network: ../zombienet.toml
+Creds: config
+
+alice: is up
+bob: is up
+
+alice: parachain 3000 is registered within 225 seconds
+alice: parachain 4000 is registered within 225 seconds
+
+{% set nodes = ["t0rn-collator01", "t0rn-collator02", "t3rn-collator01", "t3rn-collator02"] %}
+{% for node in nodes %}
+{{node}}: reports block height is at least 5 within 250 seconds
+{% endfor %}

--- a/tests/zombienet/smoke/9999-runtime_upgrade.feature
+++ b/tests/zombienet/smoke/9999-runtime_upgrade.feature
@@ -1,0 +1,18 @@
+Description: Runtime Upgrade test
+Network: ../zombienet-real-upgrade-sim.toml
+Creds: config
+
+alice: is up
+bob: is up
+
+alice: parachain 3000 is registered within 225 seconds
+
+{% set nodes = ["collator01", "collator02"] %}
+{% for node in nodes %}
+{{node}}: reports block height is at least 3 within 225 seconds
+{% endfor %}
+
+collator01: parachain 3000 perform upgrade with ../../../bin/parachain_runtime.compact.compressed.wasm within 200 seconds
+collator02: reports block height is at least 10 within 250 seconds
+collator02: js-script ./runtime_upgrade.js within 200 seconds
+collator02: reports block height is at least 15 within 600 seconds

--- a/tests/zombienet/smoke/runtime_upgrade.js
+++ b/tests/zombienet/smoke/runtime_upgrade.js
@@ -1,0 +1,24 @@
+const assert = require("assert");
+
+async function run(nodeName, networkInfo, args) {
+    const { wsUri, userDefinedTypes } = networkInfo.nodesByName[nodeName];
+    const api = await zombie.connect(wsUri, userDefinedTypes);
+
+    // get blockhash/runtimeVersion at block 1
+    const hashAtBlock1 = await api.rpc.chain.getBlockHash(1);
+    const versionAtBlock1 = await api.rpc.state.getRuntimeVersion(hashAtBlock1.toHuman());
+
+    // get blockhash/runtimeVersion at current head
+    const currentHeader = await api.rpc.chain.getHeader();
+    const hashAtCurrent = await api.rpc.chain.getBlockHash(currentHeader.number.toHuman());
+    const versionAtCurrent = await api.rpc.state.getRuntimeVersion(hashAtCurrent.toHuman());
+    const humanCurrent = versionAtCurrent.specVersion.toHuman();
+    console.log("current", humanCurrent);
+
+    const expectedVersion = parseInt(versionAtBlock1.specVersion.toHuman(), 10) + 1;
+    console.log("expectedVersion", expectedVersion);
+
+    assert.ok(humanCurrent >= expectedVersion, "Running version should more than or equal to expectedVersion");
+}
+
+module.exports = { run }

--- a/tests/zombienet/zombienet-real-upgrade-sim.toml
+++ b/tests/zombienet/zombienet-real-upgrade-sim.toml
@@ -1,0 +1,29 @@
+[relaychain]
+chain   = "rococo-local"
+command = "polkadot"
+
+[[relaychain.nodes]]
+name    = "alice"
+ws_port = 9900
+
+[[relaychain.node_groups]]
+count = 2
+name  = "bob"
+
+[[parachains]]
+chain         = "rococo-local"
+cumulus_based = true
+id            = 3000
+
+# Arbitrary collator needs to be set based on param
+[[parachains.collators]]
+command  = "../../bin/collator-old"
+name     = "collator01"
+rpc_port = 8830
+ws_port  = 9930
+
+[[parachains.collators]]
+command  = "../../bin/collator-old"
+name     = "collator02"
+rpc_port = 8831
+ws_port  = 9931

--- a/tests/zombienet/zombienet.toml
+++ b/tests/zombienet/zombienet.toml
@@ -1,0 +1,61 @@
+[relaychain]
+command = "polkadot"
+chain = "rococo-local"
+
+[[relaychain.nodes]]
+name = "alice"
+ws_port = 9900
+
+[[relaychain.node_groups]]
+name = "bob"
+count = 4
+
+[[parachains]]
+id = 3000
+cumulus_based = true
+chain = "rococo-local"
+
+[[parachains.collators]]
+name = "t0rn-collator01"
+command = "t0rn-collator"
+ws_port = 9930
+rpc_port = 8830
+
+[[parachains.collators]]
+name = "t0rn-collator02"
+command = "t0rn-collator"
+ws_port = 9931
+rpc_port = 8831
+
+[[parachains]]
+id = 4000
+cumulus_based = true
+chain = "local"
+
+[[parachains.collators]]
+name = "t3rn-collator01"
+command = "t3rn-collator"
+ws_port = 9940
+rpc_port = 8840
+
+[[parachains.collators]]
+name = "t3rn-collator02"
+command = "t3rn-collator"
+ws_port = 9941
+rpc_port = 8841
+
+[[hrmp_channels]]
+sender = 3000
+recipient = 4000
+max_capacity = 8
+max_message_size = 512
+
+[[hrmp_channels]]
+sender = 4000
+recipient = 3000
+max_capacity = 8
+max_message_size = 512
+
+[types.Header]
+number = "u64"
+weight = "u64"


### PR DESCRIPTION
This uses predefined releases to test with, speeding up zombienet much more.
Also adds some better testability to the scripts for downloading.


Tested here https://github.com/t3rn/t3rn/actions/runs/4102683866/jobs/7076121595