### PR TITLE
fix: deploy phase should not be run by dependabot

### DIFF
--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -82,6 +82,10 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/attester/eslint_report.json
 
+      - name: 🏗 Build Docs
+        run: pnpm run build-docs
+        working-directory: client/packages/attester          
+
   build-docker:
     name: Build Attester Docker
     needs: [changes]

--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -82,17 +82,27 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/attester/eslint_report.json
 
-      - name: 🏗 Build Docs
-        run: pnpm run build-docs
-        working-directory: client/packages/attester
+  build-docker:
+    name: Build Attester Docker
+    needs: [changes]
+    if: needs.changes.outputs.src == 'true' && github.ref != 'refs/heads/development'
+
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Docker
+        working-directory: ./client
+        run: |
+          docker build . -f attester.Dockerfile
 
   deploy:
     name: Build & Deploy Attester
     runs-on: self-hosted
-    needs: [changes, test-attester]
+    needs: test-attester
     concurrency: attester
 
-    if: needs.changes.outputs.src == 'true'
+    if: github.ref == 'refs/heads/development'
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
@@ -119,10 +129,8 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: EKS
-        # if: github.ref == 'refs/heads/development'
         run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
 
       - name: Helm Upgrade
-        # if: github.ref == 'refs/heads/development'
         working-directory: ./client/packages/attester
         run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-attester"

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -86,27 +86,31 @@ jobs:
       - run: pnpm test
         timeout-minutes: 5
 
+  build-docker:
+    name: Build Executor Docker
+    needs: [changes]
+    if: needs.changes.outputs.src == 'true' && github.ref != 'refs/heads/development'
+
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Docker
+        working-directory: ./client
+        run: |
+          docker build . -f executor.Dockerfile
+
   deploy:
     name: Build & Deploy Executor
     runs-on: self-hosted
-    if: needs.changes.outputs.src == 'true'
     needs: test-executor
     concurrency: executor
+
+    if: github.ref == 'refs/heads/development'
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-  
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-  
       - name: Build executor
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -117,11 +121,20 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . -f executor.Dockerfile
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
       - name: EKS
-        if: github.ref == 'refs/heads/development'
         run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
 
       - name: Helm Upgrade
-        if: github.ref == 'refs/heads/development'
         working-directory: ./client/packages/executor
         run: helm upgrade executor helm -n executor -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-executor"

--- a/.github/workflows/grandpa-ranger.yml
+++ b/.github/workflows/grandpa-ranger.yml
@@ -78,7 +78,7 @@ jobs:
   build-docker:
     name: Build Docker Grandpa Ranger
     needs: [changes]
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.src == 'true' && github.ref != 'refs/heads/development'
 
     runs-on: self-hosted
     steps:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added a new job to build a Docker image for Attester and modified the `deploy` job to only run on the `development` branch in `.github/workflows/attester.yml`.
- New Feature: Added a new `build-docker` job and modified the `deploy` job to only run on the `development` branch in `.github/workflows/executor.yml`. Moved AWS credentials configuration and ECR login steps after the executor build step in the `deploy` job.
- Chore: Added a condition to the `if` statement in the `build-docker` job in `.github/workflows/grandpa-ranger.yml`.

> Changes abound, deployment refined,
> Docker images built, AWS credentials aligned,
> A PR of chore and features combined,
> Celebrate we must, with joy enshrined.
<!-- end of auto-generated comment: release notes by openai -->