### PR TITLE
fix: make extrinsics transactional

### DIFF
--- a/finality-verifiers/grandpa/src/lib.rs
+++ b/finality-verifiers/grandpa/src/lib.rs
@@ -44,7 +44,7 @@ use bp_runtime::{BlockNumberOf, Chain, ChainId, HashOf, HasherOf, HeaderOf};
 use sp_std::convert::TryInto;
 
 use finality_grandpa::voter_set::VoterSet;
-use frame_support::{ensure, pallet_prelude::*, StorageHasher};
+use frame_support::{ensure, pallet_prelude::*, transactional, StorageHasher};
 use frame_system::{ensure_signed, RawOrigin};
 
 use sp_core::crypto::ByteArray;
@@ -432,6 +432,7 @@ pub mod pallet {
 }
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+    #[transactional]
     pub(crate) fn verify_and_store_headers(
         // seq vector of headers to be added.
         range: Vec<BridgedHeader<T, I>>,
@@ -929,7 +930,7 @@ mod tests {
     };
 
     use codec::Encode;
-    use frame_support::{assert_err, assert_noop, assert_ok};
+    use frame_support::{assert_noop, assert_ok};
     use sp_finality_grandpa::AuthorityId;
     use sp_runtime::{Digest, DigestItem, DispatchError};
 
@@ -1089,7 +1090,7 @@ mod tests {
     fn cant_register_duplicate_gateway_ids() {
         run_test(|| {
             assert_ok!(initialize_relaychain(Origin::root()));
-            assert_err!(
+            assert_noop!(
                 initialize_relaychain(Origin::root()),
                 "chain_id already initialized"
             );
@@ -1124,7 +1125,7 @@ mod tests {
     #[test]
     fn cant_register_relaychain_as_non_root() {
         run_test(|| {
-            assert_err!(initialize_relaychain(Origin::signed(1)), "Bad origin");
+            assert_noop!(initialize_relaychain(Origin::signed(1)), "Bad origin");
         })
     }
 
@@ -1325,7 +1326,7 @@ mod tests {
                 justification,
             };
 
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 Error::<TestRuntime>::InvalidRangeLinkage
             );
@@ -1352,7 +1353,7 @@ mod tests {
                 justification,
             };
 
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 Error::<TestRuntime>::InvalidJustificationLinkage
             );
@@ -1382,7 +1383,7 @@ mod tests {
                 justification,
             };
 
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 Error::<TestRuntime>::InvalidGrandpaJustification
             );
@@ -1408,7 +1409,7 @@ mod tests {
                 justification,
             };
 
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 Error::<TestRuntime>::InvalidGrandpaJustification
             );
@@ -1448,7 +1449,7 @@ mod tests {
                 justification,
             };
 
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 Error::<TestRuntime>::InvalidGrandpaJustification
             );
@@ -1537,7 +1538,7 @@ mod tests {
             };
 
             // Should not be allowed to import this header
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 <Error<TestRuntime>>::UnsupportedScheduledChange
             );
@@ -1567,7 +1568,7 @@ mod tests {
             };
 
             // Should not be allowed to import this header
-            assert_err!(
+            assert_noop!(
                 Pallet::<TestRuntime>::submit_encoded_headers(data.encode()),
                 <Error<TestRuntime>>::UnsupportedScheduledChange
             );

--- a/pallets/portal/src/lib.rs
+++ b/pallets/portal/src/lib.rs
@@ -23,6 +23,7 @@ pub mod weights;
 pub trait SelectLightClient<T: frame_system::Config> {
     fn select(vendor: GatewayVendor) -> Result<Box<dyn LightClient<T>>, Error<T>>;
 }
+use frame_support::transactional;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -99,6 +100,7 @@ pub mod pallet {
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        #[transactional]
         pub fn register_gateway(
             origin: OriginFor<T>,
             gateway_id: [u8; 4],


### PR DESCRIPTION
# Summary of changes
By default, extrinsics are not transactional, meaning state writes that occur before an error are not reverted. This introduced some hidden bugs in grandpa FV and portal. To ensure this doesn't happen in the future, we should always test errors with ´assert_noop!´ instead of `assert_err!`.

- updated tests in grandpa to use `assert_noop`
- fixed failing test by making extrinsic transactional
- make register gateway in portal transactional

If it fixes a bug or creates a feature, link the issue.

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [x] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [x] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [x] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [x] Storage Migration?
- [x] RPC methods?
- [x] Chainspec, both JSON specs & the module?
- [x] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)
