### PR TITLE
feat: move portal precompiles to 3vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6489,6 +6489,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "t3rn-abi",
  "t3rn-primitives",
  "t3rn-sdk-primitives",
 ]
@@ -9681,7 +9682,6 @@ dependencies = [
  "parity-scale-codec",
  "rlp",
  "sp-std",
- "t3rn-abi",
  "t3rn-mini-mock-runtime",
  "t3rn-primitives",
 ]
@@ -9698,6 +9698,7 @@ version = "1.0.0"
 dependencies = [
  "fp-evm 3.0.0-dev",
  "frame-system",
+ "pallet-evm 0.1.0",
  "pallet-evm-precompile-3vm-dispatch",
  "pallet-evm-precompile-blake2",
  "pallet-evm-precompile-bn128",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6484,6 +6484,7 @@ dependencies = [
  "pallet-xbi-portal",
  "pallet-xdns",
  "parity-scale-codec",
+ "rlp",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/pallets/3vm/Cargo.toml
+++ b/pallets/3vm/Cargo.toml
@@ -73,4 +73,4 @@ std = [
 ]
 
 runtime-benchmarks = [ "frame-benchmarking/runtime-benchmarks", "frame-support/runtime-benchmarks", "frame-system/runtime-benchmarks", "sp-runtime/runtime-benchmarks" ]
-try-runtime        = [ "frame-support/try-runtime", "frame-system/try-runtime" ]
+try-runtime        = [ "frame-support/try-runtime", "frame-system/try-runtime", "t3rn-abi/try-runtime" ]

--- a/pallets/3vm/Cargo.toml
+++ b/pallets/3vm/Cargo.toml
@@ -35,6 +35,7 @@ t3rn-sdk-primitives = { version = "=0.1.1-rc.4", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.0"
+rlp = "*"
 
 # t3rn dependencies
 circuit-runtime-types            = { path = "../../runtime/common-types" }

--- a/pallets/3vm/Cargo.toml
+++ b/pallets/3vm/Cargo.toml
@@ -29,6 +29,7 @@ sp-runtime = { default-features = false, version = "6.0.0", git = "https://githu
 sp-std     = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.27" }
 
 # t3rn dependencies
+t3rn-abi            = { default-features = false, path = "../../types/abi", feature = "runtime" }
 t3rn-primitives     = { default-features = false, path = "../../primitives" }
 t3rn-sdk-primitives = { version = "=0.1.1-rc.4", default-features = false }
 
@@ -67,6 +68,7 @@ std = [
   "sp-io/std",
   "sp-runtime/std",
   "t3rn-primitives/std",
+  "t3rn-abi/std",
   "t3rn-sdk-primitives/std",
 ]
 

--- a/pallets/3vm/src/lib.rs
+++ b/pallets/3vm/src/lib.rs
@@ -46,7 +46,7 @@ pub mod pallet {
     use frame_support::{pallet_prelude::*, traits::Currency};
     use t3rn_primitives::{
         account_manager::AccountManager, circuit::OnLocalTrigger, contract_metadata::ContractType,
-        contracts_registry::ContractsRegistry, ChainId,
+        contracts_registry::ContractsRegistry, portal::Portal, ChainId,
     };
     use t3rn_sdk_primitives::signal::SignalKind;
 
@@ -84,6 +84,9 @@ pub mod pallet {
 
         /// A provider that will give us access to on_local_trigger
         type OnLocalTrigger: OnLocalTrigger<Self, BalanceOf<Self>>;
+
+        /// Inject access to portal so contracts can use light clients
+        type Portal: Portal<Self>;
     }
 
     #[pallet::pallet]

--- a/pallets/3vm/src/lib.rs
+++ b/pallets/3vm/src/lib.rs
@@ -171,6 +171,7 @@ pub mod pallet {
         InvalidPrecompileArgs,
         /// Invalid arithmetic computation causes overflow
         InvalidArithmeticOverflow,
+        DownstreamCircuit,
     }
 
     #[pallet::call]

--- a/pallets/3vm/src/lib.rs
+++ b/pallets/3vm/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(associated_type_defaults)]
+#![feature(slice_take)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/pallets/3vm/src/mock.rs
+++ b/pallets/3vm/src/mock.rs
@@ -47,12 +47,12 @@ frame_support::construct_runtime!(
         ContractsRegistry: pallet_contracts_registry::{Pallet, Call, Storage, Config<T>, Event<T>},
         Sudo: pallet_sudo,
         Circuit: pallet_circuit::{Pallet, Call, Storage, Event<T>},
-        CircuitPortal: pallet_portal,
+        Portal: pallet_portal,
         Xdns: pallet_xdns,
         AccountManager: pallet_account_manager,
-        RococoBridge: pallet_grandpa_finality_verifier = 129,
-        PolkadotBridge: pallet_grandpa_finality_verifier::<Instance1> = 130,
-        KusamaBridge: pallet_grandpa_finality_verifier::<Instance2> = 131,
+        RococoBridge: pallet_grandpa_finality_verifier,
+        PolkadotBridge: pallet_grandpa_finality_verifier::<Instance1>,
+        KusamaBridge: pallet_grandpa_finality_verifier::<Instance2>,
     }
 );
 
@@ -161,6 +161,7 @@ impl pallet_3vm::Config for Test {
     type EscrowAccount = EscrowAccount;
     type Event = Event;
     type OnLocalTrigger = Circuit;
+    type Portal = Portal;
     type SignalBounceThreshold = ConstU32<2>;
 }
 
@@ -196,7 +197,7 @@ impl pallet_circuit::Config for Test {
     type DeletionQueueLimit = ConstU32<1024>;
     type Event = Event;
     type Executors = t3rn_primitives::executors::ExecutorsMock<Self>;
-    type Portal = CircuitPortal;
+    type Portal = Portal;
     type SFXBiddingPeriod = ConstU32<3>;
     type SelfAccountId = CircuitAccountId;
     type SelfGatewayId = CircuitTargetId;

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -6,7 +6,10 @@ use t3rn_abi::{Codec as T3rnCodec, FilledAbi};
 use t3rn_primitives::{
     circuit::{LocalTrigger, OnLocalTrigger},
     portal::{get_portal_interface_abi, Portal, PortalExecution, PortalPrecompileInterfaceEnum},
-    threevm::{GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation},
+    threevm::{
+        GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation,
+        EVM_RECODING_BYTE_SELECTOR, WASM_RECODING_BYTE_SELECTOR,
+    },
 };
 use t3rn_sdk_primitives::{
     signal::{ExecutionSignal, Signaller},
@@ -29,12 +32,31 @@ pub(crate) fn lookup<T: Config>(dest: &T::Hash) -> Option<u8> {
 }
 
 // FIXME: figure out charging, costing
-// TODO: determine recoding, can we always assume here that invoke_raw is invoked by EVM? if so we prefix the byte and recode everything
 pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &mut Vec<u8>) {
+    // TODO: assert the length here
+
+    // First byte determines if it came from EVM or WASM
+    let codec_selector = args[1];
+
+    // Strip the selector
+    let args = &mut &args[1..];
+
+    let codec = if codec_selector == EVM_RECODING_BYTE_SELECTOR {
+        T3rnCodec::Rlp
+    } else {
+        T3rnCodec::default()
+    };
+
+    // TODO: Is origin provided first or at all? if so that also needs recoding
     match extract_origin::<T>(args) {
         Some(origin) => match *precompile {
             GET_STATE => {
-                let args: CodecResult<GetState<T>> = Decode::decode(args);
+                let args: CodecResult<GetState<T>> = match codec {
+                    T3rnCodec::Scale => Decode::decode(args),
+                    T3rnCodec::Rlp =>
+                        Err(codec::Error::from("Cannot decode GetState with RLP yet")),
+                };
+
                 if let Ok(args) = args {
                     if let Ok(PrecompileInvocation::GetState(state)) =
                         invoke::<T>(PrecompileArgs::GetState(origin, args))
@@ -47,7 +69,11 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
             },
             SUBMIT => {
                 let args: CodecResult<SideEffects<T::AccountId, BalanceOf<T>, T::Hash>> =
-                    Decode::decode(args);
+                    match codec {
+                        T3rnCodec::Scale => Decode::decode(args),
+                        T3rnCodec::Rlp =>
+                            Err(codec::Error::from("Cannot decode SideEffects with RLP yet")),
+                    };
                 if let Ok(args) = args {
                     match invoke::<T>(PrecompileArgs::SubmitSideEffects(origin, args)) {
                         Ok(_) => {
@@ -61,7 +87,10 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                 }
             },
             POST_SIGNAL => {
-                let args: CodecResult<ExecutionSignal<T::Hash>> = Decode::decode(args);
+                let args: CodecResult<ExecutionSignal<T::Hash>> = match codec {
+                    T3rnCodec::Scale => Decode::decode(args),
+                    T3rnCodec::Rlp => Err(codec::Error::from("Cannot decode Signals with RLP yet")),
+                };
 
                 if let Ok(args) = args {
                     match invoke::<T>(PrecompileArgs::Signal(origin, args)) {
@@ -76,38 +105,31 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                 }
             },
             PORTAL => {
-                // TODO: use bytesmut and advance these
+                // First byte is portal selector
+                let portal_selector = &args[0];
+                // The rest is the input for portal
+                let input_without_vm_selectors = &args[1..];
 
-                let input = &args[..];
-                // FIXME: Panic here, dont
-                assert!(input.len() > 3, "Not enough data to determine selectors");
-
-                // First byte determines the selector here
-                // TODO: handle if this is coming from an evm contract or from wasm
-                // Second byte determines if it came from EVM or WASM
-                let input_without_vm_selectors = &input[2..];
-                // Third byte is portal
-                let portal_selector = input_without_vm_selectors.first();
-
-                let mut result = FilledAbi::try_fill_abi(
-                    get_portal_interface_abi(),
-                    // Strip the portal prefix
-                    input_without_vm_selectors[1..].to_vec(),
-                    T3rnCodec::Rlp,
-                )
-                // TODO Here determine if we should recode as RLP or not, depending on VM selector
-                .and_then(|abi| abi.recode_as(&T3rnCodec::Rlp, &T3rnCodec::Scale))
-                .and_then(|mut recoded| {
-                    portal_selector
-                        .map(|x| {
-                            recoded.insert(0, *x);
-                            recoded
+                let mut result = match codec {
+                    T3rnCodec::Rlp => {
+                        FilledAbi::try_fill_abi(
+                            get_portal_interface_abi(), // This panics :<
+                            input_without_vm_selectors.to_vec(),
+                            codec.clone(),
+                        )
+                        .and_then(|abi| {
+                            abi.recode_as(&codec.clone(), &T3rnCodec::Scale)
                         })
-                        .ok_or_else(|| DispatchError::Other("There was no portal selector byte"))
+                    }
+                    T3rnCodec::Scale => Ok(input_without_vm_selectors.to_vec())
+                }
+                .map(|mut recoded| {
+                    recoded.insert(0, *portal_selector);
+                    recoded
                 })
                 .and_then(|recoded| {
                     PortalPrecompileInterfaceEnum::decode(&mut &recoded[..])
-                        .map_err(|e| DispatchError::Other("Failed to decode portal interface enum"))
+                        .map_err(|_e| DispatchError::Other("Failed to decode portal interface enum"))
                 })
                 .and_then(|recoded_call_as_enum| {
                     invoke::<T>(PrecompileArgs::Portal(recoded_call_as_enum)).map(|x| if let PrecompileInvocation::Portal(i) = x {

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -2,10 +2,10 @@ use crate::{BalanceOf, Config, Error, Pallet, PrecompileIndex};
 use codec::{Decode, Encode};
 use frame_support::{dispatch::RawOrigin, sp_runtime::DispatchError};
 use sp_std::{vec, vec::Vec};
-use t3rn_abi::{Codec as T3rnCodec, FilledAbi};
+use t3rn_abi::Codec as T3rnCodec;
 use t3rn_primitives::{
     circuit::{LocalTrigger, OnLocalTrigger},
-    portal::{get_portal_interface_abi, Portal, PortalExecution, PortalPrecompileInterfaceEnum},
+    portal::{Portal, PortalExecution, PrecompileArgs as PortalPrecompileArgs},
     threevm::{
         GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation,
         EVM_RECODING_BYTE_SELECTOR, GET_STATE, PORTAL, POST_SIGNAL, SUBMIT,
@@ -99,39 +99,7 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                 }
             },
             PORTAL => {
-                if args.len() < 2 {
-                    return Err::<(), _>(Error::<T>::InvalidPrecompileArgs).encode_to(output)
-                }
-
-                // First byte is portal selector
-                let portal_selector = &args[0];
-                // The rest is the input for portal
-                let input_without_portal_selector = &args[1..];
-
-                let mut result = match codec {
-                    T3rnCodec::Rlp => {
-                        log::debug!(target: LOG_TARGET, "Rlp encoding bytes for portal selector {}", portal_selector);
-                        log::debug!(target: LOG_TARGET, "Bytes {:?}", input_without_portal_selector);
-                        FilledAbi::try_fill_abi(
-                            get_portal_interface_abi(), // This panics :<
-                            input_without_portal_selector.to_vec(),
-                            codec.clone(),
-                        )
-                        .and_then(|abi| {
-                            log::debug!(target: LOG_TARGET, "ABI was filled, recoding to scale {}", portal_selector);
-                            abi.recode_as(&codec.clone(), &T3rnCodec::Scale)
-                        })
-                    }
-                    T3rnCodec::Scale => Ok(input_without_portal_selector.to_vec())
-                }
-                .map(|mut recoded| {
-                    recoded.insert(0, *portal_selector);
-                    recoded
-                })
-                .and_then(|recoded| {
-                    PortalPrecompileInterfaceEnum::decode(&mut &recoded[..])
-                        .map_err(|_e| DispatchError::Other("Failed to decode portal interface enum"))
-                })
+                let mut result = PortalPrecompileArgs::recode_to_scale_and_decode(&codec, args)
                 .and_then(|recoded_call_as_enum| {
                     log::debug!(target: LOG_TARGET, "Built recoded call {:?}", recoded_call_as_enum);
                     invoke::<T>(PrecompileArgs::Portal(recoded_call_as_enum)).map(|x| if let PrecompileInvocation::Portal(i) = x {
@@ -256,34 +224,34 @@ pub(crate) fn invoke<T: Config>(
             }
         },
         PrecompileArgs::Portal(args) => match args {
-            PortalPrecompileInterfaceEnum::GetLatestFinalizedHeader(chain_id) =>
+            PortalPrecompileArgs::GetLatestFinalizedHeader(chain_id) =>
                 T::Portal::get_latest_finalized_header(chain_id)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
-            PortalPrecompileInterfaceEnum::GetLatestFinalizedHeight(chain_id) =>
+            PortalPrecompileArgs::GetLatestFinalizedHeight(chain_id) =>
                 T::Portal::get_latest_finalized_height(chain_id)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
-            PortalPrecompileInterfaceEnum::GetLatestUpdatedHeight(chain_id) =>
+            PortalPrecompileArgs::GetLatestUpdatedHeight(chain_id) =>
                 T::Portal::get_latest_updated_height(chain_id)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
-            PortalPrecompileInterfaceEnum::GetCurrentEpoch(chain_id) =>
+            PortalPrecompileArgs::GetCurrentEpoch(chain_id) =>
                 T::Portal::get_current_epoch(chain_id)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
-            PortalPrecompileInterfaceEnum::ReadEpochOffset(chain_id) =>
+            PortalPrecompileArgs::ReadEpochOffset(chain_id) =>
                 T::Portal::read_epoch_offset(chain_id)
                     .map(|x| PrecompileInvocation::Portal(PortalExecution::BlockNumber(x))),
-            PortalPrecompileInterfaceEnum::ReadFastConfirmationOffset(chain_id) =>
+            PortalPrecompileArgs::ReadFastConfirmationOffset(chain_id) =>
                 T::Portal::read_fast_confirmation_offset(chain_id)
                     .map(|x| PrecompileInvocation::Portal(PortalExecution::BlockNumber(x))),
-            PortalPrecompileInterfaceEnum::ReadRationalConfirmationOffset(chain_id) =>
+            PortalPrecompileArgs::ReadRationalConfirmationOffset(chain_id) =>
                 T::Portal::read_rational_confirmation_offset(chain_id)
                     .map(|x| PrecompileInvocation::Portal(PortalExecution::BlockNumber(x))),
-            PortalPrecompileInterfaceEnum::VerifyEventInclusion(chain_id, event) =>
+            PortalPrecompileArgs::VerifyEventInclusion(chain_id, event) =>
                 T::Portal::verify_event_inclusion(chain_id, event, None)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
-            PortalPrecompileInterfaceEnum::VerifyStateInclusion(chain_id, event) =>
+            PortalPrecompileArgs::VerifyStateInclusion(chain_id, event) =>
                 T::Portal::verify_state_inclusion(chain_id, event, None)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
-            PortalPrecompileInterfaceEnum::VerifyTxInclusion(chain_id, event) =>
+            PortalPrecompileArgs::VerifyTxInclusion(chain_id, event) =>
                 T::Portal::verify_tx_inclusion(chain_id, event, None)
                     .map(|x| PrecompileInvocation::Portal(x.into())),
         },
@@ -378,110 +346,4 @@ mod tests {
             );
         });
     }
-
-    // #[test]
-    // fn test_get_latest_finalized_header_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = GetLatestFinalizedHeader(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, GetLatestFinalizedHeader(chain_id));
-    // }
-
-    // #[test]
-    // fn test_get_latest_finalized_height_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = GetLatestFinalizedHeight(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, GetLatestFinalizedHeight(chain_id));
-    // }
-
-    // #[test]
-    // fn test_get_latest_updated_height_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = GetLatestUpdatedHeight(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, GetLatestUpdatedHeight(chain_id));
-    // }
-
-    // #[test]
-    // fn test_get_current_epoch_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = GetCurrentEpoch(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, GetCurrentEpoch(chain_id));
-    // }
-
-    // #[test]
-    // fn test_read_epoch_offset_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = ReadEpochOffset(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, ReadEpochOffset(chain_id));
-    // }
-
-    // #[test]
-    // fn test_read_fast_confirmation_offset_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = ReadFastConfirmationOffset(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, ReadFastConfirmationOffset(chain_id));
-    // }
-
-    // #[test]
-    // fn test_read_rational_confirmation_offset_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let portal_call = ReadRationalConfirmationOffset(chain_id);
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(
-    //         recoded_portal_call,
-    //         ReadRationalConfirmationOffset(chain_id)
-    //     );
-    // }
-
-    // #[test]
-    // fn test_verify_event_inclusion_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let event = vec![1, 2, 3, 4];
-    //     let portal_call = VerifyEventInclusion(chain_id, event.clone());
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, VerifyEventInclusion(chain_id, event));
-    // }
-
-    // #[test]
-    // fn test_verify_state_inclusion_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let event = vec![1, 2, 3, 4];
-    //     let portal_call = VerifyStateInclusion(chain_id, event.clone());
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, VerifyStateInclusion(chain_id, event));
-    // }
-
-    // #[test]
-    // fn test_verify_tx_inclusion_recodes_correctly_to_scale() {
-    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
-    //     let event = vec![1, 2, 3, 4];
-    //     let portal_call = VerifyTxInclusion(chain_id, event.clone());
-    //     let encoded_portal_call = portal_call.encode();
-    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
-
-    //     assert_eq!(recoded_portal_call, VerifyTxInclusion(chain_id, event));
-    // }
 }

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -1,9 +1,11 @@
 use crate::{BalanceOf, Config, Error, Pallet, PrecompileIndex};
 use codec::{Decode, Encode};
 use frame_support::{dispatch::RawOrigin, sp_runtime::DispatchError};
-use sp_std::vec::Vec;
+use sp_std::{vec, vec::Vec};
+use t3rn_abi::{Codec as T3rnCodec, FilledAbi};
 use t3rn_primitives::{
     circuit::{LocalTrigger, OnLocalTrigger},
+    portal::{get_portal_interface_abi, Portal, PortalExecution, PortalPrecompileInterfaceEnum},
     threevm::{GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation},
 };
 use t3rn_sdk_primitives::{
@@ -18,6 +20,7 @@ const LOG_TARGET: &str = "3vm::precompile";
 pub const GET_STATE: u8 = 55;
 pub const SUBMIT: u8 = 56;
 pub const POST_SIGNAL: u8 = 57;
+pub const PORTAL: u8 = 70;
 
 type CodecResult<T> = Result<T, codec::Error>;
 
@@ -25,7 +28,8 @@ pub(crate) fn lookup<T: Config>(dest: &T::Hash) -> Option<u8> {
     PrecompileIndex::<T>::get(dest)
 }
 
-// fixme: figure out charging, costing
+// FIXME: figure out charging, costing
+// TODO: determine recoding, can we always assume here that invoke_raw is invoked by EVM? if so we prefix the byte and recode everything
 pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &mut Vec<u8>) {
     match extract_origin::<T>(args) {
         Some(origin) => match *precompile {
@@ -69,6 +73,59 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                     }
                 } else {
                     Err::<(), _>(Error::<T>::InvalidPrecompileArgs).encode_to(output)
+                }
+            },
+            PORTAL => {
+                // TODO: use bytesmut and advance these
+
+                let input = &args[..];
+                // FIXME: Panic here, dont
+                assert!(input.len() > 3, "Not enough data to determine selectors");
+
+                // First byte determines the selector here
+                // TODO: handle if this is coming from an evm contract or from wasm
+                // Second byte determines if it came from EVM or WASM
+                let input_without_vm_selectors = &input[2..];
+                // Third byte is portal
+                let portal_selector = input_without_vm_selectors.first();
+
+                let mut result = FilledAbi::try_fill_abi(
+                    get_portal_interface_abi(),
+                    // Strip the portal prefix
+                    input_without_vm_selectors[1..].to_vec(),
+                    T3rnCodec::Rlp,
+                )
+                // TODO Here determine if we should recode as RLP or not, depending on VM selector
+                .and_then(|abi| abi.recode_as(&T3rnCodec::Rlp, &T3rnCodec::Scale))
+                .and_then(|mut recoded| {
+                    portal_selector
+                        .map(|x| {
+                            recoded.insert(0, *x);
+                            recoded
+                        })
+                        .ok_or_else(|| DispatchError::Other("There was no portal selector byte"))
+                })
+                .and_then(|recoded| {
+                    PortalPrecompileInterfaceEnum::decode(&mut &recoded[..])
+                        .map_err(|e| DispatchError::Other("Failed to decode portal interface enum"))
+                })
+                .and_then(|recoded_call_as_enum| {
+                    invoke::<T>(PrecompileArgs::Portal(recoded_call_as_enum)).map(|x| if let PrecompileInvocation::Portal(i) = x {
+                        let bytes: Vec<u8> = i.into();
+                        bytes
+                    } else {
+                        log::warn!("Exceptional issue, portal precompile invocation returned something other than a portal result");
+                        Default::default()
+                    })
+                })
+                .map_err(|e| match e {
+                    DispatchError::Other(msg) => msg,
+                    _ => "Failed to invoke portal",
+                });
+
+                match result {
+                    Ok(ref mut bytes) => output.append(bytes),
+                    Err(msg) => output.append(msg.as_bytes().to_vec().as_mut()),
                 }
             },
             _ => Err::<(), _>(Error::<T>::InvalidPrecompilePointer).encode_to(output),
@@ -150,6 +207,38 @@ pub(crate) fn invoke<T: Config>(
                     Err(e)
                 },
             }
+        },
+        PrecompileArgs::Portal(args) => match args {
+            PortalPrecompileInterfaceEnum::GetLatestFinalizedHeader(chain_id) =>
+                T::Portal::get_latest_finalized_header(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
+            PortalPrecompileInterfaceEnum::GetLatestFinalizedHeight(chain_id) =>
+                T::Portal::get_latest_finalized_height(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
+            PortalPrecompileInterfaceEnum::GetLatestUpdatedHeight(chain_id) =>
+                T::Portal::get_latest_updated_height(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
+            PortalPrecompileInterfaceEnum::GetCurrentEpoch(chain_id) =>
+                T::Portal::get_current_epoch(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
+            PortalPrecompileInterfaceEnum::ReadEpochOffset(chain_id) =>
+                T::Portal::read_epoch_offset(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(PortalExecution::BlockNumber(x))),
+            PortalPrecompileInterfaceEnum::ReadFastConfirmationOffset(chain_id) =>
+                T::Portal::read_fast_confirmation_offset(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(PortalExecution::BlockNumber(x))),
+            PortalPrecompileInterfaceEnum::ReadRationalConfirmationOffset(chain_id) =>
+                T::Portal::read_rational_confirmation_offset(chain_id)
+                    .map(|x| PrecompileInvocation::Portal(PortalExecution::BlockNumber(x))),
+            PortalPrecompileInterfaceEnum::VerifyEventInclusion(chain_id, event) =>
+                T::Portal::verify_event_inclusion(chain_id, event, None)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
+            PortalPrecompileInterfaceEnum::VerifyStateInclusion(chain_id, event) =>
+                T::Portal::verify_state_inclusion(chain_id, event, None)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
+            PortalPrecompileInterfaceEnum::VerifyTxInclusion(chain_id, event) =>
+                T::Portal::verify_tx_inclusion(chain_id, event, None)
+                    .map(|x| PrecompileInvocation::Portal(x.into())),
         },
     }
 }
@@ -242,4 +331,110 @@ mod tests {
             );
         });
     }
+
+    // #[test]
+    // fn test_get_latest_finalized_header_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = GetLatestFinalizedHeader(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, GetLatestFinalizedHeader(chain_id));
+    // }
+
+    // #[test]
+    // fn test_get_latest_finalized_height_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = GetLatestFinalizedHeight(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, GetLatestFinalizedHeight(chain_id));
+    // }
+
+    // #[test]
+    // fn test_get_latest_updated_height_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = GetLatestUpdatedHeight(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, GetLatestUpdatedHeight(chain_id));
+    // }
+
+    // #[test]
+    // fn test_get_current_epoch_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = GetCurrentEpoch(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, GetCurrentEpoch(chain_id));
+    // }
+
+    // #[test]
+    // fn test_read_epoch_offset_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = ReadEpochOffset(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, ReadEpochOffset(chain_id));
+    // }
+
+    // #[test]
+    // fn test_read_fast_confirmation_offset_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = ReadFastConfirmationOffset(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, ReadFastConfirmationOffset(chain_id));
+    // }
+
+    // #[test]
+    // fn test_read_rational_confirmation_offset_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let portal_call = ReadRationalConfirmationOffset(chain_id);
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(
+    //         recoded_portal_call,
+    //         ReadRationalConfirmationOffset(chain_id)
+    //     );
+    // }
+
+    // #[test]
+    // fn test_verify_event_inclusion_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let event = vec![1, 2, 3, 4];
+    //     let portal_call = VerifyEventInclusion(chain_id, event.clone());
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, VerifyEventInclusion(chain_id, event));
+    // }
+
+    // #[test]
+    // fn test_verify_state_inclusion_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let event = vec![1, 2, 3, 4];
+    //     let portal_call = VerifyStateInclusion(chain_id, event.clone());
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, VerifyStateInclusion(chain_id, event));
+    // }
+
+    // #[test]
+    // fn test_verify_tx_inclusion_recodes_correctly_to_scale() {
+    //     let chain_id: [u8; 4] = [9, 9, 9, 9];
+    //     let event = vec![1, 2, 3, 4];
+    //     let portal_call = VerifyTxInclusion(chain_id, event.clone());
+    //     let encoded_portal_call = portal_call.encode();
+    //     let recoded_portal_call = recode_input_as_portal_api_enum(&encoded_portal_call).unwrap();
+
+    //     assert_eq!(recoded_portal_call, VerifyTxInclusion(chain_id, event));
+    // }
 }

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -36,7 +36,7 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
     // TODO: assert the length here
 
     // First byte determines if it came from EVM or WASM
-    let codec_selector = args[1];
+    let codec_selector = args[0];
 
     // Strip the selector
     let args = &mut &args[1..];
@@ -48,7 +48,7 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
     };
 
     // TODO: Is origin provided first or at all? if so that also needs recoding
-    match extract_origin::<T>(args) {
+    match extract_origin::<T>(&codec, args) {
         Some(origin) => match *precompile {
             GET_STATE => {
                 let args: CodecResult<GetState<T>> = match codec {
@@ -108,20 +108,23 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                 // First byte is portal selector
                 let portal_selector = &args[0];
                 // The rest is the input for portal
-                let input_without_vm_selectors = &args[1..];
+                let input_without_portal_selector = &args[1..];
 
                 let mut result = match codec {
                     T3rnCodec::Rlp => {
+                        log::debug!(target: LOG_TARGET, "Rlp encoding bytes for portal selector {}", portal_selector);
+                        log::debug!(target: LOG_TARGET, "Bytes {:?}", input_without_portal_selector);
                         FilledAbi::try_fill_abi(
                             get_portal_interface_abi(), // This panics :<
-                            input_without_vm_selectors.to_vec(),
+                            input_without_portal_selector.to_vec(),
                             codec.clone(),
                         )
                         .and_then(|abi| {
+                            log::debug!(target: LOG_TARGET, "ABI was filled, recoding to scale {}", portal_selector);
                             abi.recode_as(&codec.clone(), &T3rnCodec::Scale)
                         })
                     }
-                    T3rnCodec::Scale => Ok(input_without_vm_selectors.to_vec())
+                    T3rnCodec::Scale => Ok(input_without_portal_selector.to_vec())
                 }
                 .map(|mut recoded| {
                     recoded.insert(0, *portal_selector);
@@ -132,11 +135,12 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                         .map_err(|_e| DispatchError::Other("Failed to decode portal interface enum"))
                 })
                 .and_then(|recoded_call_as_enum| {
+                    log::debug!(target: LOG_TARGET, "Built recoded call {:?}", recoded_call_as_enum);
                     invoke::<T>(PrecompileArgs::Portal(recoded_call_as_enum)).map(|x| if let PrecompileInvocation::Portal(i) = x {
                         let bytes: Vec<u8> = i.into();
                         bytes
                     } else {
-                        log::warn!("Exceptional issue, portal precompile invocation returned something other than a portal result");
+                        log::warn!(target: LOG_TARGET, "Exceptional issue, portal precompile invocation returned something other than a portal result");
                         Default::default()
                     })
                 })
@@ -145,9 +149,18 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                     _ => "Failed to invoke portal",
                 });
 
+                log::debug!(target: LOG_TARGET, "Result {:?}", result);
+
                 match result {
-                    Ok(ref mut bytes) => output.append(bytes),
-                    Err(msg) => output.append(msg.as_bytes().to_vec().as_mut()),
+                    Ok(ref mut bytes) => {
+                        output.push(0); // It's an ok
+                        output.append(bytes);
+                    },
+                    Err(msg) => {
+                        log::error!(target: LOG_TARGET, "Failed to invoke portal: {}", msg);
+                        output.push(1); // It's an error
+                        output.append(msg.as_bytes().to_vec().as_mut())
+                    },
                 }
             },
             _ => Err::<(), _>(Error::<T>::InvalidPrecompilePointer).encode_to(output),
@@ -156,12 +169,26 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
     }
 }
 
-fn extract_origin<T: frame_system::Config>(args: &mut &[u8]) -> Option<T::Origin> {
-    match <T::AccountId as Decode>::decode(args) {
-        Ok(account) => Some(T::Origin::from(RawOrigin::Signed(account))),
-        Err(err) => {
-            log::debug!(target: LOG_TARGET, "Failed to decode origin: {:?}", err);
-            None
+fn extract_origin<T: Config>(codec: &T3rnCodec, args: &mut &[u8]) -> Option<T::Origin> {
+    match codec {
+        T3rnCodec::Scale => match <T::AccountId as Decode>::decode(args) {
+            Ok(account) => Some(T::Origin::from(RawOrigin::Signed(account))),
+            Err(err) => {
+                log::debug!(target: LOG_TARGET, "Failed to decode origin: {:?}", err);
+                None
+            },
+        },
+        T3rnCodec::Rlp => {
+            // TODO: inject addressmapping here, dont always assume padded 12
+            let address_bytes = vec![args.take(..20)?, &[0_u8; 12][..]].concat();
+
+            match <T::AccountId as Decode>::decode(&mut &address_bytes[..]) {
+                Ok(account) => Some(T::Origin::from(RawOrigin::Signed(account))),
+                Err(err) => {
+                    log::debug!(target: LOG_TARGET, "Failed to decode origin: {:?}", err);
+                    None
+                },
+            }
         },
     }
 }
@@ -278,7 +305,7 @@ mod tests {
         new_test_ext().execute_with(|| {
             let account = 4_u64;
             let buffer = &mut &account.encode()[..];
-            let _result = extract_origin::<Test>(buffer).unwrap();
+            let _result = extract_origin::<Test>(&T3rnCodec::Scale, buffer).unwrap();
             assert_eq!(buffer.len(), 0)
         });
     }

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -8,7 +8,7 @@ use t3rn_primitives::{
     portal::{get_portal_interface_abi, Portal, PortalExecution, PortalPrecompileInterfaceEnum},
     threevm::{
         GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation,
-        EVM_RECODING_BYTE_SELECTOR, WASM_RECODING_BYTE_SELECTOR,
+        EVM_RECODING_BYTE_SELECTOR, GET_STATE, PORTAL, POST_SIGNAL, SUBMIT,
     },
 };
 use t3rn_sdk_primitives::{
@@ -18,13 +18,6 @@ use t3rn_sdk_primitives::{
 
 const LOG_TARGET: &str = "3vm::precompile";
 
-// Precompile pointers baked into the binary.
-// Genesis exists only to map hashes to pointers.
-pub const GET_STATE: u8 = 55;
-pub const SUBMIT: u8 = 56;
-pub const POST_SIGNAL: u8 = 57;
-pub const PORTAL: u8 = 70;
-
 type CodecResult<T> = Result<T, codec::Error>;
 
 pub(crate) fn lookup<T: Config>(dest: &T::Hash) -> Option<u8> {
@@ -33,7 +26,9 @@ pub(crate) fn lookup<T: Config>(dest: &T::Hash) -> Option<u8> {
 
 // FIXME: figure out charging, costing
 pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &mut Vec<u8>) {
-    // TODO: assert the length here
+    if args.len() < 2 {
+        return Err::<(), _>(Error::<T>::InvalidPrecompileArgs).encode_to(output)
+    }
 
     // First byte determines if it came from EVM or WASM
     let codec_selector = args[0];
@@ -47,7 +42,6 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
         T3rnCodec::default()
     };
 
-    // TODO: Is origin provided first or at all? if so that also needs recoding
     match extract_origin::<T>(&codec, args) {
         Some(origin) => match *precompile {
             GET_STATE => {
@@ -105,6 +99,10 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                 }
             },
             PORTAL => {
+                if args.len() < 2 {
+                    return Err::<(), _>(Error::<T>::InvalidPrecompileArgs).encode_to(output)
+                }
+
                 // First byte is portal selector
                 let portal_selector = &args[0];
                 // The rest is the input for portal
@@ -159,7 +157,7 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                     Err(msg) => {
                         log::error!(target: LOG_TARGET, "Failed to invoke portal: {}", msg);
                         output.push(1); // It's an error
-                        output.append(msg.as_bytes().to_vec().as_mut())
+                                        // output.append(msg.as_bytes().to_vec().as_mut()) No need to write result if it gets thrown away
                     },
                 }
             },

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -2,14 +2,14 @@ use crate::{BalanceOf, Config, Error, Pallet, PrecompileIndex};
 use codec::{Decode, Encode};
 use frame_support::{dispatch::RawOrigin, sp_runtime::DispatchError};
 use sp_std::{vec, vec::Vec};
-use t3rn_abi::Codec as T3rnCodec;
 use t3rn_primitives::{
     circuit::{LocalTrigger, OnLocalTrigger},
     portal::{Portal, PortalExecution, PrecompileArgs as PortalPrecompileArgs},
     threevm::{
-        GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation,
-        EVM_RECODING_BYTE_SELECTOR, GET_STATE, PORTAL, POST_SIGNAL, SUBMIT,
+        GetState, LocalStateAccess, PrecompileArgs, PrecompileInvocation, GET_STATE, PORTAL,
+        POST_SIGNAL, SUBMIT,
     },
+    T3rnCodec,
 };
 use t3rn_sdk_primitives::{
     signal::{ExecutionSignal, Signaller},
@@ -31,16 +31,10 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
     }
 
     // First byte determines if it came from EVM or WASM
-    let codec_selector = args[0];
+    let codec = T3rnCodec::from(args[0]);
 
     // Strip the selector
     let args = &mut &args[1..];
-
-    let codec = if codec_selector == EVM_RECODING_BYTE_SELECTOR {
-        T3rnCodec::Rlp
-    } else {
-        T3rnCodec::default()
-    };
 
     match extract_origin::<T>(&codec, args) {
         Some(origin) => match *precompile {
@@ -52,10 +46,14 @@ pub(crate) fn invoke_raw<T: Config>(precompile: &u8, args: &mut &[u8], output: &
                 };
 
                 if let Ok(args) = args {
-                    if let Ok(PrecompileInvocation::GetState(state)) =
-                        invoke::<T>(PrecompileArgs::GetState(origin, args))
-                    {
-                        Ok::<_, Error<T>>(state).encode_to(output)
+                    match invoke::<T>(PrecompileArgs::GetState(origin, args)) {
+                        Ok(PrecompileInvocation::GetState(state)) =>
+                            Ok::<_, Error<T>>(state).encode_to(output),
+                        Err(e) => {
+                            Err::<(), _>(Error::<T>::DownstreamCircuit).encode_to(output);
+                            Err::<(), _>(e).encode_to(output)
+                        },
+                        _ => {},
                     }
                 } else {
                     Err::<(), _>(Error::<T>::InvalidPrecompileArgs).encode_to(output)
@@ -146,7 +144,7 @@ fn extract_origin<T: Config>(codec: &T3rnCodec, args: &mut &[u8]) -> Option<T::O
         },
         T3rnCodec::Rlp => {
             // TODO: inject addressmapping here, dont always assume padded 12
-            let address_bytes = vec![args.take(..20)?, &[0_u8; 12][..]].concat();
+            let address_bytes = vec![args.take(..=20)?, &[0_u8; 12][..]].concat();
 
             match <T::AccountId as Decode>::decode(&mut &address_bytes[..]) {
                 Ok(account) => Some(T::Origin::from(RawOrigin::Signed(account))),
@@ -257,30 +255,44 @@ pub(crate) fn invoke<T: Config>(
         },
     }
 }
-// TODO: tests
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::{new_test_ext, Test};
+    use crate::mock::{new_test_ext, Test, ALICE};
+    use sp_core::H160;
     use sp_runtime::traits::Hash;
     use t3rn_primitives::circuit::LocalStateExecutionView;
 
     #[test]
     fn test_extract_origin_consumes_buffer() {
         new_test_ext().execute_with(|| {
-            let account = 4_u64;
-            let buffer = &mut &account.encode()[..];
-            let _result = extract_origin::<Test>(&T3rnCodec::Scale, buffer).unwrap();
+            let buffer = &mut &ALICE.encode()[..];
+            let result = extract_origin::<Test>(&T3rnCodec::Scale, buffer).unwrap();
+            println!("{:?}", result);
+
             assert_eq!(buffer.len(), 0)
         });
     }
 
     #[test]
-    fn invoke_raw_bad_pointer() {
+    fn test_extract_origin_consumes_buffer_rlp() {
         new_test_ext().execute_with(|| {
-            let account = 4_u64;
-            let args = &mut &account.encode()[..];
+            let account = H160::from_low_u64_be(4);
+            let buffer = &mut &rlp::encode(&account)[..];
+            let result = extract_origin::<Test>(&T3rnCodec::Rlp, buffer).unwrap();
+            println!("{:?}", result);
+
+            assert_eq!(buffer.len(), 0)
+        });
+    }
+
+    #[test]
+    fn invoke_raw_bad_pointer_rlp() {
+        new_test_ext().execute_with(|| {
+            let account = H160::from_low_u64_be(4);
+            let args = &mut &vec![vec![T3rnCodec::Rlp.into()], rlp::encode(&account).to_vec()]
+                .concat()[..];
             let mut out = Vec::<u8>::new();
 
             invoke_raw::<Test>(&244_u8, args, &mut out);
@@ -291,39 +303,74 @@ mod tests {
         });
     }
 
-    // TODO: errors from pallet-circuit should not cause a panic in the buffer.
-    #[ignore]
+    #[test]
+    fn invoke_raw_bad_pointer_scale() {
+        new_test_ext().execute_with(|| {
+            let args = &mut &vec![vec![T3rnCodec::Scale.into()], ALICE.encode()].concat()[..];
+            let mut out = Vec::<u8>::new();
+
+            invoke_raw::<Test>(&244_u8, args, &mut out);
+            let res =
+                <core::result::Result<(), crate::Error<Test>> as Decode>::decode(&mut &out[..])
+                    .unwrap();
+            assert_eq!(res, Err(Error::<Test>::InvalidPrecompilePointer));
+        });
+    }
+
+    #[test]
+    fn invoke_bad_origin() {
+        new_test_ext().execute_with(|| {
+            // RLP codec, scale encoded origin
+            let args = vec![vec![1], ALICE.encode()].concat();
+            let mut out = Vec::<u8>::new();
+
+            invoke_raw::<Test>(&244_u8, &mut &args[..], &mut out);
+            let res =
+                <core::result::Result<(), crate::Error<Test>> as Decode>::decode(&mut &out[..])
+                    .unwrap();
+            assert_eq!(res, Err(Error::<Test>::InvalidOrigin));
+        });
+    }
+
     #[test]
     fn invoke_get_state_circuit_error() {
         new_test_ext().execute_with(|| {
-            let account = 4_u64;
             let get_state = GetState::<Test> {
                 xtx_id: Some(<Test as frame_system::Config>::Hashing::hash_of(
-                    b"hello world sir",
+                    b"hello world",
                 )),
             };
-            let args = &mut &[account.encode(), get_state.encode()].concat()[..];
+
+            let mut args: Vec<u8> = vec![T3rnCodec::Scale.into()];
+            args.extend(ALICE.encode());
+            args.extend(get_state.encode());
+
             let mut out = Vec::<u8>::new();
 
-            invoke_raw::<Test>(&GET_STATE, args, &mut out);
+            invoke_raw::<Test>(&GET_STATE, &mut &args[..], &mut out);
+
             let res = <core::result::Result<
                 LocalStateExecutionView<Test, BalanceOf<Test>>,
-                DispatchError,
+                crate::Error<Test>,
             > as Decode>::decode(&mut &out[..])
             .unwrap();
-            assert_eq!(res, Err(Error::<Test>::InvalidPrecompilePointer.into()));
+            assert_eq!(res, Err(Error::<Test>::DownstreamCircuit.into()));
         });
     }
 
     #[test]
     fn invoke_get_state() {
         new_test_ext().execute_with(|| {
-            let account = 4_u64;
             let get_state = GetState::<Test> { xtx_id: None };
-            let args = &mut &[account.encode(), get_state.encode()].concat()[..];
+
+            let mut args: Vec<u8> = vec![T3rnCodec::Scale.into()];
+            args.extend(ALICE.encode());
+            args.extend(get_state.encode());
+
             let mut out = Vec::<u8>::new();
 
-            invoke_raw::<Test>(&GET_STATE, args, &mut out);
+            invoke_raw::<Test>(&GET_STATE, &mut &args[..], &mut out);
+
             let res = <core::result::Result<
                 LocalStateExecutionView<Test, BalanceOf<Test>>,
                 crate::Error<Test>,
@@ -337,7 +384,7 @@ mod tests {
                     steps_cnt: (0, 1),
                     xtx_id: <Test as frame_system::Config>::Hash::decode(
                         &mut &hex::decode(
-                            "e0f81c92f7ec3253b2bc5356d5bd928792d40f3022c38ce088553dc8f5bb32c0"
+                            "e8b9e71dc3f878ecf9dae04303767b76882fd0034dd73c98589ff45dab57b05b"
                         )
                         .unwrap()[..]
                     )

--- a/pallets/contracts/src/tests/threevm/mock.rs
+++ b/pallets/contracts/src/tests/threevm/mock.rs
@@ -27,6 +27,7 @@ mod threevm_mock {
         type EscrowAccount = EscrowAccount;
         type Event = Event;
         type OnLocalTrigger = Circuit;
+        type Portal = CircuitPortal;
         type SignalBounceThreshold = ConstU32<2>;
     }
 

--- a/pallets/evm/precompile/portal/Cargo.toml
+++ b/pallets/evm/precompile/portal/Cargo.toml
@@ -5,26 +5,24 @@ name    = "portal-precompile"
 version = "1.5.0-rc.0"
 
 [dependencies]
-codec                        = { package = "parity-scale-codec", version = "3", default-features = false }
+codec = { package = "parity-scale-codec", version = "3", default-features = false }
 
-sp-std                       = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.27', default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v0.9.27', default-features = false }
 
-frame-support                = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
-frame-system                 = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+frame-system  = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
 
-fp-evm                       = { version = "3.0.0-dev", path = "../../primitives", default-features = false }
-pallet-evm                   = { version = "0.1.0", path = "../..", default-features = false }
-pallet-portal                = { path = "../../../portal", default-features = false }
+fp-evm        = { version = "3.0.0-dev", path = "../../primitives", default-features = false }
+pallet-evm    = { version = "0.1.0", path = "../..", default-features = false }
+pallet-portal = { path = "../../../portal", default-features = false }
 
-t3rn-primitives              = { default-features = false, path = "../../../../primitives" }
-t3rn-abi                     = { default-features = false, path = "../../../../types/abi", feature = "runtime" }
+t3rn-primitives = { default-features = false, path = "../../../../primitives" }
 
 [dev-dependencies]
-pallet-evm                   = { path = "../.."}
-rlp                          = { version = "0.5" }
-t3rn-abi                     = { path = "../../../../types/abi", feature = "std" }
-t3rn-mini-mock-runtime      = { path = "../../../../runtime/mini-mock" }
+pallet-evm             = { path = "../.." }
+rlp                    = { version = "0.5" }
+t3rn-mini-mock-runtime = { path = "../../../../runtime/mini-mock" }
 
 [features]
 default = [ "std" ]
-std     = [ "pallet-portal/std", "sp-std/std", "codec/std", "t3rn-abi/std", "t3rn-primitives/std", "frame-support/std", "frame-system/std", "fp-evm/std", "pallet-evm/std" ]
+std     = [ "pallet-portal/std", "sp-std/std", "codec/std", "t3rn-primitives/std", "frame-support/std", "frame-system/std", "fp-evm/std", "pallet-evm/std" ]

--- a/pallets/evm/precompile/portal/src/lib.rs
+++ b/pallets/evm/precompile/portal/src/lib.rs
@@ -15,10 +15,10 @@ impl<T: pallet_evm::Config> EvmPrecompile for PortalPrecompile<T> {
         let _target_gas = handle.gas_limit();
         let _context = handle.context();
         let mut output = Vec::new();
-        let callee = handle.context().caller.clone();
+        let callee = handle.context().caller;
 
         let restructured_args =
-            [&[EVM_RECODING_BYTE_SELECTOR][..], callee.as_bytes(), &input].concat();
+            [&[EVM_RECODING_BYTE_SELECTOR][..], callee.as_bytes(), input].concat();
 
         T::ThreeVm::invoke_raw(&PORTAL, &restructured_args, &mut output);
 
@@ -38,15 +38,5 @@ impl<T: pallet_evm::Config> EvmPrecompile for PortalPrecompile<T> {
                 exit_status: ExitError::Other("Empty buffer".into()),
             })
         }
-    }
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    #[test]
-    fn stub() {
-        // 0x7901000000000000000000000000000000000000000a180001343434340000000000000000000000000000000000000000000000000000000000000000404b4c00000000006400000000000000000000000000000000000000000000000000000000000000000000
     }
 }

--- a/pallets/evm/precompile/portal/src/lib.rs
+++ b/pallets/evm/precompile/portal/src/lib.rs
@@ -5,7 +5,10 @@ use fp_evm::{
     PrecompileOutput, PrecompileResult,
 };
 use sp_std::{marker::PhantomData, vec::Vec};
-use t3rn_primitives::threevm::{Precompile, EVM_RECODING_BYTE_SELECTOR, PORTAL};
+use t3rn_primitives::{
+    threevm::{Precompile, PORTAL},
+    T3rnCodec,
+};
 
 pub struct PortalPrecompile<T: pallet_evm::Config>(PhantomData<T>);
 
@@ -17,8 +20,7 @@ impl<T: pallet_evm::Config> EvmPrecompile for PortalPrecompile<T> {
         let mut output = Vec::new();
         let callee = handle.context().caller;
 
-        let restructured_args =
-            [&[EVM_RECODING_BYTE_SELECTOR][..], callee.as_bytes(), input].concat();
+        let restructured_args = [&[T3rnCodec::Rlp.into()][..], callee.as_bytes(), input].concat();
 
         T::ThreeVm::invoke_raw(&PORTAL, &restructured_args, &mut output);
 

--- a/pallets/evm/precompile/portal/src/lib.rs
+++ b/pallets/evm/precompile/portal/src/lib.rs
@@ -16,37 +16,36 @@ impl<T: pallet_evm::Config> EvmPrecompile for PortalPrecompile<T> {
         let _target_gas = handle.gas_limit();
         let _context = handle.context();
         let mut output = Vec::new();
+        let callee = handle.context().caller.clone();
 
-        // TODO: assert the length is at least 2 bytes
-        if input.len() < 2 {
-            return Err(
-                ExitError::Other("PortalPrecompile input contained too little bytes".into()).into(),
-            )
-        }
+        // // TODO: assert the length is at least 2 bytes
+        // if input.len() < 2 {
+        //     return Err(
+        //         ExitError::Other("PortalPrecompile input contained too little bytes".into()).into(),
+        //     )
+        // }
 
-        // TODO; assert on first byte that it is indeed portal
-        let precompile_selector_index = input[0];
+        let restructured_args =
+            [&[EVM_RECODING_BYTE_SELECTOR][..], callee.as_bytes(), &input].concat();
 
-        // TODO: add the evm selector here
-        let args_with_evm_selector = vec![&[EVM_RECODING_BYTE_SELECTOR][..], &input[1..]].concat();
-
-        T::ThreeVm::invoke_raw(
-            &precompile_selector_index,
-            &args_with_evm_selector,
-            &mut output,
-        );
-
-        // Hmm, maybe we just recode the entire thing
+        // TODO: dont hardcode me
+        T::ThreeVm::invoke_raw(&70, &restructured_args, &mut output);
 
         // FIXME: always passes right now, needs error check
-        if !output.is_empty() {
-            Ok(PrecompileOutput {
-                exit_status: ExitSucceed::Returned,
-                output,
-            })
+        if let Some(result_byte) = output.first() {
+            if *result_byte == 0 {
+                Ok(PrecompileOutput {
+                    exit_status: ExitSucceed::Returned,
+                    output,
+                })
+            } else {
+                Err(PrecompileFailure::Error {
+                    exit_status: ExitError::Other("invalid output".into()),
+                })
+            }
         } else {
             Err(PrecompileFailure::Error {
-                exit_status: ExitError::Other("invalid output".into()),
+                exit_status: ExitError::Other("Empty buffer".into()),
             })
         }
     }
@@ -57,5 +56,7 @@ pub mod tests {
     use super::*;
 
     #[test]
-    fn stub() {}
+    fn stub() {
+        // 0x7901000000000000000000000000000000000000000a180001343434340000000000000000000000000000000000000000000000000000000000000000404b4c00000000006400000000000000000000000000000000000000000000000000000000000000000000
+    }
 }

--- a/pallets/evm/precompile/util/Cargo.toml
+++ b/pallets/evm/precompile/util/Cargo.toml
@@ -7,13 +7,13 @@ repository = 'https://github.com/t3rn/3vm'
 version    = "1.0.0"
 
 [dependencies]
-codec                     = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec                     = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
+pallet-3vm-evm            = { path = "../..", default-features = false, package = "pallet-evm" }
 pallet-3vm-evm-primitives = { path = "../../primitives", default-features = false, package = "fp-evm" }
 sp-core                   = { git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.27', default-features = false }
 sp-std                    = { git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.27', default-features = false }
 
 pallet-evm-precompile-3vm-dispatch = { path = "../3vm-dispatch", default-features = false }
-portal-precompile                  = { path = "../portal", default-features = false }
 pallet-evm-precompile-blake2       = { git = "https://github.com/paritytech/frontier.git", branch = "polkadot-v0.9.27", default-features = false }
 pallet-evm-precompile-bn128        = { git = "https://github.com/paritytech/frontier.git", branch = "polkadot-v0.9.27", default-features = false }
 pallet-evm-precompile-curve25519   = { git = "https://github.com/paritytech/frontier.git", branch = "polkadot-v0.9.27", default-features = false }
@@ -22,10 +22,10 @@ pallet-evm-precompile-ed25519      = { git = "https://github.com/paritytech/fron
 pallet-evm-precompile-modexp       = { git = "https://github.com/paritytech/frontier.git", branch = "polkadot-v0.9.27", default-features = false }
 pallet-evm-precompile-sha3fips     = { git = "https://github.com/paritytech/frontier.git", branch = "polkadot-v0.9.27", default-features = false }
 pallet-evm-precompile-simple       = { git = "https://github.com/paritytech/frontier.git", branch = "polkadot-v0.9.27", default-features = false }
+portal-precompile                  = { path = "../portal", default-features = false }
 
-frame-system                      = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
-t3rn-primitives                    = { default-features = false, path = "../../../../primitives" }
-
+frame-system    = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+t3rn-primitives = { default-features = false, path = "../../../../primitives" }
 
 [features]
 default = [ "std" ]

--- a/pallets/evm/src/lib.rs
+++ b/pallets/evm/src/lib.rs
@@ -64,7 +64,7 @@ pub mod runner;
 #[cfg(test)]
 pub mod tests;
 
-use codec::{Decode, Encode};
+pub use self::{pallet::*, runner::Runner};
 pub use evm::{
     Config as EvmConfig, Context, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed,
 };
@@ -72,6 +72,8 @@ pub use fp_evm::{
     Account, CallInfo, CreateInfo, ExecutionInfo, LinearCostPrecompile, Log, Precompile,
     PrecompileFailure, PrecompileOutput, PrecompileResult, PrecompileSet, Vicinity,
 };
+
+use codec::{Decode, Encode};
 use frame_support::{
     dispatch::DispatchResultWithPostInfo,
     pallet_prelude::IsType,
@@ -95,8 +97,6 @@ use t3rn_primitives::{
 
 #[cfg(feature = "std")]
 use fp_evm::GenesisAccount;
-
-pub use self::{pallet::*, runner::Runner};
 
 pub type CurrencyOf<T> = <T as pallet::Config>::Currency;
 

--- a/pallets/evm/src/tests/threevm/mock.rs
+++ b/pallets/evm/src/tests/threevm/mock.rs
@@ -26,6 +26,7 @@ impl pallet_3vm::Config for Test {
     type EscrowAccount = EscrowAccount;
     type Event = Event;
     type OnLocalTrigger = Circuit;
+    type Portal = CircuitPortal;
     type SignalBounceThreshold = ConstU32<2>;
 }
 

--- a/pallets/portal/src/lib.rs
+++ b/pallets/portal/src/lib.rs
@@ -149,38 +149,45 @@ pub fn match_light_client_by_gateway_id<T: Config>(
 
 impl<T: Config> Portal<T> for Pallet<T> {
     fn get_latest_finalized_header(gateway_id: ChainId) -> Result<HeaderResult, DispatchError> {
+        log::debug!(target: "portal", "Getting latest finalized header for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.get_latest_finalized_header()
     }
 
     fn get_latest_finalized_height(
         gateway_id: ChainId,
     ) -> Result<HeightResult<T::BlockNumber>, DispatchError> {
+        log::debug!(target: "portal", "Getting latest finalized height for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.get_latest_finalized_height()
     }
 
     fn get_latest_updated_height(
         gateway_id: ChainId,
     ) -> Result<HeightResult<T::BlockNumber>, DispatchError> {
+        log::debug!(target: "portal", "Getting latest updated height for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.get_latest_updated_height()
     }
 
     fn get_current_epoch(
         gateway_id: ChainId,
     ) -> Result<HeightResult<T::BlockNumber>, DispatchError> {
+        log::debug!(target: "portal", "Getting current epoch for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.get_current_epoch()
     }
 
     fn read_fast_confirmation_offset(gateway_id: ChainId) -> Result<T::BlockNumber, DispatchError> {
+        log::debug!(target: "portal", "Reading fast confirmation offset for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.read_fast_confirmation_offset()
     }
 
     fn read_rational_confirmation_offset(
         gateway_id: ChainId,
     ) -> Result<T::BlockNumber, DispatchError> {
+        log::debug!(target: "portal", "Reading rational confirmation offset for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.read_rational_confirmation_offset()
     }
 
     fn read_epoch_offset(gateway_id: ChainId) -> Result<T::BlockNumber, DispatchError> {
+        log::debug!(target: "portal", "Reading epoch offset for gateway id {:?}", gateway_id);
         match_light_client_by_gateway_id::<T>(gateway_id)?.read_epoch_offset()
     }
 

--- a/pallets/portal/src/lib.rs
+++ b/pallets/portal/src/lib.rs
@@ -14,7 +14,7 @@ use pallet_grandpa_finality_verifier::light_clients::LightClient;
 use t3rn_abi::types::Bytes;
 use t3rn_primitives::{
     self,
-    portal::{HeaderResult, HeightResult, Portal, PortalReadApi},
+    portal::{HeaderResult, HeightResult, Portal},
     xdns::Xdns,
     ChainId, GatewayVendor, TokenSysProps,
 };
@@ -310,123 +310,5 @@ impl<T: Config> Portal<T> for Pallet<T> {
 
     fn turn_off(origin: OriginFor<T>, gateway_id: [u8; 4]) -> Result<bool, DispatchError> {
         match_light_client_by_gateway_id::<T>(gateway_id)?.turn_off(origin)
-    }
-}
-
-impl<T: Config> PortalReadApi<T::BlockNumber> for Pallet<T> {
-    fn get_latest_finalized_header(gateway_id: ChainId) -> Result<HeaderResult, DispatchError> {
-        <Pallet<T> as Portal<T>>::get_latest_finalized_header(gateway_id)
-    }
-
-    fn get_latest_finalized_height(
-        gateway_id: ChainId,
-    ) -> Result<HeightResult<T::BlockNumber>, DispatchError> {
-        <Pallet<T> as Portal<T>>::get_latest_finalized_height(gateway_id)
-    }
-
-    fn get_latest_updated_height(
-        gateway_id: ChainId,
-    ) -> Result<HeightResult<T::BlockNumber>, DispatchError> {
-        <Pallet<T> as Portal<T>>::get_latest_updated_height(gateway_id)
-    }
-
-    fn get_current_epoch(
-        gateway_id: ChainId,
-    ) -> Result<HeightResult<T::BlockNumber>, DispatchError> {
-        <Pallet<T> as Portal<T>>::get_current_epoch(gateway_id)
-    }
-
-    fn read_fast_confirmation_offset(gateway_id: ChainId) -> Result<T::BlockNumber, DispatchError> {
-        <Pallet<T> as Portal<T>>::read_fast_confirmation_offset(gateway_id)
-    }
-
-    fn read_rational_confirmation_offset(
-        gateway_id: ChainId,
-    ) -> Result<T::BlockNumber, DispatchError> {
-        <Pallet<T> as Portal<T>>::read_rational_confirmation_offset(gateway_id)
-    }
-
-    fn read_epoch_offset(gateway_id: ChainId) -> Result<T::BlockNumber, DispatchError> {
-        <Pallet<T> as Portal<T>>::read_epoch_offset(gateway_id)
-    }
-
-    fn verify_event_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<T::BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Pallet<T> as Portal<T>>::verify_event_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_state_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<T::BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Pallet<T> as Portal<T>>::verify_state_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_tx_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<T::BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Pallet<T> as Portal<T>>::verify_tx_inclusion(gateway_id, message, submission_target_height)
-    }
-
-    fn verify_state_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<T::BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Pallet<T> as Portal<T>>::verify_state_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-
-    fn verify_tx_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<T::BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Pallet<T> as Portal<T>>::verify_tx_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-
-    fn verify_event_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<T::BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Pallet<T> as Portal<T>>::verify_event_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
     }
 }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -39,9 +39,9 @@ sp-trie             = { git = "https://github.com/paritytech/substrate.git", bra
 
 snowbridge-core = { path = "src/bridges/snowfork/core", default-features = false }
 
+t3rn-abi            = { path = "../types/abi", default-features = false, features = [ "runtime" ] }
 t3rn-sdk-primitives = { version = "=0.1.1-rc.4", default-features = false }
 t3rn-types          = { path = "../types", default-features = false, features = [ "runtime" ] }
-t3rn-abi            = { path = "../types/abi", default-features = false, features = [ "runtime" ] }
 
 t3rn-light-client-commons = { path = "../finality-verifiers/common", default-features = false }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -27,6 +27,7 @@ use codec::{Decode, Encode};
 use frame_support::traits::{ReservableCurrency, Time};
 use scale_info::TypeInfo;
 
+pub use t3rn_abi::recode::Codec as T3rnCodec;
 pub use t3rn_types::{gateway, types::Bytes};
 
 #[cfg(feature = "std")]

--- a/primitives/src/portal.rs
+++ b/primitives/src/portal.rs
@@ -6,7 +6,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 use sp_std::{convert::TryFrom, vec::Vec};
-use t3rn_abi::{recode::Codec, types::Bytes, Abi};
+use t3rn_abi::{recode::Codec, types::Bytes, Abi, FilledAbi};
 pub use t3rn_light_client_commons::traits::{HeaderResult, HeightResult};
 use t3rn_types::sfx::Sfx4bId;
 
@@ -159,7 +159,7 @@ impl<T: frame_system::Config> Into<Bytes> for PortalExecution<T> {
 }
 
 #[derive(Clone, Eq, Decode, Encode, PartialEq, Debug, TypeInfo)]
-pub enum PortalPrecompileInterfaceEnum {
+pub enum PrecompileArgs {
     GetLatestFinalizedHeader(ChainId),
     GetLatestFinalizedHeight(ChainId),
     GetLatestUpdatedHeight(ChainId),
@@ -172,36 +172,85 @@ pub enum PortalPrecompileInterfaceEnum {
     VerifyTxInclusion([u8; 4], Bytes),
 }
 
-pub fn get_portal_interface_abi() -> Abi {
-    Abi::try_from(PORTAL_INTERFACE_ABI_DESCRIPTOR.to_vec())
-        .expect("Expect parsing PORTAL_INTERFACE_ABI_DESCRIPTOR to succeed.")
+impl PrecompileArgs {
+    pub fn descriptor() -> Vec<u8> {
+        b"PrecompileArgs:Enum(\
+                GetLatestFinalizedHeader:Bytes4,\
+                GetLatestFinalizedHeight:Bytes4,\
+                GetLatestUpdatedHeight:Bytes4,\
+                GetCurrentEpoch:Bytes4,\
+                ReadFastConfirmationOffset:Bytes4,\
+                ReadRationalConfirmationOffset:Bytes4,\
+                ReadEpochOffset:Bytes4,\
+                VerifyEventInclusion:Tuple(Bytes4,Bytes),\
+                VerifyStateInclusion:Tuple(Bytes4,Bytes),\
+                VerifyTxInclusion:Tuple(Bytes4,Bytes),\
+        )"
+        .to_vec()
+    }
+
+    pub fn interface_abi() -> Result<Abi, DispatchError> {
+        Abi::try_from(Self::descriptor())
+    }
+
+    pub fn recode_to_scale_and_decode(
+        in_codec: &t3rn_abi::Codec,
+        input: &[u8],
+    ) -> Result<Self, DispatchError> {
+        if input.len() < 2 {
+            return Err(DispatchError::Other("Not enough arguments to build enum"))
+        }
+        // First byte is portal selector
+        let portal_selector = &input[0];
+
+        match in_codec {
+            t3rn_abi::Codec::Rlp => {
+                log::debug!(
+                    target: "portal::recode",
+                    "Rlp encoding bytes for portal selector {}",
+                    portal_selector
+                );
+                log::trace!(
+                    target: "portal::recode",
+                    "Bytes {:?}",
+                    input
+                );
+                FilledAbi::try_fill_abi(Self::interface_abi()?, input.to_vec(), in_codec.clone())
+                    .and_then(|abi| {
+                        log::debug!(
+                            target: "portal::recode",
+                            "ABI was filled, recoding to scale {}",
+                            portal_selector
+                        );
+
+                        abi.recode_as(&in_codec.clone(), &t3rn_abi::Codec::Scale)
+                    })
+            },
+            t3rn_abi::Codec::Scale => Ok(input.to_vec()),
+        }
+        .map(|mut recoded| {
+            recoded.insert(0, *portal_selector);
+            recoded
+        })
+        .and_then(|recoded| {
+            Self::decode(&mut &recoded[..])
+                .map_err(|_e| DispatchError::Other("Failed to decode portal interface enum"))
+        })
+    }
 }
 
-pub const PORTAL_INTERFACE_ABI_DESCRIPTOR: &[u8] = b"PortalPrecompileInterface:Enum(\
-        GetLatestFinalizedHeader:Bytes4,\
-        GetLatestFinalizedHeight:Bytes4,\
-        GetLatestUpdatedHeight:Bytes4,\
-        GetCurrentEpoch:Bytes4,\
-        ReadFastConfirmationOffset:Bytes4,\
-        ReadRationalConfirmationOffset:Bytes4,\
-        ReadEpochOffset:Bytes4,\
-        VerifyEventInclusion:Tuple(Bytes4,Bytes),\
-        VerifyStateInclusion:Tuple(Bytes4,Bytes),\
-        VerifyTxInclusion:Tuple(Bytes4,Bytes),\
-    )";
-
 #[cfg(test)]
-pub mod portal_precompile_decode_test {
+pub mod tests {
     use super::*;
     use t3rn_abi::{Abi, Codec, FilledAbi};
 
     #[test]
     fn portal_interface_abi_descriptor_parses() {
-        let portal_interface_abi = get_portal_interface_abi();
+        let portal_interface_abi = PrecompileArgs::interface_abi().unwrap();
         assert_eq!(
             portal_interface_abi,
             Abi::Enum(
-                Some(b"PortalPrecompileInterface".to_vec()),
+                Some(b"PrecompileArgs".to_vec()),
                 vec![
                     Box::new(Abi::Bytes4(Some(b"GetLatestFinalizedHeader".to_vec()))),
                     Box::new(Abi::Bytes4(Some(b"GetLatestFinalizedHeight".to_vec()))),
@@ -231,11 +280,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_get_latest_finalized_header() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::GetLatestFinalizedHeader([1u8; 4]).encode(),
+            PrecompileArgs::GetLatestFinalizedHeader([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -248,11 +297,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_get_latest_finalized_height() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::GetLatestFinalizedHeight([1u8; 4]).encode(),
+            PrecompileArgs::GetLatestFinalizedHeight([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -265,11 +314,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_get_latest_updated_height() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::GetLatestUpdatedHeight([1u8; 4]).encode(),
+            PrecompileArgs::GetLatestUpdatedHeight([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -282,11 +331,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_get_current_epoch() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::GetCurrentEpoch([1u8; 4]).encode(),
+            PrecompileArgs::GetCurrentEpoch([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -299,11 +348,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_read_fast_confirmation_offset() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::ReadFastConfirmationOffset([1u8; 4]).encode(),
+            PrecompileArgs::ReadFastConfirmationOffset([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -316,11 +365,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_read_rational_confirmation_offset() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::ReadRationalConfirmationOffset([1u8; 4]).encode(),
+            PrecompileArgs::ReadRationalConfirmationOffset([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -336,11 +385,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_read_epoch_offset() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::ReadEpochOffset([1u8; 4]).encode(),
+            PrecompileArgs::ReadEpochOffset([1u8; 4]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -353,11 +402,11 @@ pub mod portal_precompile_decode_test {
 
     #[test]
     fn portal_precompile_selects_enum_for_verify_event_inclusion() {
-        let portal_precompile_interface = get_portal_interface_abi();
+        let portal_precompile_interface = PrecompileArgs::interface_abi().unwrap();
 
         let filled_abi = FilledAbi::try_fill_abi(
             portal_precompile_interface,
-            PortalPrecompileInterfaceEnum::VerifyEventInclusion([1u8; 4], vec![4u8; 32]).encode(),
+            PrecompileArgs::VerifyEventInclusion([1u8; 4], vec![4u8; 32]).encode(),
             Codec::Scale,
         )
         .unwrap();
@@ -372,5 +421,159 @@ pub mod portal_precompile_decode_test {
                 ),
             )
         )
+    }
+
+    #[test]
+    fn test_get_latest_finalized_header_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::GetLatestFinalizedHeader(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        println!("Call: {:?}", encoded_portal_call);
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::GetLatestFinalizedHeader(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_get_latest_finalized_height_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::GetLatestFinalizedHeight(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::GetLatestFinalizedHeight(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_get_latest_updated_height_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::GetLatestUpdatedHeight(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::GetLatestUpdatedHeight(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_get_current_epoch_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::GetCurrentEpoch(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::GetCurrentEpoch(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_read_epoch_offset_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::ReadEpochOffset(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::ReadEpochOffset(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_read_fast_confirmation_offset_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::ReadFastConfirmationOffset(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::ReadFastConfirmationOffset(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_read_rational_confirmation_offset_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let portal_call = PrecompileArgs::ReadRationalConfirmationOffset(chain_id);
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::ReadRationalConfirmationOffset(chain_id)
+        );
+    }
+
+    #[test]
+    fn test_verify_event_inclusion_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let event = vec![1, 2, 3, 4];
+        let portal_call = PrecompileArgs::VerifyEventInclusion(chain_id, event.clone());
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::VerifyEventInclusion(chain_id, event)
+        );
+    }
+
+    #[test]
+    fn test_verify_state_inclusion_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let event = vec![1, 2, 3, 4];
+        let portal_call = PrecompileArgs::VerifyStateInclusion(chain_id, event.clone());
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::VerifyStateInclusion(chain_id, event)
+        );
+    }
+
+    #[test]
+    fn test_verify_tx_inclusion_recodes_correctly_to_scale() {
+        let chain_id: [u8; 4] = [9, 9, 9, 9];
+        let event = vec![1, 2, 3, 4];
+        let portal_call = PrecompileArgs::VerifyTxInclusion(chain_id, event.clone());
+        let encoded_portal_call = portal_call.encode();
+        let recoded_portal_call =
+            PrecompileArgs::recode_to_scale_and_decode(&t3rn_abi::Codec::Rlp, &encoded_portal_call)
+                .unwrap();
+
+        assert_eq!(
+            recoded_portal_call,
+            PrecompileArgs::VerifyTxInclusion(chain_id, event)
+        );
     }
 }

--- a/primitives/src/portal.rs
+++ b/primitives/src/portal.rs
@@ -24,69 +24,8 @@ pub struct RegistrationData {
     pub encoded_registration_data: Bytes,
 }
 
-pub trait PortalReadApi<BlockNumber> {
-    fn get_latest_finalized_header(gateway_id: ChainId) -> Result<HeaderResult, DispatchError>;
-
-    fn get_latest_finalized_height(
-        gateway_id: ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError>;
-
-    fn get_latest_updated_height(
-        gateway_id: ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError>;
-
-    fn get_current_epoch(gateway_id: ChainId) -> Result<HeightResult<BlockNumber>, DispatchError>;
-
-    fn read_fast_confirmation_offset(gateway_id: ChainId) -> Result<BlockNumber, DispatchError>;
-
-    fn read_rational_confirmation_offset(gateway_id: ChainId)
-        -> Result<BlockNumber, DispatchError>;
-
-    fn read_epoch_offset(gateway_id: ChainId) -> Result<BlockNumber, DispatchError>;
-
-    fn verify_event_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError>;
-
-    fn verify_state_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError>;
-
-    fn verify_tx_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError>;
-
-    fn verify_state_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError>;
-
-    fn verify_tx_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError>;
-
-    fn verify_event_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError>;
-}
-
+// This could be split into readable parts here, or even more specific traits in the future, if needed.
+// Something like `.. Portal: ReadHeaders + Submit { ..`
 pub trait Portal<T: frame_system::Config> {
     fn get_latest_finalized_header(gateway_id: ChainId) -> Result<HeaderResult, DispatchError>;
 
@@ -166,6 +105,57 @@ pub trait Portal<T: frame_system::Config> {
     fn turn_on(origin: T::Origin, gateway_id: [u8; 4]) -> Result<bool, DispatchError>;
 
     fn turn_off(origin: T::Origin, gateway_id: [u8; 4]) -> Result<bool, DispatchError>;
+}
+
+#[derive(Clone, Eq, Decode, Encode, PartialEq, Debug, TypeInfo)]
+pub enum PortalExecution<T: frame_system::Config> {
+    Header(HeaderResult),
+    Height(HeightResult<T::BlockNumber>),
+    BlockNumber(T::BlockNumber),
+    Data(Bytes),
+    Switched(bool),
+    Noop,
+}
+
+impl<T: frame_system::Config> From<HeaderResult> for PortalExecution<T> {
+    fn from(value: HeaderResult) -> Self {
+        Self::Header(value)
+    }
+}
+impl<T: frame_system::Config> From<HeightResult<T::BlockNumber>> for PortalExecution<T> {
+    fn from(value: HeightResult<T::BlockNumber>) -> Self {
+        Self::Height(value)
+    }
+}
+impl<T: frame_system::Config> From<Bytes> for PortalExecution<T> {
+    fn from(value: Bytes) -> Self {
+        Self::Data(value)
+    }
+}
+impl<T: frame_system::Config> From<bool> for PortalExecution<T> {
+    fn from(value: bool) -> Self {
+        Self::Switched(value)
+    }
+}
+impl<T: frame_system::Config> From<()> for PortalExecution<T> {
+    fn from(_value: ()) -> Self {
+        Self::Noop
+    }
+}
+
+// Justification, don't need from here, would require unneeded implementation too
+#[allow(clippy::from_over_into)]
+impl<T: frame_system::Config> Into<Bytes> for PortalExecution<T> {
+    fn into(self) -> Bytes {
+        match self {
+            PortalExecution::Header(x) => x.encode(),
+            PortalExecution::Height(x) => x.encode(),
+            PortalExecution::BlockNumber(x) => x.encode(),
+            PortalExecution::Data(x) => x.encode(),
+            PortalExecution::Switched(x) => x.encode(),
+            PortalExecution::Noop => sp_std::vec![],
+        }
+    }
 }
 
 #[derive(Clone, Eq, Decode, Encode, PartialEq, Debug, TypeInfo)]

--- a/primitives/src/threevm.rs
+++ b/primitives/src/threevm.rs
@@ -17,6 +17,13 @@ use t3rn_sdk_primitives::{
 pub const EVM_RECODING_BYTE_SELECTOR: u8 = 40;
 pub const WASM_RECODING_BYTE_SELECTOR: u8 = 41;
 
+// Precompile pointers baked into the binary.
+// Genesis exists only to map hashes to pointers.
+pub const GET_STATE: u8 = 55;
+pub const SUBMIT: u8 = 56;
+pub const POST_SIGNAL: u8 = 57;
+pub const PORTAL: u8 = 70;
+
 #[derive(Encode, Decode)]
 pub struct GetState<T: frame_system::Config> {
     pub xtx_id: Option<T::Hash>,

--- a/primitives/src/threevm.rs
+++ b/primitives/src/threevm.rs
@@ -13,10 +13,6 @@ use t3rn_sdk_primitives::{
     state::SideEffects,
 };
 
-// Tells the precompile indexer whether the call came from EVM or WASM in encoding-specific formats
-pub const EVM_RECODING_BYTE_SELECTOR: u8 = 40;
-pub const WASM_RECODING_BYTE_SELECTOR: u8 = 41;
-
 // Precompile pointers baked into the binary.
 // Genesis exists only to map hashes to pointers.
 pub const GET_STATE: u8 = 55;

--- a/primitives/src/threevm.rs
+++ b/primitives/src/threevm.rs
@@ -22,6 +22,7 @@ pub struct GetState<T: frame_system::Config> {
     pub xtx_id: Option<T::Hash>,
 }
 
+// FIXME: none of these work at the moment due to large updates to SFX ABI.
 #[derive(Encode, Decode)]
 pub enum PrecompileArgs<T, Balance>
 where

--- a/primitives/src/threevm.rs
+++ b/primitives/src/threevm.rs
@@ -3,7 +3,7 @@ use crate::{
     circuit::LocalStateExecutionView,
     contract_metadata::ContractType,
     contracts_registry::{AuthorInfo, RegistryContract},
-    portal::{PortalExecution, PortalPrecompileInterfaceEnum},
+    portal::{PortalExecution, PrecompileArgs as PortalPrecompileArgs},
 };
 use codec::{Decode, Encode};
 use sp_runtime::{DispatchError, DispatchResult};
@@ -39,7 +39,7 @@ where
     GetState(T::Origin, GetState<T>),
     SubmitSideEffects(T::Origin, SideEffects<T::AccountId, Balance, T::Hash>),
     Signal(T::Origin, ExecutionSignal<T::Hash>),
-    Portal(PortalPrecompileInterfaceEnum),
+    Portal(PortalPrecompileArgs),
 }
 
 /// The happy return type of an invocation

--- a/primitives/src/threevm.rs
+++ b/primitives/src/threevm.rs
@@ -3,6 +3,7 @@ use crate::{
     circuit::LocalStateExecutionView,
     contract_metadata::ContractType,
     contracts_registry::{AuthorInfo, RegistryContract},
+    portal::{PortalExecution, PortalPrecompileInterfaceEnum},
 };
 use codec::{Decode, Encode};
 use sp_runtime::{DispatchError, DispatchResult};
@@ -11,6 +12,10 @@ use t3rn_sdk_primitives::{
     signal::{ExecutionSignal, Signaller},
     state::SideEffects,
 };
+
+// Tells the precompile indexer whether the call came from EVM or WASM in encoding-specific formats
+pub const EVM_RECODING_BYTE_SELECTOR: u8 = 40;
+pub const WASM_RECODING_BYTE_SELECTOR: u8 = 41;
 
 #[derive(Encode, Decode)]
 pub struct GetState<T: frame_system::Config> {
@@ -26,6 +31,7 @@ where
     GetState(T::Origin, GetState<T>),
     SubmitSideEffects(T::Origin, SideEffects<T::AccountId, Balance, T::Hash>),
     Signal(T::Origin, ExecutionSignal<T::Hash>),
+    Portal(PortalPrecompileInterfaceEnum),
 }
 
 /// The happy return type of an invocation
@@ -33,6 +39,7 @@ pub enum PrecompileInvocation<T: frame_system::Config, Balance> {
     GetState(LocalStateExecutionView<T, Balance>),
     Submit,
     Signal,
+    Portal(PortalExecution<T>),
 }
 
 impl<T: frame_system::Config, Balance> PrecompileInvocation<T, Balance> {

--- a/runtime/mock/src/contracts_config.rs
+++ b/runtime/mock/src/contracts_config.rs
@@ -2,14 +2,14 @@ use crate::*;
 
 use crate::{
     accounts_config::EscrowAccount, AccountId, AccountManager, Aura, Balance, Balances,
-    BlockWeights, Call, Circuit, ContractsRegistry, Event, RandomnessCollectiveFlip, ThreeVm,
-    Timestamp, Weight, AVERAGE_ON_INITIALIZE_RATIO,
+    BlockWeights, Call, Circuit, ContractsRegistry, Event, Portal, RandomnessCollectiveFlip,
+    ThreeVm, Timestamp, Weight, AVERAGE_ON_INITIALIZE_RATIO,
 };
 use frame_support::{pallet_prelude::ConstU32, parameter_types, traits::FindAuthor};
 
 use circuit_runtime_pallets::{
     evm_precompile_util, pallet_3vm, pallet_3vm_contracts, pallet_3vm_evm,
-    pallet_3vm_evm_primitives, pallet_circuit::HeightResult,
+    pallet_3vm_evm_primitives,
 };
 use pallet_3vm_contracts::weights::WeightInfo;
 use pallet_3vm_evm::{
@@ -18,12 +18,10 @@ use pallet_3vm_evm::{
 };
 use pallet_3vm_evm_primitives::FeeCalculator;
 use sp_core::{H160, U256};
-use sp_runtime::{ConsensusEngineId, DispatchError, RuntimeAppPublic};
+use sp_runtime::{ConsensusEngineId, RuntimeAppPublic};
 
 #[cfg(feature = "std")]
 pub use pallet_3vm_evm_primitives::GenesisAccount as EvmGenesisAccount;
-use t3rn_abi::{types::Bytes, Codec};
-use t3rn_primitives::portal::{HeaderResult, PortalReadApi};
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;
@@ -74,6 +72,7 @@ impl pallet_3vm::Config for Runtime {
     type EscrowAccount = EscrowAccount;
     type Event = Event;
     type OnLocalTrigger = Circuit;
+    type Portal = Portal;
     type SignalBounceThreshold = ConstU32<2>;
 }
 
@@ -137,138 +136,10 @@ impl FeeCalculator for FixedGasPrice {
     }
 }
 
-impl PortalReadApi<BlockNumber> for Runtime {
-    fn get_latest_finalized_header(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeaderResult, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_latest_finalized_header(gateway_id)
-    }
-
-    fn get_latest_finalized_height(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_latest_finalized_height(gateway_id)
-    }
-
-    fn get_latest_updated_height(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_latest_updated_height(gateway_id)
-    }
-
-    fn get_current_epoch(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_current_epoch(gateway_id)
-    }
-
-    fn read_fast_confirmation_offset(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<BlockNumber, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::read_fast_confirmation_offset(gateway_id)
-    }
-
-    fn read_rational_confirmation_offset(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<BlockNumber, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::read_rational_confirmation_offset(gateway_id)
-    }
-
-    fn read_epoch_offset(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<BlockNumber, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::read_epoch_offset(gateway_id)
-    }
-
-    fn verify_event_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_event_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_state_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_state_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_tx_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_tx_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_state_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_state_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-
-    fn verify_tx_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_tx_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-
-    fn verify_event_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_event_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-}
-
 parameter_types! {
     pub const ChainId: u64 = 42;
     pub BlockGasLimit: U256 = U256::from(u32::max_value());
-    pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime, BlockNumber> = evm_precompile_util::Precompiles::new(sp_std::vec![
+    pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
         (0_u64, evm_precompile_util::KnownPrecompile::ECRecover),
         (1_u64, evm_precompile_util::KnownPrecompile::Sha256),
         (2_u64, evm_precompile_util::KnownPrecompile::Ripemd160),
@@ -277,8 +148,7 @@ parameter_types! {
         (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
         (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
         (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-    ].into_iter().collect(), sp_std::vec![
-        (819_u64, evm_precompile_util::CustomPrecompile::<Runtime, BlockNumber>::Portal),
+        (40_u64, evm_precompile_util::KnownPrecompile::Portal)
     ].into_iter().collect());
 }
 
@@ -291,12 +161,12 @@ impl pallet_3vm_evm::Config for Runtime {
     type ChainId = ChainId;
     type Currency = Balances;
     type Event = Event;
-    type FeeCalculator = FixedGasPrice;
     // BaseFee pallet may be better from frontier TODO
+    type FeeCalculator = FixedGasPrice;
     type FindAuthor = FindAuthorTruncated<Aura>;
     type GasWeightMapping = FixedGasWeightMapping;
     type OnChargeTransaction = ThreeVMCurrencyAdapter<Balances, ()>;
-    type PrecompilesType = evm_precompile_util::Precompiles<Self, BlockNumber>;
+    type PrecompilesType = evm_precompile_util::Precompiles<Self>;
     type PrecompilesValue = PrecompilesValue;
     type Runner = pallet_3vm_evm::runner::stack::Runner<Self>;
     type ThreeVm = ThreeVm;

--- a/runtime/standalone/src/contracts_config.rs
+++ b/runtime/standalone/src/contracts_config.rs
@@ -143,7 +143,7 @@ parameter_types! {
         (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
         (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
         (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-        (40_u64, evm_precompile_util::KnownPrecompile::Portal)
+        (10_u64, evm_precompile_util::KnownPrecompile::Portal)
     ].into_iter().collect());
 }
 

--- a/runtime/standalone/src/contracts_config.rs
+++ b/runtime/standalone/src/contracts_config.rs
@@ -16,7 +16,7 @@ use sp_runtime::{ConsensusEngineId, DispatchError, RuntimeAppPublic};
 #[cfg(feature = "std")]
 pub use pallet_3vm_evm_primitives::GenesisAccount as EvmGenesisAccount;
 use t3rn_abi::{types::Bytes, Codec};
-use t3rn_primitives::portal::{HeaderResult, HeightResult, PortalReadApi};
+use t3rn_primitives::portal::{HeaderResult, HeightResult};
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;
@@ -67,6 +67,7 @@ impl pallet_3vm::Config for Runtime {
     type EscrowAccount = EscrowAccount;
     type Event = Event;
     type OnLocalTrigger = Circuit;
+    type Portal = Portal;
     type SignalBounceThreshold = ConstU32<2>;
 }
 
@@ -130,138 +131,10 @@ impl FeeCalculator for FixedGasPrice {
     }
 }
 
-impl PortalReadApi<BlockNumber> for Runtime {
-    fn get_latest_finalized_header(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeaderResult, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_latest_finalized_header(gateway_id)
-    }
-
-    fn get_latest_finalized_height(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_latest_finalized_height(gateway_id)
-    }
-
-    fn get_latest_updated_height(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_latest_updated_height(gateway_id)
-    }
-
-    fn get_current_epoch(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<HeightResult<BlockNumber>, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::get_current_epoch(gateway_id)
-    }
-
-    fn read_fast_confirmation_offset(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<BlockNumber, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::read_fast_confirmation_offset(gateway_id)
-    }
-
-    fn read_rational_confirmation_offset(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<BlockNumber, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::read_rational_confirmation_offset(gateway_id)
-    }
-
-    fn read_epoch_offset(
-        gateway_id: t3rn_primitives::ChainId,
-    ) -> Result<BlockNumber, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::read_epoch_offset(gateway_id)
-    }
-
-    fn verify_event_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_event_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_state_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_state_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_tx_inclusion(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_tx_inclusion(
-            gateway_id,
-            message,
-            submission_target_height,
-        )
-    }
-
-    fn verify_state_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_state_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-
-    fn verify_tx_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_tx_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-
-    fn verify_event_inclusion_and_recode(
-        gateway_id: [u8; 4],
-        message: Bytes,
-        submission_target_height: Option<BlockNumber>,
-        abi_descriptor: Bytes,
-        out_codec: Codec,
-    ) -> Result<Bytes, DispatchError> {
-        <Portal as PortalReadApi<BlockNumber>>::verify_event_inclusion_and_recode(
-            gateway_id,
-            message,
-            submission_target_height,
-            abi_descriptor,
-            out_codec,
-        )
-    }
-}
-
 parameter_types! {
     pub const ChainId: u64 = 42;
     pub BlockGasLimit: U256 = U256::from(u32::max_value());
-    pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime, BlockNumber> = evm_precompile_util::Precompiles::new(sp_std::vec![
+    pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
         (0_u64, evm_precompile_util::KnownPrecompile::ECRecover),
         (1_u64, evm_precompile_util::KnownPrecompile::Sha256),
         (2_u64, evm_precompile_util::KnownPrecompile::Ripemd160),
@@ -270,8 +143,7 @@ parameter_types! {
         (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
         (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
         (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-    ].into_iter().collect(), sp_std::vec![
-        (819_u64, evm_precompile_util::CustomPrecompile::<Runtime, BlockNumber>::Portal),
+        (40_u64, evm_precompile_util::KnownPrecompile::Portal)
     ].into_iter().collect());
 }
 
@@ -289,7 +161,7 @@ impl pallet_3vm_evm::Config for Runtime {
     type FindAuthor = FindAuthorTruncated<Aura>;
     type GasWeightMapping = FixedGasWeightMapping;
     type OnChargeTransaction = ThreeVMCurrencyAdapter<Balances, ()>;
-    type PrecompilesType = evm_precompile_util::Precompiles<Self, BlockNumber>;
+    type PrecompilesType = evm_precompile_util::Precompiles<Self>;
     type PrecompilesValue = PrecompilesValue;
     type Runner = pallet_3vm_evm::runner::stack::Runner<Self>;
     type ThreeVm = ThreeVm;

--- a/runtime/standalone/src/contracts_config.rs
+++ b/runtime/standalone/src/contracts_config.rs
@@ -1,7 +1,7 @@
 use crate::{
     accounts_config::EscrowAccount, AccountId, AccountManager, AssetId, Aura, Balance, Balances,
-    BlockNumber, BlockWeights, Call, Circuit, ContractsRegistry, Event, Portal,
-    RandomnessCollectiveFlip, Runtime, ThreeVm, Timestamp, Weight, AVERAGE_ON_INITIALIZE_RATIO,
+    BlockWeights, Call, Circuit, ContractsRegistry, Event, Portal, RandomnessCollectiveFlip,
+    Runtime, ThreeVm, Timestamp, Weight, AVERAGE_ON_INITIALIZE_RATIO,
 };
 use frame_support::{pallet_prelude::ConstU32, parameter_types, traits::FindAuthor};
 use pallet_3vm_contracts::weights::WeightInfo;
@@ -11,12 +11,10 @@ use pallet_3vm_evm::{
 };
 use pallet_3vm_evm_primitives::FeeCalculator;
 use sp_core::{H160, U256};
-use sp_runtime::{ConsensusEngineId, DispatchError, RuntimeAppPublic};
+use sp_runtime::{ConsensusEngineId, RuntimeAppPublic};
 
 #[cfg(feature = "std")]
 pub use pallet_3vm_evm_primitives::GenesisAccount as EvmGenesisAccount;
-use t3rn_abi::{types::Bytes, Codec};
-use t3rn_primitives::portal::{HeaderResult, HeightResult};
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;

--- a/runtime/t0rn-parachain/src/contracts_config.rs
+++ b/runtime/t0rn-parachain/src/contracts_config.rs
@@ -12,12 +12,10 @@ use pallet_3vm_evm::{
 };
 use pallet_3vm_evm_primitives::FeeCalculator;
 use sp_core::{H160, U256};
-use sp_runtime::{ConsensusEngineId, DispatchError, RuntimeAppPublic};
+use sp_runtime::{ConsensusEngineId, RuntimeAppPublic};
 
 #[cfg(feature = "std")]
 pub use pallet_3vm_evm_primitives::GenesisAccount as EvmGenesisAccount;
-use t3rn_abi::{types::Bytes, Codec};
-use t3rn_primitives::portal::{HeaderResult, HeightResult};
 
 // Unit = the base number of indivisible units for balances
 const UNIT: Balance = 1_000_000_000_000;
@@ -144,7 +142,7 @@ parameter_types! {
         (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
         (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
         (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-        (40_u64, evm_precompile_util::KnownPrecompile::Portal)
+        (10_u64, evm_precompile_util::KnownPrecompile::Portal)
     ].into_iter().collect());
 }
 

--- a/types/abi/src/recode.rs
+++ b/types/abi/src/recode.rs
@@ -22,6 +22,26 @@ pub enum Codec {
     Scale,
     Rlp,
 }
+
+impl From<u8> for Codec {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Codec::Scale,
+            1 => Codec::Rlp,
+            _ => Codec::default(),
+        }
+    }
+}
+
+impl From<Codec> for u8 {
+    fn from(value: Codec) -> Self {
+        match value {
+            Codec::Scale => 0,
+            Codec::Rlp => 1,
+        }
+    }
+}
+
 // Implementable Recode trait for each codec.
 pub trait Recode {
     fn chop_encoded(


### PR DESCRIPTION
# Summary of changes

Moves the portal precompiles into 3vm

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [x] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

This refactors the precompile to use pre-defined indexes from primitives. Moves a lot of the responsibility for making the precompile arguments into the module itself and moves the tests too.

Unfortunately, due to an oversight in RLP, I have disabled most 3vm calls coming from precompiles since they never actually worked. I need to make a ticket for us to RLP-recode every call through ABI, much like the same way we do with this portal module.

Adds some logging to portal.

Allows extracting the callee from the precompile. NOTE: We currently manually use the 12-byte appendix since it isn't smart to reinject the weight mapping into 3vm. Ideally, we figure out a nicer place to put the weight mapping to avoid cyclic dependencies.

Here's the encoded call to test on standalone for self-verification, just decode this in PJS:
`0x7901000000000000000000000000000000000000000a1400343434340000000000000000000000000000000000000000000000000000000000000000404b4c00000000006400000000000000000000000000000000000000000000000000000000000000000000`

Made EVM stop returning OK for everything 🔢 

## Screenshots (Please demonstrate this working in PolkadotJS)

no gateway:

![image](https://user-images.githubusercontent.com/37594653/233343534-8c72afdd-685c-4197-bd8d-6504e55b296d.png)

gateway:

![image](https://user-images.githubusercontent.com/37594653/233343585-3a4251a3-0474-4466-aa2f-d9f7e9a7a4ce.png)
