### PR TITLE
fix: call reboot self gateway

### DIFF
--- a/client/packages/attester/pnpm-lock.yaml
+++ b/client/packages/attester/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@polkadot/util':
     specifier: ^10.4.2

--- a/client/packages/cli/src/commands/register/gateway.ts
+++ b/client/packages/cli/src/commands/register/gateway.ts
@@ -73,6 +73,13 @@ const registerGateway = async (
   try {
     const registrationData = await getRegistrationData(circuit, gatewayData)
 
+    // need to call xdns.rebootSelfGateway to add 0x03030303
+    await sdk.circuit.tx.signAndSendSafe(
+      sdk.circuit.tx.createSudo(
+        circuit.tx.xdns.rebootSelfGateway(verificationVendor)
+      )
+    )
+
     if (!registrationData) {
       throw new Error(`${gatewayData.name} gateway registration failed!`)
     }


### PR DESCRIPTION
# Summary of changes

Fixes issue #1081

Need to call xdns.reboot_self_gateway before adding gateways (like `roco`).

Tested locally with standalone and works.

# Acceptance Checklist

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

## Dependencies

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any teams which manage the dependencies have been notified of the breaking changes

## Bug (non-breaking change which fixes an issue):

- [ ] Have you **_written tests_** to protect against future occurrences of the bug?

## Feature (non-breaking change which adds functionality)

- [ ] Have you **_seen it working_** in a development environment?
- [ ] Have you **_written tests_** for **_happy_** and **_unhappy_** paths?
- [ ] Have you implemented this feature as per the **_issue acceptance criteria_**?

### Substrate

If this change involves substrate, have you remembered:

- [ ] Storage Migration?
- [ ] RPC methods?
- [ ] Chainspec, both JSON specs & the module?
- [ ] Runtime versioning?
- [ ] Benchmarks?

## Breaking change (a feature that would cause existing functionality not to work as expected)

- [ ] Is the breaking change **_documented_**?
- [ ] Are your commits fully representative of the change?
- [ ] Has any previous functionality been **_deprecated_** and versioned?

## CI/CD

- [ ] If introducing new actions, have you **_looked at the action code_** for anything spurious?
- [ ] Have you written **_custom scripts_** for things that could be actions already on the marketplace?
- [ ] If introducing new actions, have you **_pegged a static version_**?

## Documentation Update

- [ ] Have you checked other documentation, such as the docs repository?
- [ ] If updating script documentation, have you **_tested it on both environments_**?

## Further comments

Feel free to explain in further detail your choices if this is a significant change.

## Screenshots (Please demonstrate this working in PolkadotJS)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Added a call to `xdns.rebootSelfGateway` before adding gateways, passing the `verificationVendor` parameter.
- New Feature: Added a call to `sdk.circuit.tx.signAndSendSafe` to sign and send the transaction.

> "With a reboot and a signature,
> Gateways now rise with vigor.
> Bugs are fixed, features shine,
> This PR brings code divine."
<!-- end of auto-generated comment: release notes by openai -->