### PR TITLE
ci(gha): run zombienet test only before runtime upgrade

### DIFF
--- a/.github/workflows/test-circuit.yml
+++ b/.github/workflows/test-circuit.yml
@@ -131,6 +131,7 @@ jobs:
     name: Zombienet Smoke Test
     runs-on: [self-hosted, rust]
     needs: [changes, build-test]
+    # zombienet is always run before runtime upgrade so any additional run on development is superfluous
     if: needs.changes.outputs.src == 'true' && github.ref != 'refs/heads/development'
     steps:
       - name: ☁️ Checkout git repo

--- a/.github/workflows/test-circuit.yml
+++ b/.github/workflows/test-circuit.yml
@@ -131,7 +131,7 @@ jobs:
     name: Zombienet Smoke Test
     runs-on: [self-hosted, rust]
     needs: [changes, build-test]
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' && github.ref != 'refs/heads/development'
     steps:
       - name: ☁️ Checkout git repo
         uses: actions/checkout@v3


### PR DESCRIPTION
# Summary of changes

Rationale: zombienet is always run before runtime upgrade so any additional run on development is superfluous.
This will lower the pressure on our github runners

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- CI pipeline logic modified to run smoke test job only if changes are made to the source code and branch is not development.
- Superfluous test step removed from CI pipeline.

🎉 "Changes made with care, 
CI pipeline now aware. 
Smoke tests run with precision, 
Code quality on a mission." 🎉
<!-- end of auto-generated comment: release notes by openai -->