### PR TITLE
chore: deploy docs on self hosted runners

### DIFF
--- a/.github/workflows/update-dev-docs.yml
+++ b/.github/workflows/update-dev-docs.yml
@@ -91,7 +91,7 @@ jobs:
       run:
         working-directory: client/packages
     timeout-minutes: 15
-    if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
+    # if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
 
     steps:
       - name: 🎞️ Checkout repo
@@ -121,7 +121,7 @@ jobs:
       run:
         working-directory: client/packages
     timeout-minutes: 15
-    if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
+    # if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
 
     steps:
       - name: 🎞️ Checkout repo
@@ -151,7 +151,7 @@ jobs:
       run:
         working-directory: client/packages
     timeout-minutes: 15
-    if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
+    # if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
     steps:
       - name: 🎞️ Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/update-dev-docs.yml
+++ b/.github/workflows/update-dev-docs.yml
@@ -4,7 +4,7 @@ name: Deploy Documentation
 on:
   # Triggers the workflow on push to the development branch
   push:
-    branches: [ development ]
+    # branches: [ development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -59,7 +59,7 @@ jobs:
             docs.chain.t3rn.io
 
   main:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: docs/main
@@ -86,7 +86,7 @@ jobs:
             docs.t3rn.io
 
   attester:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: client/packages
@@ -98,8 +98,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Build local dependencies
-        run: make
       - name: 📦 Install packages
         run: pnpm i
         working-directory: client/packages/attester
@@ -118,7 +116,7 @@ jobs:
             docs.attester.t3rn.io
 
   executor:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: client/packages
@@ -130,8 +128,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Build local dependencies
-        run: make
       - name: 📦 Install packages
         run: yarn
         working-directory: client/packages/executor
@@ -150,7 +146,7 @@ jobs:
             docs.executor.t3rn.io
 
   ts-sdk:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: client/packages
@@ -161,8 +157,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Build local dependencies
-        run: make
       - name: 📦 Install packages
         run: yarn
         working-directory: client/packages/sdk

--- a/.github/workflows/update-dev-docs.yml
+++ b/.github/workflows/update-dev-docs.yml
@@ -4,7 +4,7 @@ name: Deploy Documentation
 on:
   # Triggers the workflow on push to the development branch
   push:
-    # branches: [ development ]
+    branches: [ development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -91,21 +91,22 @@ jobs:
       run:
         working-directory: client/packages
     timeout-minutes: 15
-    # if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
+    if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
 
     steps:
       - name: 🎞️ Checkout repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+
       - name: 📦 Install dependencies
         run: make all
       
       # Attester
-      - name: 🏗 Build Docs
+      - name: 🏗 Build Attester Docs
         run: pnpm run build-docs
         working-directory: client/packages/attester
-      - name: 👾 Deploy to Vercel
+      - name: 👾 Deploy Attester Docs to Vercel
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -117,10 +118,10 @@ jobs:
             docs.attester.t3rn.io
 
       # Executor
-      - name: 🏗 Build Docs
+      - name: 🏗 Build Executor Docs
         run: yarn build-docs
         working-directory: client/packages/executor
-      - name: 👾 Deploy to Vercel
+      - name: 👾 Deploy Executor Docs to Vercel
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -132,10 +133,10 @@ jobs:
             docs.executor.t3rn.io
 
       # ts-sdk
-      - name: 🏗 Build Docs
+      - name: 🏗 Build SDK Docs
         run: yarn build:docs
         working-directory: client/packages/sdk
-      - name: 👾 Deploy to Vercel
+      - name: 👾 Deploy SDK docs to Vercel
         uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/update-dev-docs.yml
+++ b/.github/workflows/update-dev-docs.yml
@@ -85,7 +85,7 @@ jobs:
           alias-domains: |
             docs.t3rn.io
 
-  attester:
+  clients:
     runs-on: self-hosted
     defaults:
       run:
@@ -98,9 +98,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: 📦 Install packages
-        run: pnpm i
-        working-directory: client/packages/attester
+      - name: 📦 Install dependencies
+        run: make all
+      
+      # Attester
       - name: 🏗 Build Docs
         run: pnpm run build-docs
         working-directory: client/packages/attester
@@ -115,22 +116,7 @@ jobs:
           alias-domains: |
             docs.attester.t3rn.io
 
-  executor:
-    runs-on: self-hosted
-    defaults:
-      run:
-        working-directory: client/packages
-    timeout-minutes: 15
-    # if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
-
-    steps:
-      - name: 🎞️ Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: 📦 Install packages
-        run: yarn
-        working-directory: client/packages/executor
+      # Executor
       - name: 🏗 Build Docs
         run: yarn build-docs
         working-directory: client/packages/executor
@@ -145,21 +131,7 @@ jobs:
           alias-domains: |
             docs.executor.t3rn.io
 
-  ts-sdk:
-    runs-on: self-hosted
-    defaults:
-      run:
-        working-directory: client/packages
-    timeout-minutes: 15
-    # if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
-    steps:
-      - name: 🎞️ Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: 📦 Install packages
-        run: yarn
-        working-directory: client/packages/sdk
+      # ts-sdk
       - name: 🏗 Build Docs
         run: yarn build:docs
         working-directory: client/packages/sdk


### PR DESCRIPTION
# Summary of changes

- client docs deployed in one step to save time
- steps are run on self hosted runners

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Documentation: Modified deployment process of client documentation and added self-hosted runners. Changes include modifying the `runs-on` field for jobs, adding new steps to build and deploy documentation, changing the working directory for some steps, and modifying the build command in the existing jobs.

> "New runners deployed,
> Docs now shine like a star,
> Code quality improved."
<!-- end of auto-generated comment: release notes by openai -->