### PR TITLE
fix: add update frequency

### DIFF
--- a/client/packages/executor/config/config.ts
+++ b/client/packages/executor/config/config.ts
@@ -130,7 +130,8 @@ export type Config = {
     /** The price sources that are being used */
     pricing: {
         [source: string]: {
-            [key: string]: string
+            endpoint: string,
+            frequency: number
         }
     }
     /** Assets prices that should be tracked */
@@ -180,6 +181,7 @@ export const config: Config = {
     pricing: {
         coingecko: {
             endpoint: "https://api.coingecko.com/api/v3/coins/",
+            frequency: 30000,
         },
     },
     assets: {

--- a/client/packages/executor/config/config.ts
+++ b/client/packages/executor/config/config.ts
@@ -131,6 +131,7 @@ export type Config = {
     pricing: {
         [source: string]: {
             endpoint: string,
+            endpointDefaults: string,
             frequency: number
         }
     }
@@ -181,6 +182,7 @@ export const config: Config = {
     pricing: {
         coingecko: {
             endpoint: "https://api.coingecko.com/api/v3/coins/",
+            endpointDefaults: "?localization=false&tickers=false&community_data=false&developer_data=false&sparkline=false",
             frequency: 30000,
         },
     },

--- a/client/packages/executor/src/pricing/coingecko.ts
+++ b/client/packages/executor/src/pricing/coingecko.ts
@@ -15,23 +15,28 @@ export class CoingeckoPricing {
         [assetTicker: string]: string
     } = {}
     /** How often to update the values. 0 disables updating */
-    updateFrequency: number = 0
+    updateFrequency: number
     /** Stores price in USD as a subject */
     prices: {
         [assetTicker: string]: BehaviorSubject<number>
     } = {}
+    /** Flag for finishing tests when debuging */
+    debugFlag: boolean
 
-    constructor(updateFrequency?: number) {
+    constructor(updateFrequency?: number, debugFlag: boolean = false) {
         // Get the frequency when instantiating the class
         if (updateFrequency) {
             this.updateFrequency = updateFrequency
         } else {
             this.updateFrequency = config.pricing.coingecko.frequency || 0
         }
+        this.debugFlag = debugFlag
         this.endpoint = config.pricing.coingecko.endpoint
         this.getTrackingAssets()
-        // This cannot be called here if we want to test it (it doesn't finish)
-        this.updateAssetPrices()
+        // If testing, don't update the prices since they will never finish
+        if (!this.debugFlag) {
+            this.updateAssetPrices()
+        }
     }
 
     /** Read the config file to initialize the list of assets we want to track */

--- a/client/packages/executor/src/pricing/coingecko.ts
+++ b/client/packages/executor/src/pricing/coingecko.ts
@@ -8,18 +8,26 @@ const axios = require("axios")
  * @group Pricing
  */
 export class CoingeckoPricing {
+    /** Where to get the prices from */
     endpoint: string
     /** Maps ticker to coingecko ID */
     assets: {
         [assetTicker: string]: string
     } = {}
-
+    /** How often to update the values. 0 disables updating */
+    updateFrequency: number = 0
     /** Stores price in USD as a subject */
     prices: {
         [assetTicker: string]: BehaviorSubject<number>
     } = {}
 
-    constructor() {
+    constructor(updateFrequency?: number) {
+        // Get the frequency when instantiating the class
+        if (updateFrequency) {
+            this.updateFrequency = updateFrequency
+        } else {
+            this.updateFrequency = config.pricing.coingecko.frequency || 0
+        }
         this.endpoint = config.pricing.coingecko.endpoint
         this.getTrackingAssets()
         // This cannot be called here if we want to test it (it doesn't finish)
@@ -60,6 +68,6 @@ export class CoingeckoPricing {
                     console.log("Failed fetching prices:", err.toString())
                 })
         }
-        setTimeout(this.updateAssetPrices.bind(this), 30000)
+        setTimeout(this.updateAssetPrices.bind(this), this.updateFrequency)
     }
 }

--- a/client/packages/executor/src/pricing/coingecko.ts
+++ b/client/packages/executor/src/pricing/coingecko.ts
@@ -55,7 +55,7 @@ export class CoingeckoPricing {
                 .get(
                     config.pricing.coingecko.endpoint +
                     this.assets[ids[i]] +
-                    "?localization=false&tickers=false&community_data=false&developer_data=false&sparkline=false"
+                    config.pricing.coingecko.endpointDefaults
                 )
                 .then((res) => {
                     const price = parseFloat(res.data.market_data.current_price["usd"])
@@ -65,7 +65,7 @@ export class CoingeckoPricing {
                     return new Promise((resolve) => setTimeout(resolve, 2000));
                 })
                 .catch((err) => {
-                    console.log("Failed fetching prices:", err.toString())
+                    console.log("Failed fetching prices due to ->", err.toString())
                 })
         }
         setTimeout(this.updateAssetPrices.bind(this), this.updateFrequency)

--- a/client/packages/executor/src/pricing/index.ts
+++ b/client/packages/executor/src/pricing/index.ts
@@ -10,8 +10,8 @@ import { BehaviorSubject } from "rxjs"
 export class PriceEngine {
     coingecko: CoingeckoPricing
 
-    constructor(updateFrequency?: number) {
-        this.coingecko = new CoingeckoPricing(updateFrequency || 0)
+    constructor(updateFrequency?: number, debugFlag: boolean = false) {
+        this.coingecko = new CoingeckoPricing(updateFrequency || 0, debugFlag)
     }
 
     /**

--- a/client/packages/executor/src/pricing/index.ts
+++ b/client/packages/executor/src/pricing/index.ts
@@ -10,8 +10,8 @@ import { BehaviorSubject } from "rxjs"
 export class PriceEngine {
     coingecko: CoingeckoPricing
 
-    constructor() {
-        this.coingecko = new CoingeckoPricing()
+    constructor(updateFrequency?: number) {
+        this.coingecko = new CoingeckoPricing(updateFrequency || 0)
     }
 
     /**

--- a/client/packages/executor/tests/pricing.test.ts
+++ b/client/packages/executor/tests/pricing.test.ts
@@ -1,0 +1,43 @@
+import { CoingeckoPricing } from "../src/pricing/coingecko";
+import { PriceEngine } from "../src/pricing/index";
+import { expect } from "chai";
+import { config } from "../config/config";
+
+describe("Basic PriceEngine setup", () => {
+    const pe = new PriceEngine();
+
+    it("should be a class", () => {
+        expect(PriceEngine).to.be.a("function");
+    });
+
+    it("should have a constructor", () => {
+        expect(pe).to.have.property("constructor");
+    });
+
+    it("should have a method called 'getAssetPrice'", () => {
+        expect(pe).to.have.property("getAssetPrice");
+    });
+});
+
+describe("Basic CoinGecko setup", () => {
+    it("should be a class", () => {
+        expect(CoingeckoPricing).to.be.a("function");
+    });
+
+    it("should have a constructor and methods", async () => {
+        const cg = await new CoingeckoPricing(0);
+        expect(cg).to.have.property("constructor");
+        expect(cg).to.have.property("getTrackingAssets");
+        expect(cg).to.have.property("updateAssetPrices");
+    });
+
+    it("should load the assets for tracking", async () => {
+        // Create a new instance of the class
+        const cg = await new CoingeckoPricing(0);
+        // Load the assets
+        cg.getTrackingAssets();
+
+        // CHECKS
+        expect(cg.assets).to.include.all.keys(Object.keys(config.assets));
+    })
+})

--- a/client/packages/executor/tests/pricing.test.ts
+++ b/client/packages/executor/tests/pricing.test.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import { config } from "../config/config";
 
 describe("Basic PriceEngine setup", () => {
-    const pe = new PriceEngine();
+    const pe = new PriceEngine(0);
 
     it("should be a class", () => {
         expect(PriceEngine).to.be.a("function");

--- a/client/packages/executor/tests/pricing.test.ts
+++ b/client/packages/executor/tests/pricing.test.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import { config } from "../config/config";
 
 describe("Basic PriceEngine setup", () => {
-    const pe = new PriceEngine(0);
+    const pe = new PriceEngine(0, true);
 
     it("should be a class", () => {
         expect(PriceEngine).to.be.a("function");
@@ -25,7 +25,7 @@ describe("Basic CoinGecko setup", () => {
     });
 
     it("should have a constructor and methods", async () => {
-        const cg = await new CoingeckoPricing(0);
+        const cg = await new CoingeckoPricing(0, true);
         expect(cg).to.have.property("constructor");
         expect(cg).to.have.property("getTrackingAssets");
         expect(cg).to.have.property("updateAssetPrices");
@@ -33,7 +33,7 @@ describe("Basic CoinGecko setup", () => {
 
     it("should load the assets for tracking", async () => {
         // Create a new instance of the class
-        const cg = await new CoingeckoPricing(0);
+        const cg = await new CoingeckoPricing(0, true);
         // Load the assets
         cg.getTrackingAssets();
 


### PR DESCRIPTION
# Summary of changes

Some tests were broken because the PriceEngine class could not stop fetching data.
Now, it's possible to disable it for testing and/or to set a custom frequency.

Addresses issue #746

## Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue):
  - [ ] Have you **written tests**to protect against future occurrences of the bug?
- [X] New feature (non-breaking change which adds functionality)
  - [x] Have you **seen it working** in a development environment?
  - [ ] Have you **written tests** for **happy** and **unhappy** paths?
  - [X] Have you implemented this feature as per the **issue acceptance criteria**?
- [ ] Breaking change (a feature that would cause existing functionality not to work as expected
  - [ ] Is the breaking change **documented**?
  - [ ] Has any previous changes been **deprecated**?
- [ ] CI/CD
  - [ ] If introducing new actions, have you **looked at the action code** for anything spurious?
  - [ ] Have you written **custom scripts** for things that could be actions already on the marketplace?
  - [ ] If introducing new actions, have you **pegged a static version**?
- [ ] Documentation Update
  - [ ] Have you checked other documentation, such as the docs repository?
  - [ ] If updating script documentation, have you **tested it on both environments**?
- [ ] Substrate
  - [ ] RPC methods?
  - [ ] Chainspec, both JSON specs & the module?
  - [ ] Runtime versioning?
  - [ ] Benchmarks?
- [ ] Any dependent changes have been merged and published in downstream modules
