### PR TITLE
chore: move pr template to t3rn repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,58 @@
+# Summary of changes
+
+**_Summarize_** the description of your changes.
+
+If it fixes a bug or creates a feature, link the issue.
+
+# Acceptance Checklist
+
+What types of changes does your code introduce?
+_Put an `x` in the boxes that apply_
+
+## Dependencies
+
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] Any teams which manage the dependencies have been notified of the breaking changes
+
+## Bug (non-breaking change which fixes an issue):
+
+- [ ] Have you **_written tests_** to protect against future occurrences of the bug?
+
+## Feature (non-breaking change which adds functionality)
+
+- [ ] Have you **_seen it working_** in a development environment?
+- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
+- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?
+
+### Substrate
+
+If this change involves substrate, have you remembered:
+
+- [ ] Storage Migration?
+- [ ] RPC methods?
+- [ ] Chainspec, both JSON specs & the module?
+- [ ] Runtime versioning?
+- [ ] Benchmarks?
+
+## Breaking change (a feature that would cause existing functionality not to work as expected)
+
+- [ ] Is the breaking change **_documented_**?
+- [ ] Are your commits fully representative of the change?
+- [ ] Has any previous functionality been **_deprecated_** and versioned?
+
+## CI/CD
+
+- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
+- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
+- [ ] If introducing new actions, have you **_pegged a static version_**?
+
+## Documentation Update
+
+- [ ] Have you checked other documentation, such as the docs repository?
+- [ ] If updating script documentation, have you **_tested it on both environments_**?
+
+## Further comments
+
+Feel free to explain in further detail your choices if this is a significant change.
+
+## Screenshots (Please demonstrate this working in PolkadotJS)


### PR DESCRIPTION
# Summary of changes

Moved PR template from global .github repo to t3rn. 
It will be easier to introduce changes to it, scoped specifically to `t3rn` PRs.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Chore: Minor change to the PR template.

> "A small tweak to the template,
> Makes our process more complete."
<!-- end of auto-generated comment: release notes by openai -->