### PR TITLE
ci(e2e): tests should not run when label e2e is not added atm

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -23,7 +23,8 @@ jobs:
   changes:
     runs-on: [self-hosted]
     # Run it only when e2e label is present in PR or in merge queue
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e') || github.event.pull_request.mergeable }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e') }}
+
     outputs:
       src: ${{ steps.changes.outputs.src }}
 


### PR DESCRIPTION
# Summary of changes

**_Summarize_** the description of your changes.

If it fixes a bug or creates a feature, link the issue.

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Chore: Modify e2e test workflow to run only when "e2e" label is present in the pull request. 

> "E2E tests now run with ease, 
> Only when the label's there to please."
<!-- end of auto-generated comment: release notes by openai -->