### PR TITLE
BREAKING CHANGE: change default system hashing to Keccak256

### DIFF
--- a/pallets/3vm/src/mock.rs
+++ b/pallets/3vm/src/mock.rs
@@ -18,7 +18,7 @@ use t3rn_primitives::{GatewayVendor, TreasuryAccount, TreasuryAccountProvider};
 use sp_core::H256;
 use sp_runtime::{
     generic,
-    traits::{BlakeTwo256, ConvertInto, IdentityLookup},
+    traits::{BlakeTwo256, ConvertInto, IdentityLookup, Keccak256},
     AccountId32, DispatchError,
 };
 use t3rn_primitives::xdns::PalletAssetsOverlay;
@@ -72,7 +72,7 @@ impl system::Config for Test {
     type DbWeight = ();
     type Event = Event;
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = Header;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;

--- a/pallets/3vm/src/precompile.rs
+++ b/pallets/3vm/src/precompile.rs
@@ -394,7 +394,7 @@ mod tests {
                     steps_cnt: (0, 1),
                     xtx_id: <Test as frame_system::Config>::Hash::decode(
                         &mut &hex::decode(
-                            "e8b9e71dc3f878ecf9dae04303767b76882fd0034dd73c98589ff45dab57b05b"
+                            "c3561681690c887efcedd1f891e436e0957869ba500a4b4f53fdf3b9a23a8ae3"
                         )
                         .unwrap()[..]
                     )
@@ -451,7 +451,7 @@ mod tests {
                     steps_cnt: (0, 1),
                     xtx_id: <Test as frame_system::Config>::Hash::decode(
                         &mut &hex::decode(
-                            "d2097ea5ba9ae6f4484fa960dbc0f82a6ac5a08e4c0785cff0b95d510a97ce18"
+                            "30e2bfdaad2f3c218a1a8cc54fa1c4e6182b6b7f3bca273390cf587b50b47311"
                         )
                         .unwrap()[..]
                     )

--- a/pallets/attesters/src/lib.rs
+++ b/pallets/attesters/src/lib.rs
@@ -1709,7 +1709,7 @@ pub mod attesters_test {
     };
     use sp_application_crypto::{ecdsa, ed25519, sr25519, KeyTypeId, Pair, RuntimePublic};
     use sp_core::H256;
-    use sp_runtime::traits::BlakeTwo256;
+    use sp_runtime::traits::{Keccak256};
 
     use crate::TargetBatchDispatchEvent;
     use sp_std::convert::TryInto;
@@ -2124,7 +2124,7 @@ pub mod attesters_test {
 
             let sfx_id = mock_fsx
                 .input
-                .generate_id::<BlakeTwo256>(mock_xtx_id.as_bytes(), 0u32);
+                .generate_id::<Keccak256>(mock_xtx_id.as_bytes(), 0u32);
 
             assert_ok!(Attesters::request_sfx_attestation_revert(target, sfx_id));
 
@@ -2213,7 +2213,7 @@ pub mod attesters_test {
 
             let sfx_id = mock_fsx
                 .input
-                .generate_id::<BlakeTwo256>(mock_xtx_id.as_bytes(), 0u32);
+                .generate_id::<Keccak256>(mock_xtx_id.as_bytes(), 0u32);
 
             assert_ok!(Attesters::request_sfx_attestation_commit(target, sfx_id));
 

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -42,7 +42,7 @@ use frame_system::{
 };
 use sp_core::H256;
 use sp_runtime::{
-    traits::{BadOrigin, CheckedAdd, Zero},
+    traits::{CheckedAdd, Zero},
     DispatchError, KeyTypeId,
 };
 use sp_std::{convert::TryInto, vec, vec::Vec};
@@ -98,6 +98,8 @@ pub mod weights;
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"circ");
 
 pub type SystemHashing<T> = <T as frame_system::Config>::Hashing;
+
+//
 
 reexport_currency_types!();
 

--- a/pallets/circuit/src/machine/test.rs
+++ b/pallets/circuit/src/machine/test.rs
@@ -185,7 +185,7 @@ pub mod test {
                 stage_single();
                 assert_err!(
                     <Circuit as ReadSFX<Hash, AccountId, Balance, BlockNumber>>::get_fsx(
-                        hex!("810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4")
+                        hex!("21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240")
                             .into(),
                     ),
                     DispatchError::Module(ModuleError {
@@ -213,7 +213,7 @@ pub mod test {
                         xtx_id
                     ),
                     Ok(vec![hex!(
-                        "810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4"
+                        "21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240"
                     )
                     .into()])
                 );
@@ -255,7 +255,7 @@ pub mod test {
                 stage_single();
                 assert_err!(
                     <Circuit as ReadSFX<Hash, AccountId, Balance, BlockNumber>>::get_fsx_status(
-                        hex!("810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4")
+                        hex!("21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240")
                             .into()
                     ),
                     DispatchError::Module(ModuleError {
@@ -277,7 +277,7 @@ pub mod test {
                 stage_single();
                 assert_err!(
                     <Circuit as ReadSFX<Hash, AccountId, Balance, BlockNumber>>::get_fsx_of_xtx(
-                        hex!("810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4")
+                        hex!("21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240")
                             .into()
                     ),
                     DispatchError::Module(ModuleError {
@@ -345,7 +345,7 @@ pub mod test {
 
                 assert_err!(
                     <Circuit as ReadSFX<Hash, AccountId, Balance, BlockNumber>>::get_fsx_requester(
-                        hex!("810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4")
+                        hex!("21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240")
                             .into()
                     ),
                     DispatchError::Module(ModuleError {
@@ -368,7 +368,7 @@ pub mod test {
 
                 assert_err!(
                     <Circuit as ReadSFX<Hash, AccountId, Balance, BlockNumber>>::get_xtx_status(
-                        hex!("810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4")
+                        hex!("21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240")
                             .into()
                     ),
                     DispatchError::Module(ModuleError {

--- a/pallets/circuit/src/tests.rs
+++ b/pallets/circuit/src/tests.rs
@@ -281,7 +281,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_sets_storage_entries() {
                                 "0101010101010101010101010101010101010101010101010101010101010101"
                             )),
                             hex!(
-                                "2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c"
+                                "f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29"
                             )
                             .into(),
                             vec![SideEffect {
@@ -301,7 +301,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_sets_storage_entries() {
                                 insurance: 1,
                             }],
                             vec![hex!(
-                                "810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4"
+                                "21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240"
                             )
                             .into(),],
                         )),
@@ -313,7 +313,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_sets_storage_entries() {
                             Runtime,
                         >::XTransactionReceivedForExec(
                             hex!(
-                                "2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c"
+                                "f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29"
                             )
                             .into()
                         )),
@@ -322,7 +322,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_sets_storage_entries() {
                 ]
             );
             let xtx_id: sp_core::H256 =
-                hex!("2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c").into();
+                hex!("f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29").into();
             let side_effect_a_id = valid_transfer_side_effect
                 .generate_id::<circuit_runtime_pallets::pallet_circuit::SystemHashing<Runtime>>(
                 &xtx_id.0,
@@ -442,7 +442,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_emits_expect_events() {
                                 "0101010101010101010101010101010101010101010101010101010101010101"
                             )),
                             hex!(
-                                "2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c"
+                                "f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29"
                             )
                             .into(),
                             vec![SideEffect {
@@ -462,7 +462,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_emits_expect_events() {
                                 reward_asset_id: None,
                             }],
                             vec![hex!(
-                                "810424cc4a8caa69bd0f1d9ee594f46bc45545a50b4cf8f7e78c41f0804d27a4"
+                                "21eaf9e427bbdc414c6f75e8f3a1410f9b506c66e9ee7a4601217ac431ca8240"
                             )
                             .into(),],
                         )),
@@ -474,7 +474,7 @@ fn on_extrinsic_trigger_works_with_single_transfer_emits_expect_events() {
                             Runtime,
                         >::XTransactionReceivedForExec(
                             hex!(
-                                "2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c"
+                                "f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29"
                             )
                             .into()
                         )),
@@ -808,7 +808,7 @@ fn circuit_selects_best_bid_out_of_3_for_transfer_sfx() {
                     },
                     EventRecord { phase: Phase::Initialization, event: Event::AccountManager(
                         circuit_runtime_pallets::pallet_account_manager::Event::<Runtime>::DepositReceived {
-                            charge_id: H256::from_str("0xd2170a1bae127064ba4c6cfc7b00108038de5429babc320498493567b5e2cd45").unwrap(),
+                            charge_id: H256::from_str("0x1c8fb9a762379150505eda288c226da9bc22d42e13fed24ae73fc73fb0fa1162").unwrap(),
                             payee: BID_WINNER,
                             recipient: Some(REQUESTER),
                             amount: 3
@@ -1631,7 +1631,7 @@ fn circuit_cancels_xtx_with_incomplete_bid_after_timeout() {
                 events.iter().any(|record| {
                     if let Event::Circuit(circuit_runtime_pallets::pallet_circuit::Event::<Runtime>::XTransactionXtxRevertedAfterTimeOut(xtx_id_emit)) = record.event {
                         assert_eq!(xtx_id_emit, hex!(
-                                "2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c"
+                                "f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29"
                             ).into());
                         true
                     } else {
@@ -1653,7 +1653,7 @@ fn load_local_state_can_generate_and_read_state() {
         let res = Circuit::load_local_state(&origin, None).unwrap();
 
         let xtx_id_new: sp_core::H256 =
-            hex!("2dd1ccea5b1d02d46b19803b55f7de8ee5dabc951faf617c28c7933dae30719c").into();
+            hex!("f70ef7dbe839c0f242ed54eb45933dd8cbb852e3e67c373dd8d4204d86c15f29").into();
 
         assert_eq!(res.xtx_id, xtx_id_new);
         assert_eq!(res.local_state, LocalState::new());

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -294,7 +294,7 @@ mod tests {
             assert_eq!(
                 xtx_id,
                 Hash::from(hex!(
-                    "a602173a905f72f4f93410c69db65f52480f67b7e947309b254fe718f611a0a7"
+                    "240055342551e8f9606f2c4c3ab697b0469cb34b1569191c7a2b6acafefaeb79"
                 ))
             );
 
@@ -349,7 +349,7 @@ mod tests {
             assert_eq!(
                 xtx_id,
                 Hash::from(hex!(
-                    "a602173a905f72f4f93410c69db65f52480f67b7e947309b254fe718f611a0a7"
+                    "240055342551e8f9606f2c4c3ab697b0469cb34b1569191c7a2b6acafefaeb79"
                 ))
             );
 
@@ -361,7 +361,7 @@ mod tests {
             let order_status = expect_last_event_to_read_order_status();
 
             let expected_sfx_hash = Hash::from(hex!(
-                "484c277dfcfb25b51c8e12fc2e7eb286bb9315775db60635872d51a40d5bb253"
+                "2dcd180a2f8cffd332504a06da0664f0994cf290e28e0b34b38d84e79f72140c"
             ));
 
             assert_eq!(
@@ -518,7 +518,7 @@ mod tests {
             assert_eq!(
                 xtx_id,
                 Hash::from(hex!(
-                    "a602173a905f72f4f93410c69db65f52480f67b7e947309b254fe718f611a0a7"
+                    "240055342551e8f9606f2c4c3ab697b0469cb34b1569191c7a2b6acafefaeb79"
                 ))
             );
 
@@ -530,7 +530,7 @@ mod tests {
             let order_status = expect_last_event_to_read_order_status();
 
             let expected_sfx_hash = Hash::from(hex!(
-                "484c277dfcfb25b51c8e12fc2e7eb286bb9315775db60635872d51a40d5bb253"
+                "2dcd180a2f8cffd332504a06da0664f0994cf290e28e0b34b38d84e79f72140c"
             ));
 
             assert_eq!(

--- a/pallets/contracts-registry/src/mock.rs
+++ b/pallets/contracts-registry/src/mock.rs
@@ -23,7 +23,7 @@ use crate as pallet_contracts_registry;
 use crate::types::RegistryContract;
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
 use sp_core::H256;
-use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup, Keccak256};
 type Header = generic::Header<u32, BlakeTwo256>;
 
 use sp_std::convert::{TryFrom, TryInto};
@@ -69,7 +69,7 @@ impl frame_system::Config for Test {
     type DbWeight = ();
     type Event = Event;
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = Header;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;

--- a/pallets/contracts-registry/src/tests.rs
+++ b/pallets/contracts-registry/src/tests.rs
@@ -139,7 +139,7 @@ fn fetch_contracts_by_metadata_should_return_all_matching_contracts() {
         let actual = ContractsRegistry::fetch_contracts(None, Some(b"contract".to_vec()));
         assert_ok!(
             actual,
-            vec![test_contract_name.clone(), test_contract_desc.clone()]
+            vec![test_contract_desc.clone(), test_contract_name.clone()]
         );
     })
 }
@@ -223,7 +223,7 @@ fn fetch_contracts_by_author_should_return_all_matching_contracts() {
         let actual = ContractsRegistry::fetch_contracts(Some(ALICE), None);
         assert_ok!(
             actual,
-            vec![test_contract_author1.clone(), test_contract_author2.clone()]
+            vec![test_contract_author2.clone(), test_contract_author1.clone()]
         );
     })
 }
@@ -306,7 +306,7 @@ fn fetch_contracts_by_author_and_metadata_should_return_all_matching_contracts()
         let actual = ContractsRegistry::fetch_contracts(Some(ALICE), Some(b"contract".to_vec()));
         assert_ok!(
             actual,
-            vec![test_contract_author1.clone(), test_contract_author2.clone()]
+            vec![test_contract_author2.clone(), test_contract_author1.clone()]
         );
     })
 }

--- a/pallets/contracts/src/tests.rs
+++ b/pallets/contracts/src/tests.rs
@@ -53,6 +53,7 @@ use sp_runtime::{
 };
 type Header = generic::Header<u32, BlakeTwo256>;
 
+use sp_runtime::traits::Keccak256;
 use std::{cell::RefCell, sync::Arc};
 
 mod threevm;
@@ -222,7 +223,7 @@ impl frame_system::Config for Test {
     type DbWeight = ();
     type Event = Event;
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = Header;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;

--- a/pallets/evm/precompile/portal/src/mock.rs
+++ b/pallets/evm/precompile/portal/src/mock.rs
@@ -26,7 +26,7 @@ use frame_support::{
 use sp_core::{crypto::AccountId32, H160, H256, U256};
 use sp_runtime::{
     generic,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup, Keccak256},
 };
 use sp_std::{boxed::Box, prelude::*, str::FromStr};
 
@@ -77,7 +77,7 @@ impl frame_system::Config for Test {
     type DbWeight = ();
     type Event = Event;
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = generic::Header<u32, BlakeTwo256>;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;

--- a/pallets/evm/src/mock.rs
+++ b/pallets/evm/src/mock.rs
@@ -26,7 +26,7 @@ use frame_support::{
 use sp_core::{crypto::AccountId32, H160, H256, U256};
 use sp_runtime::{
     generic,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup, Keccak256},
 };
 use sp_std::{boxed::Box, prelude::*, str::FromStr};
 
@@ -77,7 +77,7 @@ impl frame_system::Config for Test {
     type DbWeight = ();
     type Event = Event;
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = generic::Header<u32, BlakeTwo256>;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -50,7 +50,7 @@ use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::{
     generic, parameter_types,
-    traits::{BlakeTwo256, ConstU32, ConvertInto, IdentityLookup},
+    traits::{BlakeTwo256, ConstU32, ConvertInto, IdentityLookup, Keccak256},
     Perbill, Percent,
 };
 use t3rn_primitives::{EthereumToken, ExecutionVendor, GatewayVendor, SubstrateToken, TokenInfo};
@@ -311,7 +311,7 @@ impl frame_system::Config for MiniRuntime {
     type DbWeight = ();
     type Event = Event;
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = Header;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;

--- a/runtime/mock/src/system_no_version_config.rs
+++ b/runtime/mock/src/system_no_version_config.rs
@@ -11,7 +11,7 @@ use frame_support::{
 
 use sp_runtime::{
     generic,
-    traits::{AccountIdLookup, BlakeTwo256, ConvertInto},
+    traits::{AccountIdLookup, BlakeTwo256, ConvertInto, Keccak256},
 };
 
 // Configure FRAME pallets to include in runtime.
@@ -39,7 +39,7 @@ impl frame_system::Config for Runtime {
     /// The type for hashing blocks and tries.
     type Hash = HashPrimitive;
     /// The hashing algorithm used.
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     /// The header type.
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     /// The index type for storing how many extrinsics an account has signed.

--- a/runtime/mock/src/test_utils.rs
+++ b/runtime/mock/src/test_utils.rs
@@ -6,7 +6,7 @@ use sp_std::{convert::TryInto, vec, vec::Vec};
 use t3rn_types::{sfx::SideEffect, types::Bytes};
 
 pub type Arguments = Vec<Bytes>;
-pub type Hashing = sp_runtime::traits::BlakeTwo256;
+pub type Hashing = sp_runtime::traits::Keccak256;
 
 pub const FIRST_REQUESTER_NONCE: u32 = 0;
 

--- a/runtime/standalone/src/system_config.rs
+++ b/runtime/standalone/src/system_config.rs
@@ -41,7 +41,7 @@ impl frame_system::Config for Runtime {
     /// The type for hashing blocks and tries.
     type Hash = HashPrimitive;
     /// The hashing algorithm used.
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     /// The header type.
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     /// The index type for storing how many extrinsics an account has signed.

--- a/runtime/t0rn-parachain/src/system_config.rs
+++ b/runtime/t0rn-parachain/src/system_config.rs
@@ -10,7 +10,7 @@ use frame_support::{
 };
 use pallet_asset_tx_payment::HandleCredit;
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
-use sp_runtime::traits::{BlakeTwo256, ConvertInto, Zero};
+use sp_runtime::traits::{BlakeTwo256, ConvertInto, Keccak256, Zero};
 
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
@@ -37,7 +37,7 @@ impl frame_system::Config for Runtime {
     /// The type for hashing blocks and tries.
     type Hash = HashPrimitive;
     /// The hashing algorithm used.
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     /// The header type.
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     /// The index type for storing how many extrinsics an account has signed.

--- a/runtime/t3rn-parachain/src/system_config.rs
+++ b/runtime/t3rn-parachain/src/system_config.rs
@@ -1,7 +1,7 @@
 use crate::{Hash as HashPrimitive, *};
 use frame_support::{parameter_types, weights::IdentityFee};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
-use sp_runtime::traits::BlakeTwo256;
+use sp_runtime::traits::{BlakeTwo256, Keccak256};
 
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
@@ -28,7 +28,7 @@ impl frame_system::Config for Runtime {
     /// The type for hashing blocks and tries.
     type Hash = HashPrimitive;
     /// The hashing algorithm used.
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     /// The header type.
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     /// The index type for storing how many extrinsics an account has signed.

--- a/types/abi/src/mini_mock.rs
+++ b/types/abi/src/mini_mock.rs
@@ -4,7 +4,7 @@ use frame_support::RuntimeDebug;
 use sp_core::H256;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, ConstU32, IdentityLookup},
+    traits::{ConstU32, IdentityLookup, Keccak256},
 };
 
 pub type AccountId = sp_runtime::AccountId32;
@@ -49,7 +49,7 @@ impl frame_system::Config for MiniRuntime {
     type DbWeight = ();
     type Event = ();
     type Hash = H256;
-    type Hashing = BlakeTwo256;
+    type Hashing = Keccak256;
     type Header = Header;
     type Index = u64;
     type Lookup = IdentityLookup<Self::AccountId>;


### PR DESCRIPTION
This is **breaking**!

must cover all the storage migration since Hashing affects how we map the storage keys


> 
> In Substrate-based blockchains, you have two types of hashing:
> 
> The hash used for block headers (BlockHashing)
> The hash used for runtime storage (Hashing)
> BlockHashing is used to compute the block hashes and build the blockchain itself, while Hashing is used for addressing the storage in the runtime state.
> 
> If you change the Hashing type from BlakeTwo256 to Keccak256, this means that storage items in the runtime will now be hashed using Keccak256 instead of BlakeTwo256. Essentially, this change would affect how the data stored in the blockchain's state is accessed and retrieved.
> 
> However, keep in mind that making such changes would have significant implications for your blockchain:
> 
> You'd need to ensure the entire data in your blockchain's storage is migrated to use the new hashing function. If not done properly, it can lead to loss of access to data or even inconsistent state.
> It may impact performance. BlakeTwo256 is chosen in Substrate due to its good performance and strong security. Keccak256 may be slower or faster depending on the specific implementation and hardware.
> Tools and clients interacting with your blockchain would need to be updated to use the new hashing function when dealing with runtime storage.
> On the other hand, if you keep the BlockHashing as BlakeTwo256, this means the blockchain structure and block hashing will remain the same. This is important for maintaining compatibility with Polkadot and other blockchains in the ecosystem.
> 
> In summary, it's a major change that should be undertaken with caution. Always ensure thorough testing on a non-production environment before making such changes.
> 