### PR TITLE
build: install rust toolchain defined in rust-toolchain.toml config [skip release]

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -50,13 +50,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: ⚙️Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: 📜 Check code format
         uses: actions-rs/cargo@v1

--- a/.github/workflows/dependabot-update.yml
+++ b/.github/workflows/dependabot-update.yml
@@ -42,14 +42,9 @@ jobs:
             echo "DEPENDABOT=false" >> $GITHUB_ENV
           fi
 
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
+      - name: ⚙ Install rust toolchain defined in rust-toolchain.toml
         if: ${{ env.DEPENDABOT == 'true' }}
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+        run: rustup show
 
       - name: Update Cargo.lock
         if: ${{ env.DEPENDABOT == 'true' }}

--- a/.github/workflows/release-t0rn.yml
+++ b/.github/workflows/release-t0rn.yml
@@ -73,13 +73,8 @@ jobs:
           echo "WASM_BINARY=./target/release/wbuild/${{ env.PARACHAIN_NAME }}-parachain-runtime/${{ env.PARACHAIN_NAME }}_parachain_runtime.compact.compressed.wasm" >> $GITHUB_ENV
           echo "WASM_RELEASE_ASSET=${{ env.PARACHAIN_NAME }}-parachain-runtime-v${{ steps.version.outputs.version }}.compact.compressed.wasm" >> $GITHUB_ENV
 
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: 🏭 Build circuit
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release-t3rn.yml
+++ b/.github/workflows/release-t3rn.yml
@@ -22,13 +22,8 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: 🏭 Build circuit
         uses: actions-rs/cargo@v1

--- a/.github/workflows/runtime-upgrade-t0rn.yml
+++ b/.github/workflows/runtime-upgrade-t0rn.yml
@@ -20,13 +20,8 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: 📼 Run zombienet runtime upgrade test
         continue-on-error: false

--- a/.github/workflows/subalfred.yaml
+++ b/.github/workflows/subalfred.yaml
@@ -41,13 +41,8 @@ jobs:
       - name: ☁️ Checkout git repo
         uses: actions/checkout@v3
 
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: Install Subalfred
         run: |

--- a/.github/workflows/update-dev-docs.yml
+++ b/.github/workflows/update-dev-docs.yml
@@ -16,13 +16,8 @@ jobs:
       - name: ☁️Checkout git repo
         uses: actions/checkout@v3
         
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: Generate Rust Docs
         uses: actions-rs/cargo@v1

--- a/.github/workflows/zombienet-test.yml
+++ b/.github/workflows/zombienet-test.yml
@@ -46,13 +46,8 @@ jobs:
       - name: ☁️ Checkout git repo
         uses: actions/checkout@v3
 
-      - name: ⚙️ Get nightly rust toolchain with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-01-24
-          target: wasm32-unknown-unknown
-          components: rustfmt, clippy
-          override: true
+      - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
+        run: rustup show
 
       - name: Print sccache stats
         working-directory: tests/zombienet


### PR DESCRIPTION
# Summary of changes

[GHA actions-rs/toolchain doesn't support rust-toolchain.toml](https://github.com/actions-rs/toolchain/issues/126)
Instead we can use `rustup show`, which does install correct toolchain.

[Explanation why `rustup show` does install correct toolchain](https://github.com/rust-lang/rustup/issues/2070#issuecomment-545096849)

> Basically whenever rustup tries to find a toolchain it has implicitly been told should exist, it will force an installation if it cannot find it. Thus cargo build will automatically install a toolchain where needed, etc. rustup show happens to need to find the active toolchain in order to print out its version information, hence it ends up installing it. It is intended behaviour, yes.



# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [x] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)
