### PR TITLE
build: runtime upgrade script checkes runtime versions correctly

### DIFF
--- a/scripts/upgrade-runtime-set-code.sh
+++ b/scripts/upgrade-runtime-set-code.sh
@@ -59,8 +59,9 @@ fi
 set -Ee
 
 echo "🐙 checking out $tag..."
-
 git checkout $tag &>/dev/null
+echo "✅ tag checked out"
+echo
 
 echo "🔎 making sure runtime version got updated..."
 
@@ -80,37 +81,39 @@ new_impl_version=$(cat $root_dir/runtime/${parachain_name}-parachain/src/lib.rs 
 new_tx_version=$(cat $root_dir/runtime/${parachain_name}-parachain/src/lib.rs | grep -o 'transaction_version: [0-9]*' | tail -1 | grep -o '[0-9]*')
 new_author_version=$(cat $root_dir/runtime/${parachain_name}-parachain/src/lib.rs | grep -o 'authoring_version: [0-9]*' | tail -1 | grep -o '[0-9]*')
 
-if [[ $new_spec_version != $((old_spec_version + 1)) ]]; then
-  echo "runtime spec version not incremented"
+if [[ $new_spec_version -le $old_spec_version ]]; then
+  echo "🔴 runtime spec version not incremented"
   exit 1
 fi
 
-if [[ $new_impl_version != $((old_impl_version + 1)) ]]; then
-  echo "runtime impl version not incremented"
+if [[ $new_impl_version -le $old_impl_version ]]; then
+  echo "🔴 runtime impl version not incremented"
   exit 1
 fi
 
-if [[ $new_tx_version != $((old_tx_version + 1)) ]]; then
-  echo "runtime transaction version not incremented"
+if [[ $new_tx_version -le $old_tx_version ]]; then
+  echo "🔴 runtime transaction version not incremented"
   exit 1
 fi
 
-if [[ $new_author_version != $((old_author_version + 1)) ]]; then
-  echo "runtime authoring version not incremented"
+if [[ $new_author_version -le $old_author_version ]]; then
+  echo "🔴 runtime authoring version not incremented"
   exit 1
 fi
+echo "✅ runtime versions updated"
 
-echo "🫧 Check WASM artifact..."
+echo
+echo "🫧 check WASM artifact..."
 wasm_hash_calculated=$(subwasm info --json $wasm_binary | jq -r .blake2_256)
 wasm_hash_fetched="$(cat ${wasm_binary}.blake2_256)"
-echo "🔢 calculated WASM blake2_256 hash is $wasm_hash_calculated"
-echo "🔢 fetched WASM blake2_256 hash from release is $wasm_hash_fetched"
+echo "🔢 WASM blake2_256 hash: $wasm_hash_calculated"
+echo "🔢 WASM blake2_256 hash fetched from release: $wasm_hash_fetched"
 
 if [[ "$wasm_hash_calculated" != "$wasm_hash_fetched" ]]; then
-  echo "🔴 WASM artifact blake2_256 hash is not matching"
+  echo "🔴 WASM blake2_256 hash is not matching"
   exit 1
 else
-  echo "✅ WASM artifact blake2_256 hash is matching"
+  echo "✅ WASM blake2_256 hash is matching"
 fi
 
 echo "⚙️ set_code runtime upgrade... $dryrun"
@@ -136,3 +139,4 @@ if [[ -z $dryrun ]]; then
     --params $wasm_binary \
     tx.system.setCode
 fi
+echo "✅ runtime upgrade executed... $dryrun"


### PR DESCRIPTION
# Summary of changes

This changes to runtime upgrade script allows for increments of runtime versions higher than 1.
Such situation can occur when release with cargo release is made but runtime upgrade is not run.

## Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue):
    - [ ] Have you **written tests **to protect against future occurrences of the bug?
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] Have you **seen it working** in a development environment?
    - [ ] Have you **written tests** for **happy** and **unhappy** paths?
    - [ ] Have you implemented this feature as per the **issue acceptance criteria**?
- [ ] Breaking change (a feature that would cause existing functionality not to work as expected
    - [ ] Is the breaking change **documented**?
    - [ ] Has any previous changes been **deprecated**?
- [ ] CI/CD
    - [ ] If introducing new actions, have you **looked at the action code** for anything spurious?
    - [ ] Have you written **custom scripts** for things that could be actions already on the marketplace?
    - [ ] If introducing new actions, have you **pegged a static version**?
- [ ] Documentation Update
    - [ ] Have you checked other documentation, such as the docs repository?
    - [ ] If updating script documentation, have you **tested it on both environments**?
- [ ] Substrate
    - [ ] RPC methods?
    - [ ] Chainspec, both JSON specs & the module?
    - [ ] Runtime versioning?
    - [ ] Benchmarks?
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (if applicable)
