### PR TITLE
feat: error checking for test generation

### DIFF
--- a/client/packages/cli/src/commands/dgf.ts
+++ b/client/packages/cli/src/commands/dgf.ts
@@ -42,7 +42,7 @@ export const handleDgfCmd = async (
     const timeout = parseInt(args.timeout) ?? 30
     const start = Date.now()
 
-    listener.on("event", (eventData) => {
+    listener.on("error-event", (eventData) => {
       spinner.info(
         colorLogMsg(
           "INFO",

--- a/client/packages/cli/src/utils/dgf.ts
+++ b/client/packages/cli/src/utils/dgf.ts
@@ -195,7 +195,7 @@ const emitEvent = (
   notification: unknown,
   error = ErrorMode.None
 ) => {
-  listener.emit("event", <ListenerEventData>{
+  listener.emit("error-event", <ListenerEventData>{
     type: event,
     data: (
       notification as {

--- a/client/packages/executor/src/circuit/relayer.ts
+++ b/client/packages/executor/src/circuit/relayer.ts
@@ -88,6 +88,13 @@ export class CircuitRelayer extends EventEmitter {
       });
     }
 
+    // Under data generation scheme, mess up the payload proof, for example, 
+    // only if the signature contains the custom error to generate it.
+    const invalidProofCondition = sfx.signature === "InvalidProof"
+    if (invalidProofCondition) {
+      inclusionData.payload_proof = "0xMessedUpProof"
+    }
+
     const confirmedSideEffect: T3rnTypesSfxConfirmedSideEffect = createType(
       "T3rnTypesSfxConfirmedSideEffect",
       {

--- a/client/packages/executor/src/circuit/relayer.ts
+++ b/client/packages/executor/src/circuit/relayer.ts
@@ -25,7 +25,7 @@ export class CircuitRelayer extends EventEmitter {
 
   constructor(public sdk: Sdk) {
     super();
-    // @ts-ignore
+    // @ts-ignore local tsserver doesn't complain for me, but still here
     this.api = sdk.client
     this.sdk = sdk
     this.allowedTargets = ["roco"]

--- a/client/packages/executor/src/circuit/relayer.ts
+++ b/client/packages/executor/src/circuit/relayer.ts
@@ -17,13 +17,18 @@ import { T3rnTypesSfxConfirmedSideEffect } from "@polkadot/types/lookup";
 export class CircuitRelayer extends EventEmitter {
   static debug = createDebug("circuit-relayer");
 
-  api: ApiPromise;
-  id: string;
-  rpc: string;
+  api: ApiPromise
+  sdk: Sdk
+  id: string
+  rpc: string
+  allowedTargets: string[]
 
   constructor(public sdk: Sdk) {
     super();
-    this.api = sdk.client;
+    // @ts-ignore
+    this.api = sdk.client
+    this.sdk = sdk
+    this.allowedTargets = ["roco"]
   }
 
   /**
@@ -67,7 +72,8 @@ export class CircuitRelayer extends EventEmitter {
   createConfirmTx(sfx: SideEffect) {
     let inclusionData: ReturnType<typeof this.api.createType>;
 
-    if (sfx.target === "roco") {
+    // TODO: check that it doesn't only have to be "roco"
+    if (this.allowedTargets.includes(sfx.target)) {
       inclusionData = this.api.createType("RelaychainInclusionProof", {
         encoded_payload: sfx.inclusionProof.encoded_payload,
         payload_proof: sfx.inclusionProof.payload_proof,

--- a/client/packages/executor/src/circuit/relayer.ts
+++ b/client/packages/executor/src/circuit/relayer.ts
@@ -90,7 +90,8 @@ export class CircuitRelayer extends EventEmitter {
 
     // Under data generation scheme, mess up the payload proof, for example, 
     // only if the signature contains the custom error to generate it.
-    const invalidProofCondition = sfx.raw.signature === "InvalidProof"
+    const encoder = new TextEncoder()
+    const invalidProofCondition = sfx.raw.signature === encoder.encode("InvalidProof")
     if (invalidProofCondition) {
       inclusionData.payload_proof = "0xMessedUpProof"
     }

--- a/client/packages/executor/src/circuit/relayer.ts
+++ b/client/packages/executor/src/circuit/relayer.ts
@@ -90,7 +90,7 @@ export class CircuitRelayer extends EventEmitter {
 
     // Under data generation scheme, mess up the payload proof, for example, 
     // only if the signature contains the custom error to generate it.
-    const invalidProofCondition = sfx.signature === "InvalidProof"
+    const invalidProofCondition = sfx.raw.signature === "InvalidProof"
     if (invalidProofCondition) {
       inclusionData.payload_proof = "0xMessedUpProof"
     }

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -368,7 +368,8 @@ export class ExecutionManager {
 
       // In the error generating scheme, when ErrorMode.NoBidders, 
       // do NOT add the sfx to the queue for bidding.
-      const noBiddersCondition = sfx.raw.signature === "NoBidders";
+      const encoder = new TextEncoder()
+      const noBiddersCondition = sfx.raw.signature === encoder.encode("NoBidders");
       if (noBiddersCondition) {
         this.sfxToXtx[sfxId] = xtx.id;
         this.queue[sfx.vendor].isBidding.push(sfxId);
@@ -580,7 +581,8 @@ export class ExecutionManager {
       if (sfx.phase === this.xtx[sfx.xtxId].currentPhase) {
         // In the data generation framework, if ErrorMode.ConfirmationTimeout is set
         // we filter OUT them from the confirmation queue
-        const confirmationTimeoutCondition = sfx.raw.signature === "ConfirmationTimeout";
+        const encoder = new TextEncoder()
+        const confirmationTimeoutCondition = sfx.raw.signature === encoder.encode("ConfirmationTimeout");
         if (!confirmationTimeoutCondition) {
           readyByStep.push(sfx);
         }

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -171,12 +171,13 @@ export class ExecutionManager {
           this.circuitListener.once("Event", recheckQueue);
         }
       }
-    };
-
-    return new Promise((resolve) => {
-      this.circuitListener.once("Event", recheckQueue);
-      recheckQueue(this, resolve);
-    });
+    }
+      // FIXME unreachable code
+      // return new Promise((resolve) => {
+      //   this.circuitListener.once("Event", recheckQueue);
+      //   recheckQueue(this, resolve);
+      // });
+    )
   }
 
   initializeVendors(vendors: string[]) {

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -379,7 +379,7 @@ export class ExecutionManager {
 
       // In the error generating scheme, when ErrorMode.NoBidders, 
       // do NOT add the sfx to the queue for bidding.
-      const noBiddersCondition = sfx.signature === "NoBidders";
+      const noBiddersCondition = sfx.raw.signature === "NoBidders";
       if (noBiddersCondition) {
         this.sfxToXtx[sfxId] = xtx.id;
         this.queue[sfx.vendor].isBidding.push(sfxId);
@@ -591,7 +591,7 @@ export class ExecutionManager {
       if (sfx.phase === this.xtx[sfx.xtxId].currentPhase) {
         // In the data generation framework, if ErrorMode.ConfirmationTimeout is set
         // we filter OUT them from the confirmation queue
-        const confirmationTimeoutCondition = sfx.signature === "ConfirmationTimeout";
+        const confirmationTimeoutCondition = sfx.raw.signature === "ConfirmationTimeout";
         if (!confirmationTimeoutCondition) {
           readyByStep.push(sfx);
         }

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -94,6 +94,12 @@ export class ExecutionManager {
   biddingEngine: BiddingEngine;
   circuitListener: CircuitListener;
   circuitRelayer: CircuitRelayer;
+  signer: any;
+  logger: any;
+  validActions: string[]
+  validAssets: string[]
+  trackedEvents: Map<string, Extrinsic>;
+  config: Config;
 
   constructor(
     public circuitClient: Sdk["client"],
@@ -106,6 +112,13 @@ export class ExecutionManager {
     this.biddingEngine = new BiddingEngine(logger);
     this.circuitListener = new CircuitListener(this.circuitClient);
     this.circuitRelayer = new CircuitRelayer(sdk);
+    this.sdk = sdk;
+    this.logger = logger;
+    // hardcoded from types/abi/src/standard.rs; so get from somewhere else
+    this.validActions = ["data", "tran", "tass", "swap", "aliq", "rliq", "cevm", "wasm", "cgen"]
+    this.validAssets = []
+    this.trackedEvents = new Map<string, any>()
+    this.config = config;
   }
 
   /** Injects persisted execution state.
@@ -130,6 +143,7 @@ export class ExecutionManager {
     await this.initializeGateways(gatewayConfig);
     await this.circuitListener.start();
     await this.initializeEventListeners();
+    await this.indirectErrorListener();
     this.addLog({ msg: "Setup Successful" });
   }
 
@@ -202,6 +216,7 @@ export class ExecutionManager {
         // initialize gateway estimator
         this.targetEstimator[entry.id] = new Estimator(relayer);
 
+        // @ts-ignore editor not picking up that has the method
         relayer.on("Event", async (eventData: RelayerEventData) => {
           switch (eventData.type) {
             case RelayerEvents.SfxExecutedOnTarget:
@@ -254,7 +269,7 @@ export class ExecutionManager {
               }
               break;
             case RelayerEvents.SfxExecutionError:
-              // @todo - figure out how to handle this
+              // TODO figure out how to handle this
               break;
           }
         });
@@ -266,6 +281,7 @@ export class ExecutionManager {
 
   /** Initialize the circuit listeners */
   async initializeEventListeners() {
+    // @ts-ignore editor not picking up that has the method
     this.circuitListener.on("Event", async (eventData: ListenerEventData) => {
       Instance.prom.events.inc();
 
@@ -356,12 +372,110 @@ export class ExecutionManager {
     // add XTX and init required event listeners
     this.xtx[xtx.id] = xtx;
     for (const [sfxId, sfx] of xtx.sideEffects.entries()) {
-      this.initSfxListeners(sfx);
-      this.sfxToXtx[sfxId] = xtx.id;
-      this.queue[sfx.vendor].isBidding.push(sfxId);
-      await this.addRiskRewardParameters(sfx);
+      // check if the sfx is valid and get a reason if not
+      const { valid, reason } = this.isValidSfxDirect(sfx);
+      if (valid) {
+        this.initSfxListeners(sfx);
+        this.sfxToXtx[sfxId] = xtx.id;
+        this.queue[sfx.vendor].isBidding.push(sfxId);
+        await this.addRiskRewardParameters(sfx);
+      } else {
+        this.addLog({ msg: `Invalid sfx. Reason: ${reason}`, debug: false })
+      }
     }
     this.addLog({ msg: "XTX initialized", xtxId: xtx.id });
+  }
+
+  /**
+   * Check if a side effect is valid for execution.
+   * This method checks for direct errors, and not delayed ones after N blocks.
+   * 
+   * @param sfx The side effect to check for soundness
+   */
+  isValidSfxDirect(sfx: SideEffect) {
+    // Reason that failed
+    let reason = "SFX is valid"
+
+    // Check if sfx target exists in allowed targets in circuit relayer
+    const targetExists = this.circuitRelayer.allowedTargets.includes(sfx.target);
+    if (!targetExists) {
+      reason = "Invalid target"
+    }
+
+    // Check that the action is one of the valid ones
+    const validAction = this.validActions.includes(sfx.action.toString());
+    if (!validAction) {
+      reason = "Invalid action"
+    }
+
+    // all conditions must be met
+    const isValid = targetExists && validAction
+
+    return { valid: isValid, reason: reason };
+  }
+
+  /**
+   * Keep a record { hash -> event } of the events that contain a custom error
+   * 
+   * @param event Event received from the circuit
+   */
+  trackEvent(event: any) {
+    const event_hash = event.data[0].toHuman();
+    this.trackedEvents.set(event_hash, event);
+  }
+
+  /**
+   * Check if the event received is a custom error, and matches what we want
+   * 
+   * @param event Event received from the circuit
+   */
+  checkTrackedEvent(event: any, reason: ListenerEvents) {
+    const event_hash = event.data[0].toHuman();
+
+    if (this.trackedEvents.has(event_hash)) {
+      const event_data = this.getTrackedEventData(event_hash);
+    } else {
+      console.log("[ERR] Not tracking this event!")
+      return
+    }
+  }
+
+  /**
+   * Parse the info from the event and return it in a nice format
+   * 
+   * @param event_hash Event hash to get the data from
+   * @returns The event data
+   */
+  getTrackedEventData(event_hash: string) {
+    return this.trackedEvents.get(event_hash);
+  }
+
+  /** Initialize the circuit listeners for the custom 
+   *  errors injected in the signature field.
+   */
+  async indirectErrorListener() {
+    // @ts-ignore editor not picking up that has the method
+    this.circuitListener.on("Event", async (eventData: ListenerEventData) => {
+      // check only custom errors, those with injected info in the signature field
+      if (!eventData.data.signature.startswith("0x")) {
+        switch (eventData.type) {
+          case ListenerEvents.NewSideEffectsAvailable:
+            this.trackEvent(eventData)
+            this.addXtx(eventData.data, this.sdk);
+            break;
+          case ListenerEvents.SFXNewBidReceived:
+            this.checkTrackedEvent(eventData, ListenerEvents.SFXNewBidReceived)
+            this.addBid(eventData.data);
+            break;
+          case ListenerEvents.DroppedAtBidding:
+            // Check the reason it was dropped at bidding
+            this.checkTrackedEvent(eventData, ListenerEvents.DroppedAtBidding)
+            break;
+          case ListenerEvents.RevertTimedOut:
+            this.revertTimeout(eventData.data[0].toString());
+        }
+      }
+    });
   }
 
   /**
@@ -538,6 +652,7 @@ export class ExecutionManager {
    * @param sfx Object of the sfx
    */
   initSfxListeners(sfx: SideEffect) {
+    // @ts-ignore editor not picking up it has the method
     sfx.on("Notification", (notification: Notification) => {
       switch (notification.type) {
         case NotificationType.SubmitBid: {

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -220,7 +220,7 @@ export class ExecutionManager {
         relayer.on("Event", async (eventData: RelayerEventData) => {
           switch (eventData.type) {
             case RelayerEvents.SfxExecutedOnTarget: {
-              // @ts-ignore
+              // @ts-ignore the object might be undefined FIXME add a default value
               const vendor = this.xtx[
                 this.sfxToXtx[eventData.sfxId]
               ].sideEffects.get(eventData.sfxId).vendor;

--- a/client/packages/executor/src/executionManager/sideEffect.ts
+++ b/client/packages/executor/src/executionManager/sideEffect.ts
@@ -1,6 +1,6 @@
 import "@t3rn/types";
 // @ts-ignore - Typescript does not know about this type
-import { T3rnTypesSideEffect } from "@polkadot/types/lookup";
+import { T3rnTypesSfxSideEffect } from "@polkadot/types/lookup";
 import { TextDecoder } from "util";
 import {
   SecurityLevel,
@@ -376,10 +376,12 @@ export class SideEffect extends EventEmitter {
       case SfxType.Transfer: {
         let amount = this.getTransferArguments()[1];
         if (!invalidExecutionValidProofCondition) {
+          // @ts-ignore - amount is a number
           amount *= 2;
         }
         return {
           amount: BigInt(amount),
+          // @ts-ignore - amount is assignable
           amountHuman: this.gateway.toFloat(amount), // converts to human format
           asset: this.gateway.ticker,
         };

--- a/client/packages/executor/src/executionManager/sideEffect.ts
+++ b/client/packages/executor/src/executionManager/sideEffect.ts
@@ -368,11 +368,15 @@ export class SideEffect extends EventEmitter {
    * @returns TxOutput.
    */
   getTxOutputs(): TxOutput {
+    // In the data generation framework, execution can be invalid
+    // but the proof can be valid. In that case, alter the amount.
+    const invalidExecutionValidProofCondition = this.signature === "invalidExecutionValidProof";
     switch (this.action) {
       case SfxType.Transfer: {
         let amount = this.getTransferArguments()[1];
-        amount = parseInt(amount.toString());
-
+        if (!invalidExecutionValidProofCondition) {
+          amount *= 2;
+        }
         return {
           amount: BigInt(amount),
           amountHuman: this.gateway.toFloat(amount), // converts to human format

--- a/client/packages/executor/src/executionManager/sideEffect.ts
+++ b/client/packages/executor/src/executionManager/sideEffect.ts
@@ -117,7 +117,7 @@ export class SideEffect extends EventEmitter {
   /** The current reward paid by the user for executing this SFX. This amount can reduce through executor bidding */
   reward: BehaviorSubject<number>;
   /** The raw SideEffect, encoded in SCALE */
-  raw: T3rnTypesSideEffect;
+  raw: T3rnTypesSfxSideEffect;
 
   // TargetConfirmation
   /** Required data for confirming the inclusion on circuit. contains encoded payload, inclusionProof, and blockHash */
@@ -163,7 +163,7 @@ export class SideEffect extends EventEmitter {
    */
 
   constructor(
-    sideEffect: T3rnTypesSideEffect,
+    sideEffect: T3rnTypesSfxSideEffect,
     id: string,
     xtxId: string,
     sdk: Sdk,
@@ -370,7 +370,8 @@ export class SideEffect extends EventEmitter {
   getTxOutputs(): TxOutput {
     // In the data generation framework, execution can be invalid
     // but the proof can be valid. In that case, alter the amount.
-    const invalidExecutionValidProofCondition = this.raw.signature === "InvalidExecutionValidProof";
+    const encoder = new TextEncoder();
+    const invalidExecutionValidProofCondition = this.raw.signature === encoder.encode("InvalidExecutionValidProof")
     switch (this.action) {
       case SfxType.Transfer: {
         let amount = this.getTransferArguments()[1];

--- a/client/packages/executor/src/executionManager/sideEffect.ts
+++ b/client/packages/executor/src/executionManager/sideEffect.ts
@@ -370,7 +370,7 @@ export class SideEffect extends EventEmitter {
   getTxOutputs(): TxOutput {
     // In the data generation framework, execution can be invalid
     // but the proof can be valid. In that case, alter the amount.
-    const invalidExecutionValidProofCondition = this.signature === "invalidExecutionValidProof";
+    const invalidExecutionValidProofCondition = this.raw.signature === "InvalidExecutionValidProof";
     switch (this.action) {
       case SfxType.Transfer: {
         let amount = this.getTransferArguments()[1];

--- a/client/packages/executor/src/executionManager/sideEffect.ts
+++ b/client/packages/executor/src/executionManager/sideEffect.ts
@@ -36,7 +36,7 @@ export type TxOutput = {
   amount: bigint;
   /** Output amount in human-readable float */
   amountHuman: number;
-  /** Output asset tickker */
+  /** Output asset ticker */
   asset: string;
 };
 
@@ -476,7 +476,7 @@ export class SideEffect extends EventEmitter {
     this.inclusionProof.block_hash = blockHash;
   }
 
-  /** SFX is confirmed, so wecan update the status and emit an event */
+  /** SFX is confirmed, so we can update the status and emit an event */
   confirmedOnCircuit() {
     this.status = SfxStatus.Confirmed;
 

--- a/client/packages/executor/src/gateways/substrate/relayer.ts
+++ b/client/packages/executor/src/gateways/substrate/relayer.ts
@@ -76,17 +76,6 @@ export class SubstrateRelayer extends EventEmitter {
    * @param sfx Object to execute
    */
   async executeTx(sfx: SideEffect) {
-    // TODO: validate the SFX
-
-
-
-
-
-
-
-
-
-
     this.logger.info(
       `Execution started SFX: ${sfx.humanId} - ${sfx.target} with nonce: ${this.nonce} 🔮`
     );

--- a/client/packages/executor/src/gateways/substrate/relayer.ts
+++ b/client/packages/executor/src/gateways/substrate/relayer.ts
@@ -68,13 +68,25 @@ export class SubstrateRelayer extends EventEmitter {
   }
 
   /**
-   * Submit the transaction to the target chain. This function increments the nonce locally to enable optimistic nonce increment. This
-   * allows transaction to be submitted in parallel without waiting for the previous one to be included. A successful submission will
-   * trigger inclusion proof generation.
+   * Submit the transaction to the target chain. 
+   * This function increments the nonce locally to enable optimistic nonce increment. 
+   * This allows transaction to be submitted in parallel without waiting for the previous one to be included. 
+   * A successful submission will trigger inclusion proof generation.
    *
    * @param sfx Object to execute
    */
   async executeTx(sfx: SideEffect) {
+    // TODO: validate the SFX
+
+
+
+
+
+
+
+
+
+
     this.logger.info(
       `Execution started SFX: ${sfx.humanId} - ${sfx.target} with nonce: ${this.nonce} 🔮`
     );


### PR DESCRIPTION
WIP

SFX within executor doesn't have the signature field.
SFX's schema might need to be ported.

@openai: ignore 


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Bug fix and Error handling: This PR includes several bug fixes and error handling improvements across multiple packages. Notably, it adds error checking for test generation, introduces new methods to check if a side effect is valid for execution, and modifies the `createConfirmTx` method to check if the `sfx.target` is included in the `allowedTargets` array. These changes aim to improve the reliability and stability of the codebase.

> "Bugs were squashed, errors tamed,
> Code now runs more stable, less maimed.
> With each fix, we move ahead,
> Towards a brighter future, free of dread."
<!-- end of auto-generated comment: release notes by openai -->