### PR TITLE
ci: disable pallet-executors tests

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -9,7 +9,7 @@ on:
       - ".github/workflows/circuit.yml"
       - ".git/modules/*/HEAD"
   schedule:
-    - cron: '0,1 5 * * MON-FRI'
+    - cron: "0,1 5 * * MON-FRI"
 
 env:
   RUST_BACKTRACE: 1
@@ -82,7 +82,8 @@ jobs:
           args: --locked
       - name: 📼 Run unit tests (standalone)
         continue-on-error: false
+        # TODO: unbork pallet-executors tests
         run: |
           chmod +x target/debug/circuit-standalone
           target/debug/circuit-standalone --alice --log=main,debug --tmp > /dev/null 2>&1 &
-          cargo test --workspace --locked --features runtime --manifest-path Cargo.toml
+          cargo test --workspace --exclude pallet-executors --locked --features runtime --manifest-path Cargo.toml


### PR DESCRIPTION
Disable pallet executors tests for now since they are causing a lot of OOM issues and kernel faults.