### PR TITLE
feat: added attestationsDone array

### DIFF
--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -119,10 +119,10 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: EKS
-        # if: github.ref == 'refs/heads/development'
+        if: github.ref == 'refs/heads/development'
         run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
 
       - name: Helm Upgrade
-        # if: github.ref == 'refs/heads/development'
+        if: github.ref == 'refs/heads/development'
         working-directory: ./client/packages/attester
         run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-attester"

--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -119,10 +119,10 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: EKS
-        if: github.ref == 'refs/heads/development'
+        # if: github.ref == 'refs/heads/development'
         run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
 
       - name: Helm Upgrade
-        if: github.ref == 'refs/heads/development'
+        # if: github.ref == 'refs/heads/development'
         working-directory: ./client/packages/attester
         run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-attester"

--- a/client/packages/attester/src/attester.ts
+++ b/client/packages/attester/src/attester.ts
@@ -68,7 +68,9 @@ export class Attester {
             const comittee = await this.getCommittee()
             this.checkIsInCommittee(comittee, this.keys.substrate.accountId)
             if (!this.isInCurrentCommittee) {
-                logger.debug('Not in current committee, not submitting attestation')
+                logger.debug(
+                    'Not in current committee, not submitting attestation'
+                )
                 return
             }
 
@@ -191,7 +193,6 @@ export class Attester {
             data.targetId,
             data.executionVendor
         )
-        return true
     }
 
     private async submitAttestationEVM(
@@ -240,9 +241,6 @@ export class Attester {
             }
             return
         }
-        if (!result) {
-            return
-        }
 
         this.prometheus.attestationSubmitted.inc({
             targetId: targetId,
@@ -254,7 +252,7 @@ export class Attester {
                 executionVendor: executionVendor,
                 targetId: targetId,
                 messageHash: messageHash,
-                hash: result.hash.toHex(),
+                block: result,
             },
             'Attestation submitted'
         )

--- a/client/packages/attester/tests/processAttestations.test.ts
+++ b/client/packages/attester/tests/processAttestations.test.ts
@@ -1,0 +1,90 @@
+// Import necessary dependencies and modules
+import { Attester } from '../src/attester'
+
+jest.mock('../src/prometheus')
+console.warn = jest.fn()
+
+// Mock the dependencies
+const mockCircuit = {
+    client: {
+        query: {
+            attesters: {
+                currentCommittee: jest.fn(),
+            },
+        },
+    },
+}
+
+const mockPrometheus = {
+    currentCommitteeMember: {
+        set: jest.fn(),
+    },
+}
+
+describe('processAttestation', () => {
+    let attester
+
+    beforeEach(() => {
+        // Create a new instance of Attester before each test
+        const config = {
+            circuit: {
+                rpc1: 'mock1',
+                rpc2: 'mock2',
+            },
+        }
+        const keys = {
+            substrate: {},
+            ethereum: {
+                privateKey:
+                    '0x0123456789012345678901234567890123456789012345678901234567890123',
+            },
+            btc: {},
+        }
+        attester = new Attester(config, keys)
+        Object.defineProperty(attester, 'prometheus', {
+            get: jest.fn(() => mockPrometheus),
+        })
+        Object.defineProperty(attester, 'circuit', {
+            get: jest.fn(() => mockCircuit),
+        })
+    })
+
+    afterEach(() => {
+        // Reset the mock implementation for each test
+        jest.clearAllMocks()
+    })
+
+    it('should return true when attestationsDone has messageHash', async () => {
+        attester.attestationsDone = ['0x1234']
+        
+        const result = attester.isAttestationDone( '0x1234')
+
+        expect(result).toBe(true)
+    })
+
+    it('should return false when attestationsDone doesnt have messageHash', async () => {
+        attester.attestationsDone = []
+        
+        const result = await attester.isAttestationDone(
+            '0x1234'
+       )
+
+        expect(result).toBe(false)
+    })
+
+    it('should return false when target is not allowed', async () => {
+        attester.config.targetsAllowed = ['0x1234']
+        
+        const result = await attester.isTargetAllowed('0x5678')
+
+        expect(result).toBe(false)
+    })
+
+    it('should return true when target is allowed', async () => {
+        attester.config.targetsAllowed = ['0x1234']
+        
+        const result = await attester.isTargetAllowed('0x1234')
+
+        expect(result).toBe(true)
+    })
+})

--- a/client/packages/attester/tests/processAttestations.test.ts
+++ b/client/packages/attester/tests/processAttestations.test.ts
@@ -56,25 +56,23 @@ describe('processAttestation', () => {
 
     it('should return true when attestationsDone has messageHash', async () => {
         attester.attestationsDone = ['0x1234']
-        
-        const result = attester.isAttestationDone( '0x1234')
+
+        const result = attester.isAttestationDone('0x1234')
 
         expect(result).toBe(true)
     })
 
     it('should return false when attestationsDone doesnt have messageHash', async () => {
         attester.attestationsDone = []
-        
-        const result = await attester.isAttestationDone(
-            '0x1234'
-       )
+
+        const result = await attester.isAttestationDone('0x1234')
 
         expect(result).toBe(false)
     })
 
     it('should return false when target is not allowed', async () => {
         attester.config.targetsAllowed = ['0x1234']
-        
+
         const result = await attester.isTargetAllowed('0x5678')
 
         expect(result).toBe(false)
@@ -82,7 +80,7 @@ describe('processAttestation', () => {
 
     it('should return true when target is allowed', async () => {
         attester.config.targetsAllowed = ['0x1234']
-        
+
         const result = await attester.isTargetAllowed('0x1234')
 
         expect(result).toBe(true)


### PR DESCRIPTION
# Summary of changes

Attestation will be removed from PendingConfirmation event after majority is reached + 6 blocks (batching window on t0rn)
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added `attestationsDone` array to keep track of already done attestations and checks to skip attestation if it was already done or if the target is not allowed.
- Refactor: Removed unnecessary imports and code related to queuePurge().
- Test: Added unit tests for the `isAttestationDone` and `isTargetAllowed` methods of the `Attester` class.

> "Code changes abound,
Logic, security, and tests found,
Attentions paid all around,
Quality improved, let's astound!"
<!-- end of auto-generated comment: release notes by openai -->