### PR TITLE
ci(gha): wait for release to finish before merge [skip release]

### DIFF
--- a/.github/workflows/release-lock.yml
+++ b/.github/workflows/release-lock.yml
@@ -1,0 +1,15 @@
+# This is dummy GHA that waits for release concurrency to finish
+# Reason behind it is that after release is finished, we want to commit cargo release changes and changelog
+# So anything in merge queue needs to wait for release to finish
+name: Wait for Release to Finish
+
+on:
+  merge_group:
+
+jobs:
+  release:
+    runs-on: self-hosted
+    concurrency: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3

--- a/.github/workflows/runtime-upgrade-t0rn.yml
+++ b/.github/workflows/runtime-upgrade-t0rn.yml
@@ -78,11 +78,11 @@ jobs:
           to: ${{ secrets.TELEGRAM_T0RN_CHAT_ID }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
           message: |
-            🚀 t0rn Runtime Upgrade
+            🚀 t0rn Runtime Upgrade ${{ env.PUSHED_TAG }}
             
             Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.PUSHED_TAG }}
             Monitoring: https://monitoring.t3rn.io/d/HyX9GHGVz/chain-statistics?orgId=1&refresh=1m&var-parachain=${{ env.PARACHAIN_NAME }}&var-region=All
-            This github action run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Github Action Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   ranger-deploy:
     runs-on: self-hosted


### PR DESCRIPTION
# Summary of changes

This is dummy GHA that waits for release concurrency to finish
Reason behind it is that after release is finished, we want to commit cargo release changes and changelog
So anything in merge queue needs to wait for release to finish

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Chore: Minor changes to GitHub Actions workflows for improved readability and documentation.

> "A few small tweaks, a little bit of care,
> Our GitHub Actions now have flair!
> With comments and descriptions, clear as can be,
> Our code is now more readable, you'll see!"
<!-- end of auto-generated comment: release notes by openai -->