### PR TITLE
build: gha should checkout code before running paths-filter [skip-release]

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -25,6 +25,9 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
+      - name: ☁ Checkout git repo
+        uses: actions/checkout@v3
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "client/packages/executor/**/*.ts"
       - "client/packages/executor/**/*.json"
+      - ".github/workflows/executor.yml"
   push:
     branches:
       - development

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - run: |
           tee commitlint.config.js<<EOF
             module.exports = {

--- a/.github/workflows/runtime-upgrade-t0rn.yml
+++ b/.github/workflows/runtime-upgrade-t0rn.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_PAT }}
 
       - name: ⚙️ Install rust toolchain defined in rust-toolchain.toml
         run: rustup show

--- a/.github/workflows/subalfred.yml
+++ b/.github/workflows/subalfred.yml
@@ -16,6 +16,9 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
+      - name: ☁ Checkout git repo
+        uses: actions/checkout@v3
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/zombienet-test.yml
+++ b/.github/workflows/zombienet-test.yml
@@ -22,6 +22,9 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
+      - name: ☁ Checkout git repo
+        uses: actions/checkout@v3
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:


### PR DESCRIPTION
# Summary of changes

When github runner is fresh then circuit build or other action that uses paths-filter will fail due to not initilized git repo.
Additional remove of unnecesary use of GH_PAT and renaming subalfred action so we have consistent extension yml used.

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)
