### PR TITLE
feat: integrate attesters with SFX protocol & rewards: prevent collusion with repatriation & slash 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6034,8 +6034,10 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
+ "t3rn-abi",
  "t3rn-mini-mock-runtime",
  "t3rn-primitives",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -12785,6 +12787,7 @@ dependencies = [
  "pallet-attesters",
  "pallet-aura",
  "pallet-balances",
+ "pallet-circuit",
  "pallet-clock",
  "pallet-contracts 4.0.0-dev",
  "pallet-grandpa-finality-verifier",

--- a/pallets/attesters/Cargo.toml
+++ b/pallets/attesters/Cargo.toml
@@ -11,7 +11,8 @@ version     = "1.9.0-rc.0"
 targets = [ "x86_64-unknown-linux-gnu" ]
 
 [dependencies]
-frame-support      = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.27' }
+tiny-keccak       = "2.0.0"
+frame-support     = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.27' }
 frame-system      = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.27' }
 
 scale-info       = { version = "2.1.1", default-features = false, features = [ "derive" ] }

--- a/pallets/attesters/Cargo.toml
+++ b/pallets/attesters/Cargo.toml
@@ -29,6 +29,8 @@ sp-application-crypto = { default-features = false, git = "https://github.com/pa
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = 'polkadot-v0.9.27', optional = true }
 
 t3rn-primitives = { path = "../../primitives", default-features = false }
+t3rn-abi        = { path = "../../types/abi", default-features = false }
+
 [dev-dependencies]
 hex                             = "0.4.2"
 hex-literal                     = "0.2.1"
@@ -48,9 +50,10 @@ std = [
     "frame-support/std",
     "frame-system/std",
     "t3rn-primitives/std",
+    "t3rn-abi/std",
 ]
 
-try-runtime = [ "frame-support/try-runtime", "frame-system/try-runtime" ]
+try-runtime = [ "frame-support/try-runtime", "frame-system/try-runtime", "t3rn-abi/std" ]
 
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
@@ -58,3 +61,5 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks"
 ]
+
+test-skip-verification = [ ]

--- a/pallets/attesters/README.md
+++ b/pallets/attesters/README.md
@@ -1,0 +1,99 @@
+# pallet-attesters
+
+`pallet-attesters` is a Substrate module designed for managing attesters in a blockchain network. It provides APIs for registering attesters, nominating them, and handling slash risks.
+
+## API
+
+`pallet-attesters` provides the following extrinsics:
+
+- `register_attester`: Register a new attester.
+- `deregister_attester`: Deregister an attester.
+- `nominate`: Nominate an attester.
+- `submit_attestation`: Submit an attestation.
+- `commit_batch`: Commit a batch of attestations.
+
+## Registering an Attester
+
+To register a new attester, call the `register_attester` function. The new attester will then be added to the attesters list.
+
+The function takes in the following parameters:
+
+- `origin`: The origin of the call (i.e., the account of the new attester).
+- `self_nominate_amount`: The balance that the attester is willing to nominate themselves with.
+- `ecdsa_key`: The ECDSA key of the attester.
+- `ed25519_key`: The ED25519 key of the attester.
+- `sr25519_key`: The SR25519 key of the attester.
+- `custom_commission`: An optional parameter specifying the commission rate of the attester.
+
+Here's an example of how to call `register_attester` using Polkadot.js:
+
+```javascript
+const attesterAccountId = ... // The accountId of the attester
+const selfNominateAmount = ... // The amount the attester wants to nominate themselves with
+const ecdsaKey = ... // The ECDSA key of the attester
+const ed25519Key = ... // The ED25519 key of the attester
+const sr25519Key = ... // The SR25519 key of the attester
+const customCommission = ... // The custom commission rate of the attester
+
+await api.tx.palletAttesters.registerAttester(attesterAccountId, selfNominateAmount, ecdsaKey, ed25519Key, sr25519Key, customCommission).signAndSend(sender);
+```
+
+## Deregistering an Attester
+To deregister an attester, call the deregister_attester function. This will remove the attester from the attesters list.
+
+Here's an example of how to call deregister_attester using Polkadot.js:
+
+```javascript
+await api.tx.palletAttesters.deregisterAttester().signAndSend(attesterAccountId);
+``` 
+
+## Nominating an Attester
+To nominate an attester, call the nominate function. The nomination will then be added to the attester's nominations list.
+
+The function takes in the following parameters:
+
+- `origin`: The origin of the call (i.e., the account of the nominator).
+- `attester`: The account ID of the attester to nominate.
+- `amount`: The amount to nominate.
+
+Here's an example of how to call nominate using Polkadot.js:
+
+```javascript
+const nominatorAccountId = ... // The accountId of the nominator
+const attesterAccountId = ... // The accountId of the attester to nominate
+const nominationAmount = ... // The amount to nominate
+
+await api.tx.palletAttesters.nominate(nominatorAccountId, attesterAccountId, nominationAmount).signAndSend(sender);
+```
+
+## Committing a Batch of Attestations
+To commit a batch of attestations, call the commit_batch function.
+
+The function takes in the following parameters:
+
+origin: The origin of the call (i.e., the account of the committer).
+target: The target of the attestations.
+target_inclusion_proof_encoded: The encoded inclusion proof of the target.
+Here's an example of how to call commit_batch using Polkadot.js:
+
+```javascript
+const committerAccountId = ... // The accountId of the committer
+const target = ... // The target of the attestations
+const targetInclusionProofEncoded = ... // The encoded inclusion proof of the target
+
+await api.tx.palletAttesters.commitBatch(committerAccountId, target, targetInclusionProofEncoded).signAndSend(sender);
+```
+
+## Handling Slash Risk
+
+Attesters carry the risk of being slashed for misbehavior. This module provides two functions for handling slash: apply_partial_slash and apply_permanent_slash.
+
+### Partial Slash
+The apply_partial_slash function applies a partial slash on an attester based on a given percentage. The slash is applied to both the attester's balance and the nomination balances of their nominators. This function is useful for discouraging misbehavior without completely disincentivizing participation.
+
+### Permanent Slash
+The apply_permanent_slash function applies a permanent slash on an attester. The attester's balance and the nomination balances of their nominators are completely slashed. This function is useful for dealing with severe misbehavior.
+
+### Risk of Slashing
+
+Becoming an attester carries the risk of slashing if the attester misbehaves or colludes with others. Slashing reduces the attester's balance and the nomination balances of their nominators. In severe cases, attesters may be permanently slashed, completely eliminating their balance and their nominators' balances. Therefore, it is crucial for attesters to behave honestly and for nominators to carefully choose the attesters they nominate.

--- a/pallets/attesters/src/lib.rs
+++ b/pallets/attesters/src/lib.rs
@@ -35,7 +35,7 @@ pub mod pallet {
         CommitteeTransition, PublicKeyEcdsa33b, Signature65b, COMMITTEE_SIZE,
         ECDSA_ATTESTER_KEY_TYPE_ID, ED25519_ATTESTER_KEY_TYPE_ID, SR25519_ATTESTER_KEY_TYPE_ID,
     };
-    use t3rn_primitives::{portal::Portal, xdns::Xdns};
+    use t3rn_primitives::{circuit::ReadSFX, portal::Portal, xdns::Xdns};
 
     #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo, PartialOrd)]
     pub enum BatchStatus {
@@ -140,6 +140,7 @@ pub mod pallet {
         type MinNominatorBond: Get<BalanceOf<Self>>;
         type MinAttesterBond: Get<BalanceOf<Self>>;
         type Portal: Portal<Self>;
+        type ReadSFX: ReadSFX<Self::Hash, Self::AccountId, BalanceOf<Self>, Self::BlockNumber>;
         type Xdns: Xdns<Self>;
     }
 

--- a/pallets/attesters/src/lib.rs
+++ b/pallets/attesters/src/lib.rs
@@ -96,8 +96,9 @@ pub mod pallet {
 
     #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
     pub enum Slash<BlockNumber> {
+        // Slash for not submitting attestations
         LateOrNoSubmissionAtBlocks(Vec<BlockNumber>),
-        // Permanent slash
+        // Permanent Slash for submitting invalid attestations
         Permanent,
     }
 

--- a/pallets/circuit/src/machine/mod.rs
+++ b/pallets/circuit/src/machine/mod.rs
@@ -426,6 +426,9 @@ impl<T: Config> Machine<T> {
             return false
         }
 
+        let mut mutate_xexec = false;
+        let mut mutate_fsx = false;
+
         match (old_status, new_status) {
             (CircuitStatus::Requested, CircuitStatus::Reserved | CircuitStatus::PendingBidding) => {
                 let steps_side_effects_ids: Vec<(

--- a/pallets/circuit/src/machine/mod.rs
+++ b/pallets/circuit/src/machine/mod.rs
@@ -426,9 +426,6 @@ impl<T: Config> Machine<T> {
             return false
         }
 
-        let mut mutate_xexec = false;
-        let mut mutate_fsx = false;
-
         match (old_status, new_status) {
             (CircuitStatus::Requested, CircuitStatus::Reserved | CircuitStatus::PendingBidding) => {
                 let steps_side_effects_ids: Vec<(

--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -1297,6 +1297,7 @@ pub mod test {
                 &MiniRuntime::get_treasury_account(TreasuryAccount::Slash),
                 SLASH_TREASURY_BALANCE,
             );
+
             let fsx = FullSideEffect {
                 input: SideEffect {
                     enforce_executor: Some(executor.clone()),

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -432,6 +432,13 @@ pub mod pallet {
             }
         }
 
+        fn get_target_codec(chain_id: &ChainId) -> Result<Codec, DispatchError> {
+            match <Gateways<T>>::get(chain_id) {
+                Some(rec) => Ok(rec.codec),
+                None => Err(Error::<T>::XdnsRecordNotFound.into()),
+            }
+        }
+
         fn get_escrow_account(chain_id: &ChainId) -> Result<Bytes, DispatchError> {
             match <Gateways<T>>::get(chain_id) {
                 Some(rec) => Ok(rec.escrow_account.encode()),

--- a/primitives/src/attesters.rs
+++ b/primitives/src/attesters.rs
@@ -63,7 +63,8 @@ pub trait AttestersWriteApi<Account, Error> {
     fn request_add_attesters_attestation(add_attester: &Account) -> Result<(), Error>;
     fn request_ban_attesters_attestation(ban_attesters: &Account) -> Result<(), Error>;
     fn request_remove_attesters_attestation(remove_attesters: &Account) -> Result<(), Error>;
-    fn request_next_committee_attestation(next_committee: CommitteeTransition);
+    fn request_next_committee_attestation(next_committee: CommitteeTransition)
+        -> Result<(), Error>;
 }
 
 pub trait AttestersReadApi<Account, Balance> {
@@ -98,11 +99,11 @@ impl<Account, Balance> AttestersReadApi<Account, Balance>
         vec![]
     }
 
-    fn read_attester_info(_attester: &Account) -> Option<AttesterInfo> {
+    fn read_attester_info(attester: &Account) -> Option<AttesterInfo> {
         None
     }
 
-    fn read_nominations(_for_attester: &Account) -> Vec<(Account, Balance)> {
+    fn read_nominations(for_attester: &Account) -> Vec<(Account, Balance)> {
         vec![]
     }
 }

--- a/primitives/src/attesters.rs
+++ b/primitives/src/attesters.rs
@@ -63,8 +63,7 @@ pub trait AttestersWriteApi<Account, Error> {
     fn request_add_attesters_attestation(add_attester: &Account) -> Result<(), Error>;
     fn request_ban_attesters_attestation(ban_attesters: &Account) -> Result<(), Error>;
     fn request_remove_attesters_attestation(remove_attesters: &Account) -> Result<(), Error>;
-    fn request_next_committee_attestation(next_committee: CommitteeTransition)
-        -> Result<(), Error>;
+    fn request_next_committee_attestation(next_committee: CommitteeTransition);
 }
 
 pub trait AttestersReadApi<Account, Balance> {
@@ -99,11 +98,11 @@ impl<Account, Balance> AttestersReadApi<Account, Balance>
         vec![]
     }
 
-    fn read_attester_info(attester: &Account) -> Option<AttesterInfo> {
+    fn read_attester_info(_attester: &Account) -> Option<AttesterInfo> {
         None
     }
 
-    fn read_nominations(for_attester: &Account) -> Vec<(Account, Balance)> {
+    fn read_nominations(_for_attester: &Account) -> Vec<(Account, Balance)> {
         vec![]
     }
 }

--- a/primitives/src/circuit/types.rs
+++ b/primitives/src/circuit/types.rs
@@ -8,12 +8,11 @@ use frame_support::dispatch::DispatchError;
 use frame_system::Config;
 use scale_info::TypeInfo;
 use sp_core::Hasher;
-use sp_runtime::{traits::Zero, RuntimeDebug};
-use sp_std::{default::Default, fmt::Debug, prelude::*};
-use t3rn_types::sfx::FullSideEffect;
-
 #[cfg(feature = "no_std")]
 use sp_runtime::RuntimeDebug as Debug;
+use sp_runtime::{traits::Zero, RuntimeDebug};
+use sp_std::{default::Default, fmt::Debug, prelude::*};
+pub use t3rn_types::sfx::{FullSideEffect, SecurityLvl, SideEffect};
 
 type SystemHashing<T> = <T as Config>::Hashing;
 

--- a/primitives/src/claimable.rs
+++ b/primitives/src/claimable.rs
@@ -24,6 +24,7 @@ pub enum BenefitSource {
     TrafficFees,
     TrafficRewards,
     Unsettled,
+    SlashTreasury,
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -54,6 +54,7 @@ pub mod light_client;
 pub mod match_format;
 pub mod monetary;
 pub mod portal;
+pub mod rewards;
 pub mod signature_caster;
 pub mod storage;
 pub mod threevm;

--- a/primitives/src/rewards.rs
+++ b/primitives/src/rewards.rs
@@ -1,0 +1,8 @@
+use frame_support::pallet_prelude::*;
+use sp_core::H256;
+use sp_std::prelude::*;
+
+pub trait RewardsWriteApi<Account, Error> {
+    fn repatriate_executors_from_slash_treasury(sfx_id: &H256) -> bool;
+    fn repatriate_requesters_from_slash_treasury(sfx_id: &H256) -> bool;
+}

--- a/primitives/src/rewards.rs
+++ b/primitives/src/rewards.rs
@@ -1,6 +1,4 @@
-use frame_support::pallet_prelude::*;
 use sp_core::H256;
-use sp_std::prelude::*;
 use t3rn_types::fsx::FullSideEffect;
 
 pub trait RewardsWriteApi<Account, Balance, BlockNumber> {

--- a/primitives/src/rewards.rs
+++ b/primitives/src/rewards.rs
@@ -1,8 +1,11 @@
 use frame_support::pallet_prelude::*;
 use sp_core::H256;
 use sp_std::prelude::*;
+use t3rn_types::fsx::FullSideEffect;
 
-pub trait RewardsWriteApi<Account, Error> {
-    fn repatriate_executors_from_slash_treasury(sfx_id: &H256) -> bool;
-    fn repatriate_requesters_from_slash_treasury(sfx_id: &H256) -> bool;
+pub trait RewardsWriteApi<Account, Balance, BlockNumber> {
+    fn repatriate_executor_from_slash_treasury(
+        sfx_id: &H256,
+        fsx: &FullSideEffect<Account, BlockNumber, Balance>,
+    ) -> bool;
 }

--- a/primitives/src/xdns.rs
+++ b/primitives/src/xdns.rs
@@ -254,6 +254,8 @@ pub trait Xdns<T: frame_system::Config> {
 
     fn get_verification_vendor(chain_id: &ChainId) -> Result<GatewayVendor, DispatchError>;
 
+    fn get_target_codec(chain_id: &ChainId) -> Result<t3rn_abi::Codec, DispatchError>;
+
     fn get_escrow_account(chain_id: &ChainId) -> Result<Vec<u8>, DispatchError>;
 
     fn fetch_full_gateway_records() -> Vec<FullGatewayRecord<T::AccountId>>;

--- a/runtime/mini-mock/Cargo.toml
+++ b/runtime/mini-mock/Cargo.toml
@@ -53,6 +53,7 @@ pallet-treasury   = { git = "https://github.com/paritytech/substrate.git", branc
 pallet-clock = { path = "../../pallets/clock" }
 pallet-grandpa-finality-verifier = { path = "../../finality-verifiers/grandpa" }
 pallet-portal                    = { path = "../../pallets/portal" }
+pallet-circuit                   = { path = "../../pallets/circuit" }
 pallet-xdns                      = { path = "../../pallets/xdns" }
 pallet-account-manager           = { path = "../../pallets/account-manager" }
 pallet-attesters                 = { path = "../../pallets/attesters" }

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -1,10 +1,9 @@
 use codec::{Decode, Encode};
 use frame_support::{traits::FindAuthor, RuntimeDebug};
 pub use pallet_attesters::{
-    ActiveSet, Attestation, AttestationFor, AttestationStatus, AttestationTargets, Attestations,
-    Attesters as AttestersStore, BatchMessage, BatchStatus, Batches, Config as ConfigAttesters,
-    CurrentCommittee, Error as AttestersError, NextBatch, Nominations, PendingSlashes,
-    PendingUnnominations, PreviousCommittee, SortedNominatedAttesters,
+    ActiveSet, AttestationTargets, Attesters as AttestersStore, BatchMessage, BatchStatus, Batches,
+    Config as ConfigAttesters, CurrentCommittee, Error as AttestersError, NextBatch, Nominations,
+    PendingSlashes, PendingUnnominations, PreviousCommittee, SortedNominatedAttesters,
 };
 
 mod treasuries_config;

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -202,10 +202,12 @@ impl pallet_attesters::Config for MiniRuntime {
     type MaxBatchSize = ConstU32<128>;
     type MinAttesterBond = MinAttesterBond;
     type MinNominatorBond = MinNominatorBond;
+    type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = SlashAccount;
+    type Xdns = XDNS;
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for MiniRuntime {}

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -5,7 +5,7 @@ pub use pallet_attesters::{
     Config as ConfigAttesters, CurrentCommittee, Error as AttestersError, NextBatch, Nominations,
     PendingSlashes, PendingUnnominations, PreviousCommittee, SortedNominatedAttesters,
 };
-
+pub use pallet_circuit::{Config as ConfigCircuit, FullSideEffects, SFX2XTXLinksMap, XExecSignals};
 mod treasuries_config;
 
 pub use pallet_account_manager::{
@@ -208,7 +208,9 @@ impl pallet_attesters::Config for MiniRuntime {
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type ReadSFX = Circuit;
+    type RepatriationPeriod = ConstU32<60>;
     type RewardMultiplier = RewardMultiplier;
+    type Rewards = Rewards;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = SlashAccount;
     type Xdns = XDNS;

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -65,6 +65,7 @@ frame_support::construct_runtime!(
         Rewards: pallet_rewards = 102,
         AccountManager: pallet_account_manager = 103,
         Clock: pallet_clock = 104,
+        Circuit: pallet_circuit = 105,
         // Portal
         Portal: pallet_portal = 128,
         RococoBridge: pallet_grandpa_finality_verifier = 129,
@@ -204,6 +205,7 @@ impl pallet_attesters::Config for MiniRuntime {
     type MinNominatorBond = MinNominatorBond;
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
+    type ReadSFX = Circuit;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = SlashAccount;
@@ -298,6 +300,31 @@ impl pallet_xdns::Config for MiniRuntime {
     type Event = Event;
     type Time = Timestamp;
     type WeightInfo = pallet_xdns::weights::SubstrateWeight<MiniRuntime>;
+}
+
+parameter_types! {
+    pub const CircuitAccountId: AccountId = AccountId::new([51u8; 32]); // 0x333...3
+    pub const SelfGatewayId: [u8; 4] = [3, 3, 3, 3];
+}
+
+impl pallet_circuit::Config for MiniRuntime {
+    type AccountManager = AccountManager;
+    type Balances = Balances;
+    type Call = Call;
+    type Currency = Balances;
+    type DeletionQueueLimit = ConstU32<100u32>;
+    type Event = Event;
+    type Executors = t3rn_primitives::executors::ExecutorsMock<Self>;
+    type Portal = Portal;
+    type SFXBiddingPeriod = ConstU32<3u32>;
+    type SelfAccountId = CircuitAccountId;
+    type SelfGatewayId = SelfGatewayId;
+    type SelfParaId = ConstU32<3333u32>;
+    type SignalQueueDepth = ConstU32<5u32>;
+    type WeightInfo = ();
+    type Xdns = XDNS;
+    type XtxTimeoutCheckInterval = ConstU32<10u32>;
+    type XtxTimeoutDefault = ConstU32<400u32>;
 }
 
 impl pallet_portal::Config for MiniRuntime {

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -139,6 +139,7 @@ parameter_types! {
     pub const AttesterBootstrapRewards: Percent = Percent::from_parts(40); // 40%
     pub const CollatorBootstrapRewards: Percent = Percent::from_parts(20); // 20%
     pub const ExecutorBootstrapRewards: Percent = Percent::from_parts(40); // 40%
+    pub const StartingRepatriationPercentage: Percent = Percent::from_parts(10); // 10%
     pub const OneYear: BlockNumber = 2_628_000; // (365.25 * 24 * 60 * 60) / 12; assuming 12s block time
     pub const InflationDistributionPeriod: BlockNumber = 100_800; // (14 * 24 * 60 * 60) / 12; assuming one distribution per two weeks
     pub const AvailableBootstrapSpenditure: Balance = 1_000_000 * (TRN as Balance); // 1 MLN UNIT
@@ -178,6 +179,7 @@ impl pallet_rewards::Config for MiniRuntime {
     type FindAuthor = FindAuthorMockRoundRobinRotate32;
     type InflationDistributionPeriod = InflationDistributionPeriod;
     type OneYear = OneYear;
+    type StartingRepatriationPercentage = StartingRepatriationPercentage;
     type TotalInflation = TotalInflation;
     type TreasuryAccounts = MiniRuntime;
     type TreasuryInflation = TreasuryInflation;
@@ -623,6 +625,12 @@ impl ExtBuilder {
         pallet_xdns::GenesisConfig::<MiniRuntime> {
             known_gateway_records: self.known_gateway_records,
             standard_sfx_abi: self.standard_sfx_abi,
+        }
+        .assimilate_storage(&mut t)
+        .expect("Pallet xdns can be assimilated");
+
+        pallet_rewards::GenesisConfig::<MiniRuntime> {
+            phantom: Default::default(),
         }
         .assimilate_storage(&mut t)
         .expect("Pallet xdns can be assimilated");

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -1,10 +1,10 @@
 use codec::{Decode, Encode};
 use frame_support::{traits::FindAuthor, RuntimeDebug};
 pub use pallet_attesters::{
-    ActiveSet, Attestation, AttestationFor, AttestationStatus, Attestations,
-    Attesters as AttestersStore, BatchStatus, Batches, Config as ConfigAttesters, CurrentCommittee,
-    Error as AttestersError, Nominations, PendingSlashes, PendingUnnominations, PreviousCommittee,
-    SortedNominatedAttesters,
+    ActiveSet, Attestation, AttestationFor, AttestationStatus, AttestationTargets, Attestations,
+    Attesters as AttestersStore, BatchMessage, BatchStatus, Batches, Config as ConfigAttesters,
+    CurrentCommittee, Error as AttestersError, NextBatch, Nominations, PendingSlashes,
+    PendingUnnominations, PreviousCommittee, SortedNominatedAttesters,
 };
 
 mod treasuries_config;

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -157,10 +157,12 @@ impl pallet_attesters::Config for Runtime {
     type MaxBatchSize = ConstU32<128>;
     type MinAttesterBond = MinAttesterBond;
     type MinNominatorBond = MinNominatorBond;
+    type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;
+    type Xdns = XDNS;
 }
 
 use t3rn_primitives::monetary::TRN;

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -159,6 +159,7 @@ impl pallet_attesters::Config for Runtime {
     type MinNominatorBond = MinNominatorBond;
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
+    type ReadSFX = Circuit;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -177,6 +177,7 @@ parameter_types! {
     pub const AttesterBootstrapRewards: Percent = Percent::from_parts(40); // 40%
     pub const CollatorBootstrapRewards: Percent = Percent::from_parts(20); // 20%
     pub const ExecutorBootstrapRewards: Percent = Percent::from_parts(40); // 40%
+    pub const StartingRepatriationPercentage: Percent = Percent::from_parts(10); // 10%
     pub const OneYear: BlockNumber = 2_628_000; // (365.25 * 24 * 60 * 60) / 12; assuming 12s block time
     pub const InflationDistributionPeriod: BlockNumber = 100_800; // (14 * 24 * 60 * 60) / 12; assuming one distribution per two weeks
     pub const AvailableBootstrapSpenditure: Balance = 1_000_000 * (TRN as Balance); // 1 MLN UNIT
@@ -198,6 +199,7 @@ impl pallet_rewards::Config for Runtime {
     type FindAuthor = ();
     type InflationDistributionPeriod = InflationDistributionPeriod;
     type OneYear = OneYear;
+    type StartingRepatriationPercentage = StartingRepatriationPercentage;
     type TotalInflation = TotalInflation;
     type TreasuryAccounts = Runtime;
     type TreasuryInflation = TreasuryInflation;

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -160,7 +160,9 @@ impl pallet_attesters::Config for Runtime {
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type ReadSFX = Circuit;
+    type RepatriationPeriod = ConstU32<60>;
     type RewardMultiplier = RewardMultiplier;
+    type Rewards = Rewards;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;
     type Xdns = XDNS;

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -150,6 +150,7 @@ impl pallet_attesters::Config for Runtime {
     type MinNominatorBond = MinNominatorBond;
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
+    type ReadSFX = Circuit;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -148,10 +148,12 @@ impl pallet_attesters::Config for Runtime {
     type MaxBatchSize = ConstU32<128>;
     type MinAttesterBond = MinAttesterBond;
     type MinNominatorBond = MinNominatorBond;
+    type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;
+    type Xdns = XDNS;
 }
 
 use t3rn_primitives::monetary::TRN;

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -168,6 +168,7 @@ parameter_types! {
     pub const AttesterBootstrapRewards: Percent = Percent::from_parts(40); // 40%
     pub const CollatorBootstrapRewards: Percent = Percent::from_parts(20); // 20%
     pub const ExecutorBootstrapRewards: Percent = Percent::from_parts(40); // 40%
+    pub const StartingRepatriationPercentage: Percent = Percent::from_parts(10); // 10%
     pub const OneYear: BlockNumber = 2_628_000; // (365.25 * 24 * 60 * 60) / 12; assuming 12s block time
     pub const InflationDistributionPeriod: BlockNumber = 100_800; // (14 * 24 * 60 * 60) / 12; assuming one distribution per two weeks
     pub const AvailableBootstrapSpenditure: Balance = 1_000_000 * (TRN as Balance); // 1 MLN UNIT
@@ -189,6 +190,7 @@ impl pallet_rewards::Config for Runtime {
     type FindAuthor = ();
     type InflationDistributionPeriod = InflationDistributionPeriod;
     type OneYear = OneYear;
+    type StartingRepatriationPercentage = StartingRepatriationPercentage;
     type TotalInflation = TotalInflation;
     type TreasuryAccounts = Runtime;
     type TreasuryInflation = TreasuryInflation;

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -151,7 +151,9 @@ impl pallet_attesters::Config for Runtime {
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type ReadSFX = Circuit;
+    type RepatriationPeriod = ConstU32<60>;
     type RewardMultiplier = RewardMultiplier;
+    type Rewards = Rewards;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;
     type Xdns = XDNS;

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -147,10 +147,12 @@ impl pallet_attesters::Config for Runtime {
     type MaxBatchSize = ConstU32<128>;
     type MinAttesterBond = MinAttesterBond;
     type MinNominatorBond = MinNominatorBond;
+    type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;
+    type Xdns = XDNS;
 }
 
 use t3rn_primitives::monetary::TRN;

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -1,6 +1,6 @@
 use crate::{
     AccountId, AccountManager, Attesters, Aura, Balance, Balances, BlockNumber, Call, Circuit,
-    Clock, Event, Portal, RandomnessCollectiveFlip, Runtime, Timestamp, XDNS,
+    Clock, Event, Portal, RandomnessCollectiveFlip, Rewards, Runtime, Timestamp, XDNS,
 };
 use sp_runtime::Percent;
 use sp_std::marker::PhantomData;
@@ -150,7 +150,9 @@ impl pallet_attesters::Config for Runtime {
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
     type ReadSFX = Circuit;
+    type RepatriationPeriod = ConstU32<60>;
     type RewardMultiplier = RewardMultiplier;
+    type Rewards = Rewards;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;
     type Xdns = XDNS;

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -167,6 +167,7 @@ parameter_types! {
     pub const AttesterBootstrapRewards: Percent = Percent::from_parts(40); // 40%
     pub const CollatorBootstrapRewards: Percent = Percent::from_parts(20); // 20%
     pub const ExecutorBootstrapRewards: Percent = Percent::from_parts(40); // 40%
+    pub const StartingRepatriationPercentage: Percent = Percent::from_parts(10); // 10%
     pub const OneYear: BlockNumber = 2_628_000; // (365.25 * 24 * 60 * 60) / 12; assuming 12s block time
     pub const InflationDistributionPeriod: BlockNumber = 100_800; // (14 * 24 * 60 * 60) / 12; assuming one distribution per two weeks
     pub const AvailableBootstrapSpenditure: Balance = 1_000_000 * (TRN as Balance); // 1 MLN UNIT
@@ -188,6 +189,7 @@ impl pallet_rewards::Config for Runtime {
     type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
     type InflationDistributionPeriod = InflationDistributionPeriod;
     type OneYear = OneYear;
+    type StartingRepatriationPercentage = StartingRepatriationPercentage;
     type TotalInflation = TotalInflation;
     type TreasuryAccounts = Runtime;
     type TreasuryInflation = TreasuryInflation;

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -149,6 +149,7 @@ impl pallet_attesters::Config for Runtime {
     type MinNominatorBond = MinNominatorBond;
     type Portal = Portal;
     type RandomnessSource = RandomnessCollectiveFlip;
+    type ReadSFX = Circuit;
     type RewardMultiplier = RewardMultiplier;
     type ShufflingFrequency = ConstU32<400>;
     type SlashAccount = EscrowAccount;


### PR DESCRIPTION
# Summary of changes

Extend the work on requesting repatriations to pallet-rewards (#PR993) and integrate pallet-attesters to request for reiterations to honest SFX executors after attestations haven't been provided within the RepatrationPeriod. 

- connect pallet-attesters with Circuit via ReadSFX API 
- connect pallet-attesters with Rewards via RewardsWrite API 

If it fixes a bug or creates a feature, link the issue.

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

New Feature: A new Substrate module, `pallet-attesters`, has been added to manage attesters in a blockchain network. It provides APIs for registering attesters, nominating them, and handling slash risks. The changes also add a new function to the pallet module that retrieves the codec of a given chain ID, as well as new types and traits to integrate with external APIs.

> "Attesters and rewards, now in sync,
> With Circuit and ReadSFX, no need to think.
> New functionality, carefully reviewed,
> Bugs and vulnerabilities, all subdued."
<!-- end of auto-generated comment: release notes by openai -->