### PR TITLE
fix: round information was never bumped

### DIFF
--- a/pallets/clock/src/lib.rs
+++ b/pallets/clock/src/lib.rs
@@ -132,7 +132,13 @@ pub mod pallet {
                 head: n,
                 term,
             };
-            if new_round.should_update(n) {
+            log::debug!(
+                "check_bump_round: past_round: {:?}, new_round: {:?}",
+                past_round,
+                new_round
+            );
+            if past_round.should_update(n) {
+                log::debug!("check_bump_round: updating round");
                 <CurrentRound<T>>::put(new_round);
                 Self::deposit_event(Event::NewRound {
                     index: new_round.index,
@@ -152,7 +158,7 @@ pub mod pallet {
         // `on_finalize` is executed at the end of block after all extrinsic are dispatched.
         fn on_finalize(n: T::BlockNumber) {
             let max_on_finalize_weight = T::BlockWeights::get().max_block.saturating_div(FIVE);
-            log::info!(
+            log::debug!(
                 "Clock::on_finalize process hooks with max_on_finalize_weight: {:?}",
                 max_on_finalize_weight
             );
@@ -165,9 +171,10 @@ pub mod pallet {
         // This function must return the weight consumed by `on_initialize` and `on_finalize`.
         fn on_initialize(n: BlockNumberFor<T>) -> Weight {
             let max_on_initialize_weight = T::BlockWeights::get().max_block.saturating_div(FIVE);
-            log::info!(
-                "Clock::on_initialize process hooks with max_on_initialize_weight: {:?}",
-                max_on_initialize_weight
+            log::debug!(
+                "Clock::on_initialize process hooks with max_on_initialize_weight: {:?} and block number: {:?}",
+                max_on_initialize_weight,
+                n
             );
             T::OnInitializeQueues::process(n, max_on_initialize_weight)
         }

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -113,7 +113,7 @@ impl pallet_clock::Config for Runtime {
     type Executors = t3rn_primitives::executors::ExecutorsMock<Self>;
     type OnFinalizeQueues = pallet_clock::traits::EmptyOnHookQueues<Self>;
     type OnInitializeQueues = GlobalOnInitQueues;
-    type RoundDuration = ConstU32<500u32>;
+    type RoundDuration = ConstU32<500>;
 }
 
 impl pallet_xdns::Config for Runtime {


### PR DESCRIPTION
There was an issue regarding the way that we bump the round information coming from the clock.

In the check, we always passed the next round, so the bump_check was never being triggered.