### PR TITLE
fix: extend SFXAbi with prefix validation for Substrate ingress events

### DIFF
--- a/types/abi/src/recode_rlp.rs
+++ b/types/abi/src/recode_rlp.rs
@@ -1,5 +1,5 @@
 use crate::{recode::Recode, to_abi::Abi, to_filled_abi::FilledAbi, types::Name};
-use codec::{Decode, Encode, KeyedVec};
+use codec::{Decode, Encode};
 
 use sp_core::{H160, H256};
 use sp_runtime::DispatchError;
@@ -7,7 +7,7 @@ use sp_std::{prelude::*, vec::IntoIter};
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct EthIngressEventLog(pub Vec<H256>, pub Vec<u8>);
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, Bytes};
 use frame_support::ensure;
 
 pub struct RecodeRlp;

--- a/types/abi/src/to_filled_abi.rs
+++ b/types/abi/src/to_filled_abi.rs
@@ -47,6 +47,27 @@ pub fn matches_name(field_name: Option<&Name>, by_name: &Name) -> bool {
 }
 
 impl FilledAbi {
+    pub fn get_prefix_memo(&self) -> Option<u8> {
+        match self {
+            FilledAbi::Struct(_name, _, prefix_memo) => Some(*prefix_memo),
+            FilledAbi::Enum(_name, _, prefix_memo) => Some(*prefix_memo),
+            FilledAbi::Log(_name, _, prefix_memo) => Some(*prefix_memo),
+            FilledAbi::Option(_name, _) => None,
+            FilledAbi::Bytes(_name, _) => None,
+            FilledAbi::Account20(_name, _) => None,
+            FilledAbi::Account32(_name, _) => None,
+            FilledAbi::H256(_name, _) => None,
+            FilledAbi::Value256(_name, _) => None,
+            FilledAbi::Value128(_name, _) => None,
+            FilledAbi::Value64(_name, _) => None,
+            FilledAbi::Value32(_name, _) => None,
+            FilledAbi::Byte(_name, _) => None,
+            FilledAbi::Bool(_name, _) => None,
+            FilledAbi::Vec(_name, _, _) => None,
+            FilledAbi::Tuple(_name, _) => None,
+        }
+    }
+
     pub fn type_name(&self) -> &str {
         match self {
             FilledAbi::Struct(_name, _, _) => "Struct",

--- a/types/src/sfx.rs
+++ b/types/src/sfx.rs
@@ -110,7 +110,8 @@ where
     }
 
     pub fn validate(&self, sfx_abi: SFXAbi, egress_codec: &Codec) -> Result<(), DispatchError> {
-        sfx_abi.validate_ordered_arguments(&self.encoded_args, egress_codec)
+        let _ = sfx_abi.validate_ordered_arguments(&self.encoded_args, egress_codec)?;
+        Ok(())
     }
 
     pub fn confirm(


### PR DESCRIPTION
# Summary of changes

Extend SFXAbi with prefix validation for Substrate ingress events

Check prefix memo if it's set - it's optional since not required for any Event decoding besides Substrate Events
At the same time imposes security risk by attacker faking events sent out of unauthorized pallets


## Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue):
    - [ ] Have you **written tests **to protect against future occurrences of the bug?
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] Have you **seen it working** in a development environment?
    - [ ] Have you **written tests** for **happy** and **unhappy** paths?
    - [ ] Have you implemented this feature as per the **issue acceptance criteria**?
- [ ] Breaking change (a feature that would cause existing functionality not to work as expected
    - [ ] Is the breaking change **documented**?
    - [ ] Has any previous changes been **deprecated**?
- [ ] CI/CD
    - [ ] If introducing new actions, have you **looked at the action code** for anything spurious?
    - [ ] Have you written **custom scripts** for things that could be actions already on the marketplace?
    - [ ] If introducing new actions, have you **pegged a static version**?
- [ ] Documentation Update
    - [ ] Have you checked other documentation, such as the docs repository?
    - [ ] If updating script documentation, have you **tested it on both environments**?
- [ ] Substrate
    - [ ] RPC methods?
    - [ ] Chainspec, both JSON specs & the module?
    - [ ] Runtime versioning?
    - [ ] Benchmarks?
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (if applicable)
