### PR TITLE
feat(executor): bid monitoring and logging

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -73,7 +73,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/cli/eslint_report.json
 
-      - run: yarn test
+      - run: pnpm test
 
   build-docker:
     name: Build Docker CLI

--- a/client/packages/cli/src/commands/register/gateway.ts
+++ b/client/packages/cli/src/commands/register/gateway.ts
@@ -10,7 +10,6 @@ import {
   T3rnPrimitivesExecutionVendor,
   //@ts-ignore - TS doesn't know about the type
   T3rnAbiRecodeCodec,
-  //@ts-ignore - TS doesn't know about the type
 } from "@polkadot/types/lookup"
 import { Gateway } from "@/schemas/setup.ts"
 import { colorLogMsg, log } from "@/utils/log.ts"

--- a/client/packages/cli/src/commands/register/gateway.ts
+++ b/client/packages/cli/src/commands/register/gateway.ts
@@ -2,6 +2,7 @@ import "@t3rn/types"
 import ora from "ora"
 import { ApiPromise } from "@t3rn/sdk"
 import { createType } from "@t3rn/types"
+//@ts-ignore - TS doesn't know about the type
 import {
   //@ts-ignore - TS doesn't know about the type
   T3rnPrimitivesGatewayVendor,
@@ -9,6 +10,7 @@ import {
   T3rnPrimitivesExecutionVendor,
   //@ts-ignore - TS doesn't know about the type
   T3rnAbiRecodeCodec,
+  //@ts-ignore - TS doesn't know about the type
 } from "@polkadot/types/lookup"
 import { Gateway } from "@/schemas/setup.ts"
 import { colorLogMsg, log } from "@/utils/log.ts"

--- a/client/packages/cli/src/commands/register/gateway.ts
+++ b/client/packages/cli/src/commands/register/gateway.ts
@@ -3,8 +3,11 @@ import ora from "ora"
 import { ApiPromise } from "@t3rn/sdk"
 import { createType } from "@t3rn/types"
 import {
+  //@ts-ignore - TS doesn't know about the type
   T3rnPrimitivesGatewayVendor,
+  //@ts-ignore - TS doesn't know about the type
   T3rnPrimitivesExecutionVendor,
+  //@ts-ignore - TS doesn't know about the type
   T3rnAbiRecodeCodec,
 } from "@polkadot/types/lookup"
 import { Gateway } from "@/schemas/setup.ts"
@@ -100,6 +103,7 @@ const registerGateway = async (
       codec.toJSON(),
       registrant,
       escrowAccounts,
+      //@ts-ignore - TS doesn't know about the type
       allowedSideEffects,
       tokenInfo,
       registrationData

--- a/client/packages/cli/src/utils/sfx.ts
+++ b/client/packages/cli/src/utils/sfx.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "fs"
 import { Sdk } from "@t3rn/sdk"
 import { createType } from "@t3rn/types"
+//@ts-ignore - TS doesn't know about the type
 import { T3rnTypesSfxSideEffect } from "@polkadot/types/lookup"
 import { Extrinsic, SpeedMode } from "@/schemas/extrinsic.ts"
 import {

--- a/client/packages/executor/pnpm-lock.yaml
+++ b/client/packages/executor/pnpm-lock.yaml
@@ -78,7 +78,7 @@ dependencies:
     version: 8.14.1
   pino-pretty:
     specifier: ^10.0.1
-    version: 10.0.1
+    version: 10.1.0
   prettier:
     specifier: ^3.0.0
     version: 3.0.0
@@ -585,8 +585,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@esbuild/android-arm64@0.18.14:
-    resolution: {integrity: sha512-rZ2v+Luba5/3D6l8kofWgTnqE+qsC/L5MleKIKFyllHTKHrNBMqeRCnZI1BtRx8B24xMYxeU32iIddRQqMsOsg==}
+  /@esbuild/android-arm64@0.18.15:
+    resolution: {integrity: sha512-NI/gnWcMl2kXt1HJKOn2H69SYn4YNheKo6NZt1hyfKWdMbaGadxjZIkcj4Gjk/WPxnbFXs9/3HjGHaknCqjrww==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -594,8 +594,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.18.14:
-    resolution: {integrity: sha512-blODaaL+lngG5bdK/t4qZcQvq2BBqrABmYwqPPcS5VRxrCSGHb9R/rA3fqxh7R18I7WU4KKv+NYkt22FDfalcg==}
+  /@esbuild/android-arm@0.18.15:
+    resolution: {integrity: sha512-wlkQBWb79/jeEEoRmrxt/yhn5T1lU236OCNpnfRzaCJHZ/5gf82uYx1qmADTBWE0AR/v7FiozE1auk2riyQd3w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -603,8 +603,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.18.14:
-    resolution: {integrity: sha512-qSwh8y38QKl+1Iqg+YhvCVYlSk3dVLk9N88VO71U4FUjtiSFylMWK3Ugr8GC6eTkkP4Tc83dVppt2n8vIdlSGg==}
+  /@esbuild/android-x64@0.18.15:
+    resolution: {integrity: sha512-FM9NQamSaEm/IZIhegF76aiLnng1kEsZl2eve/emxDeReVfRuRNmvT28l6hoFD9TsCxpK+i4v8LPpEj74T7yjA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -612,8 +612,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.18.14:
-    resolution: {integrity: sha512-9Hl2D2PBeDYZiNbnRKRWuxwHa9v5ssWBBjisXFkVcSP5cZqzZRFBUWEQuqBHO4+PKx4q4wgHoWtfQ1S7rUqJ2Q==}
+  /@esbuild/darwin-arm64@0.18.15:
+    resolution: {integrity: sha512-XmrFwEOYauKte9QjS6hz60FpOCnw4zaPAb7XV7O4lx1r39XjJhTN7ZpXqJh4sN6q60zbP6QwAVVA8N/wUyBH/w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -621,8 +621,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.18.14:
-    resolution: {integrity: sha512-ZnI3Dg4ElQ6tlv82qLc/UNHtFsgZSKZ7KjsUNAo1BF1SoYDjkGKHJyCrYyWjFecmXpvvG/KJ9A/oe0H12odPLQ==}
+  /@esbuild/darwin-x64@0.18.15:
+    resolution: {integrity: sha512-bMqBmpw1e//7Fh5GLetSZaeo9zSC4/CMtrVFdj+bqKPGJuKyfNJ5Nf2m3LknKZTS+Q4oyPiON+v3eaJ59sLB5A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -630,8 +630,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.18.14:
-    resolution: {integrity: sha512-h3OqR80Da4oQCIa37zl8tU5MwHQ7qgPV0oVScPfKJK21fSRZEhLE4IIVpmcOxfAVmqjU6NDxcxhYaM8aDIGRLw==}
+  /@esbuild/freebsd-arm64@0.18.15:
+    resolution: {integrity: sha512-LoTK5N3bOmNI9zVLCeTgnk5Rk0WdUTrr9dyDAQGVMrNTh9EAPuNwSTCgaKOKiDpverOa0htPcO9NwslSE5xuLA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -639,8 +639,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.18.14:
-    resolution: {integrity: sha512-ha4BX+S6CZG4BoH9tOZTrFIYC1DH13UTCRHzFc3GWX74nz3h/N6MPF3tuR3XlsNjMFUazGgm35MPW5tHkn2lzQ==}
+  /@esbuild/freebsd-x64@0.18.15:
+    resolution: {integrity: sha512-62jX5n30VzgrjAjOk5orYeHFq6sqjvsIj1QesXvn5OZtdt5Gdj0vUNJy9NIpjfdNdqr76jjtzBJKf+h2uzYuTQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -648,8 +648,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.18.14:
-    resolution: {integrity: sha512-IXORRe22In7U65NZCzjwAUc03nn8SDIzWCnfzJ6t/8AvGx5zBkcLfknI+0P+hhuftufJBmIXxdSTbzWc8X/V4w==}
+  /@esbuild/linux-arm64@0.18.15:
+    resolution: {integrity: sha512-BWncQeuWDgYv0jTNzJjaNgleduV4tMbQjmk/zpPh/lUdMcNEAxy+jvneDJ6RJkrqloG7tB9S9rCrtfk/kuplsQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -657,8 +657,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.18.14:
-    resolution: {integrity: sha512-5+7vehI1iqru5WRtJyU2XvTOvTGURw3OZxe3YTdE9muNNIdmKAVmSHpB3Vw2LazJk2ifEdIMt/wTWnVe5V98Kg==}
+  /@esbuild/linux-arm@0.18.15:
+    resolution: {integrity: sha512-dT4URUv6ir45ZkBqhwZwyFV6cH61k8MttIwhThp2BGiVtagYvCToF+Bggyx2VI57RG4Fbt21f9TmXaYx0DeUJg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -666,8 +666,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.18.14:
-    resolution: {integrity: sha512-BfHlMa0nibwpjG+VXbOoqJDmFde4UK2gnW351SQ2Zd4t1N3zNdmUEqRkw/srC1Sa1DRBE88Dbwg4JgWCbNz/FQ==}
+  /@esbuild/linux-ia32@0.18.15:
+    resolution: {integrity: sha512-JPXORvgHRHITqfms1dWT/GbEY89u848dC08o0yK3fNskhp0t2TuNUnsrrSgOdH28ceb1hJuwyr8R/1RnyPwocw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -675,8 +675,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.18.14:
-    resolution: {integrity: sha512-j2/Ex++DRUWIAaUDprXd3JevzGtZ4/d7VKz+AYDoHZ3HjJzCyYBub9CU1wwIXN+viOP0b4VR3RhGClsvyt/xSw==}
+  /@esbuild/linux-loong64@0.18.15:
+    resolution: {integrity: sha512-kArPI0DopjJCEplsVj/H+2Qgzz7vdFSacHNsgoAKpPS6W/Ndh8Oe24HRDQ5QCu4jHgN6XOtfFfLpRx3TXv/mEg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -684,8 +684,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.18.14:
-    resolution: {integrity: sha512-qn2+nc+ZCrJmiicoAnJXJJkZWt8Nwswgu1crY7N+PBR8ChBHh89XRxj38UU6Dkthl2yCVO9jWuafZ24muzDC/A==}
+  /@esbuild/linux-mips64el@0.18.15:
+    resolution: {integrity: sha512-b/tmngUfO02E00c1XnNTw/0DmloKjb6XQeqxaYuzGwHe0fHVgx5/D6CWi+XH1DvkszjBUkK9BX7n1ARTOst59w==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -693,8 +693,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.18.14:
-    resolution: {integrity: sha512-aGzXzd+djqeEC5IRkDKt3kWzvXoXC6K6GyYKxd+wsFJ2VQYnOWE954qV2tvy5/aaNrmgPTb52cSCHFE+Z7Z0yg==}
+  /@esbuild/linux-ppc64@0.18.15:
+    resolution: {integrity: sha512-KXPY69MWw79QJkyvUYb2ex/OgnN/8N/Aw5UDPlgoRtoEfcBqfeLodPr42UojV3NdkoO4u10NXQdamWm1YEzSKw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -702,8 +702,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.18.14:
-    resolution: {integrity: sha512-8C6vWbfr0ygbAiMFLS6OPz0BHvApkT2gCboOGV76YrYw+sD/MQJzyITNsjZWDXJwPu9tjrFQOVG7zijRzBCnLw==}
+  /@esbuild/linux-riscv64@0.18.15:
+    resolution: {integrity: sha512-komK3NEAeeGRnvFEjX1SfVg6EmkfIi5aKzevdvJqMydYr9N+pRQK0PGJXk+bhoPZwOUgLO4l99FZmLGk/L1jWg==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -711,8 +711,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.18.14:
-    resolution: {integrity: sha512-G/Lf9iu8sRMM60OVGOh94ZW2nIStksEcITkXdkD09/T6QFD/o+g0+9WVyR/jajIb3A0LvBJ670tBnGe1GgXMgw==}
+  /@esbuild/linux-s390x@0.18.15:
+    resolution: {integrity: sha512-632T5Ts6gQ2WiMLWRRyeflPAm44u2E/s/TJvn+BP6M5mnHSk93cieaypj3VSMYO2ePTCRqAFXtuYi1yv8uZJNA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -720,8 +720,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.18.14:
-    resolution: {integrity: sha512-TBgStYBQaa3EGhgqIDM+ECnkreb0wkcKqL7H6m+XPcGUoU4dO7dqewfbm0mWEQYH3kzFHrzjOFNpSAVzDZRSJw==}
+  /@esbuild/linux-x64@0.18.15:
+    resolution: {integrity: sha512-MsHtX0NgvRHsoOtYkuxyk4Vkmvk3PLRWfA4okK7c+6dT0Fu4SUqXAr9y4Q3d8vUf1VWWb6YutpL4XNe400iQ1g==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -729,8 +729,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.18.14:
-    resolution: {integrity: sha512-stvCcjyCQR2lMTroqNhAbvROqRjxPEq0oQ380YdXxA81TaRJEucH/PzJ/qsEtsHgXlWFW6Ryr/X15vxQiyRXVg==}
+  /@esbuild/netbsd-x64@0.18.15:
+    resolution: {integrity: sha512-djST6s+jQiwxMIVQ5rlt24JFIAr4uwUnzceuFL7BQT4CbrRtqBPueS4GjXSiIpmwVri1Icj/9pFRJ7/aScvT+A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -738,8 +738,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.18.14:
-    resolution: {integrity: sha512-apAOJF14CIsN5ht1PA57PboEMsNV70j3FUdxLmA2liZ20gEQnfTG5QU0FhENo5nwbTqCB2O3WDsXAihfODjHYw==}
+  /@esbuild/openbsd-x64@0.18.15:
+    resolution: {integrity: sha512-naeRhUIvhsgeounjkF5mvrNAVMGAm6EJWiabskeE5yOeBbLp7T89tAEw0j5Jm/CZAwyLe3c67zyCWH6fsBLCpw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -747,8 +747,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.18.14:
-    resolution: {integrity: sha512-fYRaaS8mDgZcGybPn2MQbn1ZNZx+UXFSUoS5Hd2oEnlsyUcr/l3c6RnXf1bLDRKKdLRSabTmyCy7VLQ7VhGdOQ==}
+  /@esbuild/sunos-x64@0.18.15:
+    resolution: {integrity: sha512-qkT2+WxyKbNIKV1AEhI8QiSIgTHMcRctzSaa/I3kVgMS5dl3fOeoqkb7pW76KwxHoriImhx7Mg3TwN/auMDsyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -756,8 +756,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.18.14:
-    resolution: {integrity: sha512-1c44RcxKEJPrVj62XdmYhxXaU/V7auELCmnD+Ri+UCt+AGxTvzxl9uauQhrFso8gj6ZV1DaORV0sT9XSHOAk8Q==}
+  /@esbuild/win32-arm64@0.18.15:
+    resolution: {integrity: sha512-HC4/feP+pB2Vb+cMPUjAnFyERs+HJN7E6KaeBlFdBv799MhD+aPJlfi/yk36SED58J9TPwI8MAcVpJgej4ud0A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -765,8 +765,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.18.14:
-    resolution: {integrity: sha512-EXAFttrdAxZkFQmpvcAQ2bywlWUsONp/9c2lcfvPUhu8vXBBenCXpoq9YkUvVP639ld3YGiYx0YUQ6/VQz3Maw==}
+  /@esbuild/win32-ia32@0.18.15:
+    resolution: {integrity: sha512-ovjwoRXI+gf52EVF60u9sSDj7myPixPxqzD5CmkEUmvs+W9Xd0iqISVBQn8xcx4ciIaIVlWCuTbYDOXOnOL44Q==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -774,8 +774,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.18.14:
-    resolution: {integrity: sha512-K0QjGbcskx+gY+qp3v4/940qg8JitpXbdxFhRDA1aYoNaPff88+aEwoq45aqJ+ogpxQxmU0ZTjgnrQD/w8iiUg==}
+  /@esbuild/win32-x64@0.18.15:
+    resolution: {integrity: sha512-imUxH9a3WJARyAvrG7srLyiK73XdX83NXQkjKvQ+7vPh3ZxoLrzvPkQKKw2DwZ+RV2ZB6vBfNHP8XScAmQC3aA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -2269,7 +2269,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001517
-      electron-to-chromium: 1.4.464
+      electron-to-chromium: 1.4.467
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.9)
     dev: true
@@ -2311,13 +2311,13 @@ packages:
       semver: 7.5.4
     dev: false
 
-  /bundle-require@4.0.1(esbuild@0.18.14):
+  /bundle-require@4.0.1(esbuild@0.18.15):
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.17'
     dependencies:
-      esbuild: 0.18.14
+      esbuild: 0.18.15
       load-tsconfig: 0.2.5
     dev: true
 
@@ -2680,8 +2680,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: false
 
-  /electron-to-chromium@1.4.464:
-    resolution: {integrity: sha512-guZ84yoou4+ILNdj0XEbmGs6DEWj6zpVOWYpY09GU66yEb0DSYvP/biBPzHn0GuW/3RC/pnaYNUWlQE1fJYtgA==}
+  /electron-to-chromium@1.4.467:
+    resolution: {integrity: sha512-2qI70O+rR4poYeF2grcuS/bCps5KJh6y1jtZMDDEteyKJQrzLOEhFyXCLcHW6DTBjKjWkk26JhWoAi+Ux9A0fg==}
     dev: true
 
   /elliptic@6.5.4:
@@ -2801,34 +2801,34 @@ packages:
       is-symbol: 1.0.4
     dev: false
 
-  /esbuild@0.18.14:
-    resolution: {integrity: sha512-uNPj5oHPYmj+ZhSQeYQVFZ+hAlJZbAGOmmILWIqrGvPVlNLbyOvU5Bu6Woi8G8nskcx0vwY0iFoMPrzT86Ko+w==}
+  /esbuild@0.18.15:
+    resolution: {integrity: sha512-3WOOLhrvuTGPRzQPU6waSDWrDTnQriia72McWcn6UCi43GhCHrXH4S59hKMeez+IITmdUuUyvbU9JIp+t3xlPQ==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.18.14
-      '@esbuild/android-arm64': 0.18.14
-      '@esbuild/android-x64': 0.18.14
-      '@esbuild/darwin-arm64': 0.18.14
-      '@esbuild/darwin-x64': 0.18.14
-      '@esbuild/freebsd-arm64': 0.18.14
-      '@esbuild/freebsd-x64': 0.18.14
-      '@esbuild/linux-arm': 0.18.14
-      '@esbuild/linux-arm64': 0.18.14
-      '@esbuild/linux-ia32': 0.18.14
-      '@esbuild/linux-loong64': 0.18.14
-      '@esbuild/linux-mips64el': 0.18.14
-      '@esbuild/linux-ppc64': 0.18.14
-      '@esbuild/linux-riscv64': 0.18.14
-      '@esbuild/linux-s390x': 0.18.14
-      '@esbuild/linux-x64': 0.18.14
-      '@esbuild/netbsd-x64': 0.18.14
-      '@esbuild/openbsd-x64': 0.18.14
-      '@esbuild/sunos-x64': 0.18.14
-      '@esbuild/win32-arm64': 0.18.14
-      '@esbuild/win32-ia32': 0.18.14
-      '@esbuild/win32-x64': 0.18.14
+      '@esbuild/android-arm': 0.18.15
+      '@esbuild/android-arm64': 0.18.15
+      '@esbuild/android-x64': 0.18.15
+      '@esbuild/darwin-arm64': 0.18.15
+      '@esbuild/darwin-x64': 0.18.15
+      '@esbuild/freebsd-arm64': 0.18.15
+      '@esbuild/freebsd-x64': 0.18.15
+      '@esbuild/linux-arm': 0.18.15
+      '@esbuild/linux-arm64': 0.18.15
+      '@esbuild/linux-ia32': 0.18.15
+      '@esbuild/linux-loong64': 0.18.15
+      '@esbuild/linux-mips64el': 0.18.15
+      '@esbuild/linux-ppc64': 0.18.15
+      '@esbuild/linux-riscv64': 0.18.15
+      '@esbuild/linux-s390x': 0.18.15
+      '@esbuild/linux-x64': 0.18.15
+      '@esbuild/netbsd-x64': 0.18.15
+      '@esbuild/openbsd-x64': 0.18.15
+      '@esbuild/sunos-x64': 0.18.15
+      '@esbuild/win32-arm64': 0.18.15
+      '@esbuild/win32-ia32': 0.18.15
+      '@esbuild/win32-x64': 0.18.15
     dev: true
 
   /escalade@3.1.1:
@@ -2849,14 +2849,14 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-standard-jsx@11.0.0(eslint-plugin-react@7.32.2)(eslint@8.45.0):
+  /eslint-config-standard-jsx@11.0.0(eslint-plugin-react@7.33.0)(eslint@8.45.0):
     resolution: {integrity: sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==}
     peerDependencies:
       eslint: ^8.8.0
       eslint-plugin-react: ^7.28.0
     dependencies:
       eslint: 8.45.0
-      eslint-plugin-react: 7.32.2(eslint@8.45.0)
+      eslint-plugin-react: 7.33.0(eslint@8.45.0)
     dev: false
 
   /eslint-config-standard@17.1.0(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.45.0):
@@ -2983,8 +2983,8 @@ packages:
       eslint: 8.45.0
     dev: false
 
-  /eslint-plugin-react@7.32.2(eslint@8.45.0):
-    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
+  /eslint-plugin-react@7.33.0(eslint@8.45.0):
+    resolution: {integrity: sha512-qewL/8P34WkY8jAqdQxsiL82pDUeT7nhs8IsuXgfgnsEloKCT4miAV9N9kGtx7/KM9NH/NCGUE7Edt9iGxLXFw==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -4948,8 +4948,8 @@ packages:
       split2: 4.2.0
     dev: false
 
-  /pino-pretty@10.0.1:
-    resolution: {integrity: sha512-yrn00+jNpkvZX/NrPVCPIVHAfTDy3ahF0PND9tKqZk4j9s+loK8dpzrJj4dGb7i+WLuR50ussuTAiWoMWU+qeA==}
+  /pino-pretty@10.1.0:
+    resolution: {integrity: sha512-9gAgVHCVTEq0ThcjoXkOICYQgdqh1h90WSuVAnNeCrRrefJInUvMbpDfy6PlsI29Nbu9UW9CGkUHztrR1A9N+A==}
     hasBin: true
     dependencies:
       colorette: 2.0.20
@@ -5457,11 +5457,11 @@ packages:
     dependencies:
       eslint: 8.45.0
       eslint-config-standard: 17.1.0(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.45.0)
-      eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.32.2)(eslint@8.45.0)
+      eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.33.0)(eslint@8.45.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.1.0)(eslint@8.45.0)
       eslint-plugin-n: 15.7.0(eslint@8.45.0)
       eslint-plugin-promise: 6.1.1(eslint@8.45.0)
-      eslint-plugin-react: 7.32.2(eslint@8.45.0)
+      eslint-plugin-react: 7.33.0(eslint@8.45.0)
       standard-engine: 15.1.0
       version-guard: 1.1.1
     transitivePeerDependencies:
@@ -5566,8 +5566,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /sucrase@3.33.0:
-    resolution: {integrity: sha512-ARGC7vbufOHfpvyGcZZXFaXCMZ9A4fffOGC5ucOW7+WHDGlAe8LJdf3Jts1sWhDeiI1RSWrKy5Hodl+JWGdW2A==}
+  /sucrase@3.34.0:
+    resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
@@ -5765,11 +5765,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 4.0.1(esbuild@0.18.14)
+      bundle-require: 4.0.1(esbuild@0.18.15)
       cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4(supports-color@8.1.1)
-      esbuild: 0.18.14
+      esbuild: 0.18.15
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
@@ -5777,7 +5777,7 @@ packages:
       resolve-from: 5.0.0
       rollup: 3.26.3
       source-map: 0.8.0-beta.0
-      sucrase: 3.33.0
+      sucrase: 3.34.0
       tree-kill: 1.2.2
       typescript: 5.1.6
     transitivePeerDependencies:

--- a/client/packages/executor/pnpm-lock.yaml
+++ b/client/packages/executor/pnpm-lock.yaml
@@ -93,11 +93,7 @@ dependencies:
     version: 15.2.0
   standard:
     specifier: ^17.1.0
-<<<<<<< HEAD
     version: 17.1.0(@typescript-eslint/parser@6.1.0)
-=======
-    version: 17.1.0(@typescript-eslint/parser@5.62.0)
->>>>>>> origin/development
   ts-mockito:
     specifier: ^2.6.1
     version: 2.6.1
@@ -116,19 +112,11 @@ devDependencies:
     specifier: ^5.1.1
     version: 5.1.1
   '@typescript-eslint/eslint-plugin':
-<<<<<<< HEAD
     specifier: ^6.1.0
     version: 6.1.0(@typescript-eslint/parser@6.1.0)(eslint@8.45.0)(typescript@5.1.6)
   '@typescript-eslint/parser':
     specifier: ^6.1.0
     version: 6.1.0(eslint@8.45.0)(typescript@5.1.6)
-=======
-    specifier: ^5.62.0
-    version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)(typescript@4.9.4)
-  '@typescript-eslint/parser':
-    specifier: ^5.62.0
-    version: 5.62.0(eslint@8.45.0)(typescript@4.9.4)
->>>>>>> origin/development
   eslint:
     specifier: ^8.45.0
     version: 8.45.0
@@ -137,21 +125,13 @@ devDependencies:
     version: 1.1.4(chai@4.3.7)
   ts-node:
     specifier: ^10.9.1
-<<<<<<< HEAD
     version: 10.9.1(@types/node@20.4.2)(typescript@5.1.6)
-=======
-    version: 10.9.1(@types/node@20.4.2)(typescript@4.9.4)
->>>>>>> origin/development
   tsup:
     specifier: ^7.1.0
     version: 7.1.0(ts-node@10.9.1)(typescript@5.1.6)
   typedoc:
     specifier: ^0.24.8
-<<<<<<< HEAD
     version: 0.24.8(typescript@5.1.6)
-=======
-    version: 0.24.8(typescript@4.9.4)
->>>>>>> origin/development
   typescript:
     specifier: 5.1.6
     version: 5.1.6
@@ -1818,15 +1798,9 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-<<<<<<< HEAD
   /@typescript-eslint/eslint-plugin@6.1.0(@typescript-eslint/parser@6.1.0)(eslint@8.45.0)(typescript@5.1.6):
     resolution: {integrity: sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==}
     engines: {node: ^16.0.0 || >=18.0.0}
-=======
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
->>>>>>> origin/development
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
       eslint: ^7.0.0 || ^8.0.0
@@ -1836,18 +1810,11 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-<<<<<<< HEAD
       '@typescript-eslint/parser': 6.1.0(eslint@8.45.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 6.1.0
       '@typescript-eslint/type-utils': 6.1.0(eslint@8.45.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 6.1.0(eslint@8.45.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.1.0
-=======
-      '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@4.9.4)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.45.0)(typescript@4.9.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.45.0)(typescript@4.9.4)
->>>>>>> origin/development
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.45.0
       graphemer: 1.4.0
@@ -1861,15 +1828,9 @@ packages:
       - supports-color
     dev: true
 
-<<<<<<< HEAD
   /@typescript-eslint/parser@6.1.0(eslint@8.45.0)(typescript@5.1.6):
     resolution: {integrity: sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==}
     engines: {node: ^16.0.0 || >=18.0.0}
-=======
-  /@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
->>>>>>> origin/development
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
@@ -1883,11 +1844,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.1.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.45.0
-<<<<<<< HEAD
       typescript: 5.1.6
-=======
-      typescript: 4.9.4
->>>>>>> origin/development
     transitivePeerDependencies:
       - supports-color
 
@@ -1898,15 +1855,9 @@ packages:
       '@typescript-eslint/types': 6.1.0
       '@typescript-eslint/visitor-keys': 6.1.0
 
-<<<<<<< HEAD
   /@typescript-eslint/type-utils@6.1.0(eslint@8.45.0)(typescript@5.1.6):
     resolution: {integrity: sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==}
     engines: {node: ^16.0.0 || >=18.0.0}
-=======
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.45.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
->>>>>>> origin/development
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
@@ -1914,21 +1865,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-<<<<<<< HEAD
       '@typescript-eslint/typescript-estree': 6.1.0(typescript@5.1.6)
       '@typescript-eslint/utils': 6.1.0(eslint@8.45.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.45.0
       ts-api-utils: 1.0.1(typescript@5.1.6)
       typescript: 5.1.6
-=======
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.45.0)(typescript@4.9.4)
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.45.0
-      tsutils: 3.21.0(typescript@4.9.4)
-      typescript: 4.9.4
->>>>>>> origin/development
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1957,33 +1899,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-<<<<<<< HEAD
   /@typescript-eslint/utils@6.1.0(eslint@8.45.0)(typescript@5.1.6):
     resolution: {integrity: sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
-=======
-  /@typescript-eslint/utils@5.62.0(eslint@8.45.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
->>>>>>> origin/development
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.45.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-<<<<<<< HEAD
       '@typescript-eslint/scope-manager': 6.1.0
       '@typescript-eslint/types': 6.1.0
       '@typescript-eslint/typescript-estree': 6.1.0(typescript@5.1.6)
       eslint: 8.45.0
-=======
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.4)
-      eslint: 8.45.0
-      eslint-scope: 5.1.1
->>>>>>> origin/development
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -2340,13 +2268,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-<<<<<<< HEAD
       caniuse-lite: 1.0.30001517
       electron-to-chromium: 1.4.464
-=======
-      caniuse-lite: 1.0.30001516
-      electron-to-chromium: 1.4.463
->>>>>>> origin/development
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.9)
     dev: true
@@ -2757,13 +2680,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: false
 
-<<<<<<< HEAD
   /electron-to-chromium@1.4.464:
     resolution: {integrity: sha512-guZ84yoou4+ILNdj0XEbmGs6DEWj6zpVOWYpY09GU66yEb0DSYvP/biBPzHn0GuW/3RC/pnaYNUWlQE1fJYtgA==}
-=======
-  /electron-to-chromium@1.4.463:
-    resolution: {integrity: sha512-fT3hvdUWLjDbaTGzyOjng/CQhQJSQP8ThO3XZAoaxHvHo2kUXiRQVMj9M235l8uDFiNPsPa6KHT1p3RaR6ugRw==}
->>>>>>> origin/development
     dev: true
 
   /elliptic@6.5.4:
@@ -2951,11 +2869,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.45.0
-<<<<<<< HEAD
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.1.0)(eslint@8.45.0)
-=======
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)
->>>>>>> origin/development
       eslint-plugin-n: 15.7.0(eslint@8.45.0)
       eslint-plugin-promise: 6.1.1(eslint@8.45.0)
     dev: false
@@ -2970,11 +2884,7 @@ packages:
       - supports-color
     dev: false
 
-<<<<<<< HEAD
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.1.0)(eslint-import-resolver-node@0.3.7)(eslint@8.45.0):
-=======
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint@8.45.0):
->>>>>>> origin/development
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2995,11 +2905,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-<<<<<<< HEAD
       '@typescript-eslint/parser': 6.1.0(eslint@8.45.0)(typescript@5.1.6)
-=======
-      '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@4.9.4)
->>>>>>> origin/development
       debug: 3.2.7
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
@@ -3018,11 +2924,7 @@ packages:
       regexpp: 3.2.0
     dev: false
 
-<<<<<<< HEAD
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.1.0)(eslint@8.45.0):
-=======
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.45.0):
->>>>>>> origin/development
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3032,11 +2934,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-<<<<<<< HEAD
       '@typescript-eslint/parser': 6.1.0(eslint@8.45.0)(typescript@5.1.6)
-=======
-      '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@4.9.4)
->>>>>>> origin/development
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -3044,11 +2942,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
-<<<<<<< HEAD
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.1.0)(eslint-import-resolver-node@0.3.7)(eslint@8.45.0)
-=======
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint@8.45.0)
->>>>>>> origin/development
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -5121,11 +5015,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-<<<<<<< HEAD
       ts-node: 10.9.1(@types/node@20.4.2)(typescript@5.1.6)
-=======
-      ts-node: 10.9.1(@types/node@20.4.2)(typescript@4.9.4)
->>>>>>> origin/development
       yaml: 2.3.1
     dev: true
 
@@ -5560,11 +5450,7 @@ packages:
       xdg-basedir: 4.0.0
     dev: false
 
-<<<<<<< HEAD
   /standard@17.1.0(@typescript-eslint/parser@6.1.0):
-=======
-  /standard@17.1.0(@typescript-eslint/parser@5.62.0):
->>>>>>> origin/development
     resolution: {integrity: sha512-jaDqlNSzLtWYW4lvQmU0EnxWMUGQiwHasZl5ZEIwx3S/ijZDjZOzs1y1QqKwKs5vqnFpGtizo4NOYX2s0Voq/g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
@@ -5572,11 +5458,7 @@ packages:
       eslint: 8.45.0
       eslint-config-standard: 17.1.0(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.45.0)
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.32.2)(eslint@8.45.0)
-<<<<<<< HEAD
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.1.0)(eslint@8.45.0)
-=======
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)
->>>>>>> origin/development
       eslint-plugin-n: 15.7.0(eslint@8.45.0)
       eslint-plugin-promise: 6.1.1(eslint@8.45.0)
       eslint-plugin-react: 7.32.2(eslint@8.45.0)
@@ -5819,11 +5701,7 @@ packages:
       lodash: 4.17.21
     dev: false
 
-<<<<<<< HEAD
   /ts-node@10.9.1(@types/node@20.4.2)(typescript@5.1.6):
-=======
-  /ts-node@10.9.1(@types/node@20.4.2)(typescript@4.9.4):
->>>>>>> origin/development
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -5964,11 +5842,7 @@ packages:
       is-typed-array: 1.1.12
     dev: false
 
-<<<<<<< HEAD
   /typedoc@0.24.8(typescript@5.1.6):
-=======
-  /typedoc@0.24.8(typescript@4.9.4):
->>>>>>> origin/development
     resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
     engines: {node: '>= 14.14'}
     hasBin: true

--- a/client/packages/executor/src/attestationManager/index.ts
+++ b/client/packages/executor/src/attestationManager/index.ts
@@ -105,6 +105,7 @@ export class AttestationManager {
   async listener() {
     logger.info("Listening for NewConfirmationBatch events...");
     // Subscribe to all events and filter based on the specified event method
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.client.query.system.events(async (events: any) => {
       if (events === undefined || events === null) {
         return;
@@ -119,6 +120,8 @@ export class AttestationManager {
       await this.processConfirmedBatches(attesterEvents);
     });
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async processConfirmedBatches(events: any) {
     // Loop through the Vec<EventRecord>
     await Promise.all(

--- a/client/packages/executor/src/attestationManager/index.ts
+++ b/client/packages/executor/src/attestationManager/index.ts
@@ -126,19 +126,26 @@ export class AttestationManager {
         // Extract the phase, event and the event types
         const { event } = record;
 
+        this.prometheus.attestationEvents.inc({ method: event.method });
+        if (record.event.method != "NewConfirmationBatch") {
+          return;
+        }
+
         logger.debug(
           {
             event: event.method,
             data: event.data,
           },
-          "Received attesters event"
+          "Received attesters NewConfirmationBatch event"
         );
-        this.prometheus.attestationsEvents.inc({ method: event.method });
-        if (record.event.method != "NewConfirmationBatch") {
-          return;
-        }
 
         const batch = event.data as ConfirmationBatch;
+        logger.debug(
+          {
+            batch
+          },
+          "Batch debug"
+        );
         const messageHash = this.getMessageHash(batch);
 
         await this.receiveAttestationBatchCall(batch, messageHash);
@@ -248,10 +255,10 @@ export class AttestationManager {
         { receipt: transactionReceipt },
         `Batch ${batch.index} procesed!`
       );
-      this.prometheus.attestatonsBatchesProcessed.inc();
+      this.prometheus.attestationBatchesProcessed.inc();
     } catch (error) {
       logger.warn({ error: error }, "Error sending transaction: ");
-      this.prometheus.attestatonsBatchesFailed.inc();
+      this.prometheus.attestatonBatchesFailed.inc();
       // throw new Error("Error sending transaction: " + error);
     }
   }

--- a/client/packages/executor/src/bidding/index.ts
+++ b/client/packages/executor/src/bidding/index.ts
@@ -54,15 +54,15 @@ export class BiddingEngine {
     switch (scenario) {
       case Scenario.noBidAndNoCompetition:
         bid = this.computeNoBidAndNoCompetition(sfx);
-        this.prometheus.noBidAndNoCompetition.inc();
+        this.prometheus.executorNoBidAndNoCompetition.inc();
         break;
       case Scenario.noBidButCompetition:
         bid = this.computeNoBidButCompetition(sfx);
-        this.prometheus.noBidButCompetition.inc();
+        this.prometheus.executorNoBidButCompetition.inc();
         break;
       case Scenario.beenOutbid:
         bid = this.computeBeenOutbid(sfx);
-        this.prometheus.beenOutBid.inc();
+        this.prometheus.executorBeenOutBid.inc();
         break;
     }
     return bid;

--- a/client/packages/executor/src/circuit/listener.ts
+++ b/client/packages/executor/src/circuit/listener.ts
@@ -80,8 +80,7 @@ export class CircuitListener extends EventEmitter {
             data: notifications[i].event.data,
           });
         } else if (notifications[i].event.method === "HeadersAdded") {
-          logger.info(notifications[i].toHuman());
-
+          logger.debug({event: notifications[i].toHuman()}, "Received new headers with HeadersAdded event");
           let vendor = "";
           if (notifications[i].event.section === "rococoBridge") {
             vendor = "Rococo";

--- a/client/packages/executor/src/circuit/listener.ts
+++ b/client/packages/executor/src/circuit/listener.ts
@@ -2,6 +2,7 @@ import "@t3rn/types";
 import { EventEmitter } from "events";
 import { Sdk } from "@t3rn/sdk";
 import { Codec } from "@polkadot/types/types";
+import { logger } from "../logging";
 
 /**
  * Enum for the different types of events emitted by the relayer
@@ -79,7 +80,7 @@ export class CircuitListener extends EventEmitter {
             data: notifications[i].event.data,
           });
         } else if (notifications[i].event.method === "HeadersAdded") {
-          console.log(notifications[i].toHuman());
+          logger.info(notifications[i].toHuman());
 
           let vendor = "";
           if (notifications[i].event.section === "rococoBridge") {

--- a/client/packages/executor/src/circuit/relayer.ts
+++ b/client/packages/executor/src/circuit/relayer.ts
@@ -8,6 +8,7 @@ import { Sdk, ApiPromise } from "@t3rn/sdk";
 import { Codec } from "@polkadot/types/types";
 // @ts-ignore - Typescript does not know about this type
 import { T3rnTypesSfxConfirmedSideEffect } from "@polkadot/types/lookup";
+import { logger } from "../logging";
 
 /**
  * Class responsible for submitting any type of transaction to the circuit. All communication with the circuit is done through the circuit relayer.
@@ -128,7 +129,7 @@ export const exportData = (
     JSON.stringify(encoded, null, 4),
     (err) => {
       if (err) {
-        console.log("Err", err);
+        logger.error({err}, "Export data failed");
       }
     },
   );

--- a/client/packages/executor/src/executionManager/execution.ts
+++ b/client/packages/executor/src/executionManager/execution.ts
@@ -16,6 +16,7 @@ import { BiddingEngine } from "../bidding";
 import { Logger } from "pino";
 import { EventData } from "src/circuit/listener";
 import { Prometheus } from "../prometheus";
+import { logger } from "../logging";
 
 /**
  * Class used for tracking the life-cycle of an XTX. Contains all required parameters and methods for executing the XTX.
@@ -138,15 +139,13 @@ export class Execution extends EventEmitter {
       sfx.readyToExecute();
     }
 
-    this.logger.info(`Ready XTX: ${this.humanId}`);
-    this.addLog({ msg: "Ready XTX" });
+    logger.info(`Ready XTX: ${this.humanId}`);
   }
 
   /** Update XTX status to complete */
   completed() {
     this.status = XtxStatus.FinishedAllSteps;
-    this.logger.info(`Completed XTX: ✨${this.humanId}✨`);
-    this.addLog({ msg: "Completed XTX" });
+    logger.info(`Completed XTX: ✨${this.humanId}✨`);
   }
 
   /** Update XTX and all its SFX status to ready. */
@@ -155,8 +154,7 @@ export class Execution extends EventEmitter {
     for (const [, sfx] of this.sideEffects) {
       sfx.droppedAtBidding();
     }
-    this.logger.info(`Dropped XTX: ${this.humanId}`);
-    this.addLog({ msg: "Dropped XTX", xtxId: this.id });
+    logger.info({ xtxId: this.id }, "Dropped XTX");
   }
 
   /** Update XTX and all its SFX status to reverted. */
@@ -166,8 +164,7 @@ export class Execution extends EventEmitter {
       sfx.reverted();
     }
 
-    this.logger.info(`Revert XTX: ${this.humanId}`);
-    this.addLog({ msg: "Revert XTX", xtxId: this.id });
+    logger.info({  xtxId: this.id }, "Revert XTX");
   }
 
   /**
@@ -187,24 +184,5 @@ export class Execution extends EventEmitter {
       }
     }
     return result;
-  }
-
-  private addLog(
-    msg: {
-      msg: string;
-      component?: string;
-      id?: string;
-      xtxId?: string;
-    },
-    debug = true,
-  ) {
-    msg.component = "XTX";
-    msg.id = this.id;
-
-    if (debug) {
-      this.logger.debug(msg);
-    } else {
-      this.logger.error(msg);
-    }
   }
 }

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -134,7 +134,7 @@ export class ExecutionManager {
     await this.initializeGateways(gatewayConfig);
     await this.circuitListener.start();
     await this.initializeEventListeners();
-    logger.info("Setup Successful");
+    logger.info("ExecutionManager setup successful");
   }
 
   /** Initiates a shutdown, the promise resolves once all executions are done. */

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -559,7 +559,7 @@ export class ExecutionManager {
               sfx.bidAccepted(notification.payload.bidAmount as number);
             })
             .catch((e) => {
-              logger.info(`Bid rejected for SFX ${sfx.humanId} ❌`);
+              logger.warn(`Bid rejected for SFX ${sfx.humanId} ❌`);
               sfx.bidRejected(e);
             });
         }

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -21,6 +21,7 @@ import { Config, Gateway } from "../../config/config";
 import { Logger } from "pino";
 import BN from "bn.js";
 import { Prometheus } from "../prometheus";
+import { logger } from "../logging";
 
 // A type used for storing the different SideEffects throughout their respective life-cycle.
 // Please note that waitingForInsurance and readyToExecute are only used to track the progress. The actual logic is handeled in the execution
@@ -133,7 +134,7 @@ export class ExecutionManager {
     await this.initializeGateways(gatewayConfig);
     await this.circuitListener.start();
     await this.initializeEventListeners();
-    this.addLog({ msg: "Setup Successful" });
+    logger.info("Setup Successful");
   }
 
   /** Initiates a shutdown, the promise resolves once all executions are done. */
@@ -198,7 +199,7 @@ export class ExecutionManager {
         // initialize gateway relayer
         const relayer = new SubstrateRelayer();
 
-        await relayer.setup(config, this.logger);
+        await relayer.setup(config, logger);
 
         this.relayers[entry.id] = relayer;
 
@@ -228,11 +229,12 @@ export class ExecutionManager {
                   eventData.sfxId,
                 );
 
-                this.addLog({
-                  msg: "moved sfx from isExecuting to isConfirming",
+                logger.info({
                   sfxId: eventData.sfxId,
                   xtxId: this.sfxToXtx[eventData.sfxId],
-                });
+                },
+                  "SFX transition from isExecuting to isConfirming",
+                );
               }
               break;
             case RelayerEvents.HeaderInclusionProofRequest:
@@ -266,7 +268,7 @@ export class ExecutionManager {
         });
       }
 
-      this.addLog({ msg: "Gateways Initialized" });
+      logger.info("Gateways Initialized");
     }
   }
 
@@ -309,11 +311,10 @@ export class ExecutionManager {
             if (!sfx) break;
 
             sfx.confirmedOnCircuit();
-            this.addLog({
-              msg: "Sfx confirmed",
+            logger.info({
               sfxId: sfxId,
               xtxId: this.sfxToXtx[sfxId],
-            });
+            }, "Sfx confirmed");
           }
           break;
         case ListenerEvents.XtxCompleted:
@@ -337,7 +338,7 @@ export class ExecutionManager {
   async addXtx(xtxData: EventData, sdk: Sdk) {
     // create the XTX object
     const xtx = new Execution(
-      this.logger,
+      logger,
       sdk.signer.address,
       xtxData,
       sdk,
@@ -349,16 +350,15 @@ export class ExecutionManager {
     // Run the XTX strategy checks
     try {
       this.strategyEngine.evaluateXtx(xtx);
-      this.addLog({ msg: "XTX strategy passed!", xtxId: xtx.id });
+      logger.info({  xtxId: xtx.id }, "XTX strategy passed!");
     } catch (e) {
       // XTX does not meet strategy requirements
-      this.addLog({
-        msg: "XTX strategy reject! " + e.toString(),
+      logger.warn({
         xtxId: xtx.id,
-      });
+      }, "XTX strategy reject! " + e.toString(),);
       return;
     }
-    this.logger.info(`Received XTX ${xtx.humanId} 🌱`); // XTX is valid for execution
+    logger.info(`Received XTX ${xtx.humanId} 🌱`); // XTX is valid for execution
 
     // add XTX and init required event listeners
     this.xtx[xtx.id] = xtx;
@@ -368,7 +368,7 @@ export class ExecutionManager {
       this.queue[sfx.vendor].isBidding.push(sfxId);
       await this.addRiskRewardParameters(sfx);
     }
-    this.addLog({ msg: "XTX initialized", xtxId: xtx.id });
+    logger.info({ xtxId: xtx.id }, "XTX initialized");
   }
 
   /**
@@ -403,7 +403,7 @@ export class ExecutionManager {
       // Get the SFX that the executor has won the bid on and can execute now
       const ready = this.xtx[xtxId].getReadyToExecute();
       if (ready.length > 0) {
-        this.logger.info(
+        logger.info(
           `Won bids for XTX ${this.xtx[xtxId].humanId}: ${ready.map(
             (sfx) => sfx.humanId,
           )} 🏆`,
@@ -429,12 +429,11 @@ export class ExecutionManager {
    * @param blockHeight The latest block height
    */
   updateGatewayHeight(vendor: string, blockHeight: number) {
-    this.addLog({
-      msg: "Update Gateway Height",
+    logger.info({
       vendor: vendor,
       blockHeight: blockHeight,
-    });
-    this.logger.info(`Gateway height updated: ${vendor} #${blockHeight} 🧱`);
+    }, "Update Gateway Height");
+      
     if (this.queue[vendor]) {
       this.queue[vendor].blockHeight = blockHeight;
       this.executeConfirmationQueue(vendor);
@@ -482,33 +481,34 @@ export class ExecutionManager {
 
     // if we found SFXs, we confirm them
     if (readyByStep.length > 0) {
-      this.addLog({
-        msg: "Execute confirmation queue",
+      logger.info({
         gatewayId: vendor,
         sfxIds: readyByStep.map((sfx) => sfx.id),
-      });
+      },
+        "Execute confirmation queue",
+      );
       this.circuitRelayer
         .confirmSideEffects(readyByStep)
         .then(() => {
           // remove from queue and update status
-          this.logger.info(
+          logger.info(
             `Confirmed SFXs: ${readyByStep.map((sfx) => sfx.humanId)} 📜`,
           );
           this.processConfirmationBatch(readyByStep, batchBlocks, vendor);
-          this.addLog({
-            msg: "Confirmation batch successful",
+          logger.info({
             vendor: vendor,
-          });
+          },
+         "Confirmation batch successful");
         })
         .catch((err) => {
-          this.addLog(
+          logger.info(
             {
-              msg: "Error confirming side effects",
+              
               vendor: vendor,
               sfxIds: readyByStep.map((sfx) => sfx.id),
               error: err,
             },
-            false,
+ "Error confirming side effects"
           );
         });
     }
@@ -557,7 +557,7 @@ export class ExecutionManager {
               sfx.bidAccepted(notification.payload.bidAmount as number);
             })
             .catch((e) => {
-              this.logger.info(`Bid rejected for SFX ${sfx.humanId} ❌`);
+              logger.info(`Bid rejected for SFX ${sfx.humanId} ❌`);
               sfx.bidRejected(e);
             });
         }
@@ -645,15 +645,5 @@ export class ExecutionManager {
       this.queue[gatewayId][queue].splice(index, 1);
     }
     this.biddingEngine.cleanUp(id);
-  }
-
-  private addLog(msg: object, debug = true) {
-    msg["component"] = "ExecutionManager";
-
-    if (debug) {
-      this.logger.debug(msg);
-    } else {
-      this.logger.error(msg);
-    }
   }
 }

--- a/client/packages/executor/src/executionManager/index.ts
+++ b/client/packages/executor/src/executionManager/index.ts
@@ -353,9 +353,11 @@ export class ExecutionManager {
       logger.info({  xtxId: xtx.id }, "XTX strategy passed!");
     } catch (e) {
       // XTX does not meet strategy requirements
+      this.prometheus.executorXtxStrategyRejects.inc();
       logger.warn({
+        e: e.toString(),
         xtxId: xtx.id,
-      }, "XTX strategy reject! " + e.toString(),);
+      }, "XTX strategy reject!");
       return;
     }
     logger.info(`Received XTX ${xtx.humanId} 🌱`); // XTX is valid for execution

--- a/client/packages/executor/src/executionManager/sideEffect.ts
+++ b/client/packages/executor/src/executionManager/sideEffect.ts
@@ -332,9 +332,14 @@ export class SideEffect extends EventEmitter {
    */
   // ToDo fix return type
   private generateBid() {
-    if (this.isBidder) return { trigger: false, reason: "Already a bidder" };
-    if (this.txStatus !== TxStatus.Ready)
+    if (this.isBidder) {
+
+      return { trigger: false, reason: "Already a bidder" };
+    }
+    if (this.txStatus !== TxStatus.Ready) {
+
       return { trigger: false, reason: "Tx not ready" };
+    }
     if (this.status !== SfxStatus.InBidding)
       return { trigger: false, reason: "Not in bidding phase" };
 
@@ -351,7 +356,7 @@ export class SideEffect extends EventEmitter {
 
     const bidUsd = this.biddingEngine.computeBid(this);
     const bidRewardAsset = bidUsd / this.rewardAssetPrice.getValue();
-    this.prometheus.bids.inc();
+    this.prometheus.executorBids.inc();
 
     return { trigger: true, bidAmount: floatToBn(bidRewardAsset) };
   }

--- a/client/packages/executor/src/gateways/substrate/relayer.ts
+++ b/client/packages/executor/src/gateways/substrate/relayer.ts
@@ -10,6 +10,7 @@ import { CostEstimator, Estimate } from "./estimator/cost";
 import { Sdk, Utils } from "@t3rn/sdk";
 import { Gateway } from "../../../config/config";
 import { Logger } from "pino";
+import { logger } from "../../logging";
 
 /**
  * Class responsible for submitting transactions to a target chain. Three main tasks are handled by this class:
@@ -75,7 +76,7 @@ export class SubstrateRelayer extends EventEmitter {
    * @param sfx Object to execute
    */
   async executeTx(sfx: SideEffect) {
-    this.logger.info(
+    logger.info(
       `Execution started SFX: ${sfx.humanId} - ${sfx.target} with nonce: ${this.nonce} 🔮`,
     );
     const tx = this.buildTx(sfx) as SubmittableExtrinsic;
@@ -91,7 +92,7 @@ export class SubstrateRelayer extends EventEmitter {
             const err = this.client.registry.findMetaError(
               dispatchError.asModule,
             );
-            this.logger.info(`Execution failed SFX: ${sfx.humanId}`);
+            logger.info(`Execution failed SFX: ${sfx.humanId}`);
             this.emit("Event", <RelayerEventData>{
               type: RelayerEvents.SfxExecutionError,
               data: `${err.section}::${err.name}: ${err.docs.join(" ")}`,
@@ -122,7 +123,7 @@ export class SubstrateRelayer extends EventEmitter {
               status.asFinalized as never,
               events,
             );
-            this.logger.info(
+            logger.info(
               `Execution complete SFX:  ${sfx.humanId} - #${blockNumber} 🏁`,
             );
             this.emit("Event", <RelayerEventData>{
@@ -169,7 +170,7 @@ export class SubstrateRelayer extends EventEmitter {
         blockHash,
       ).catch((err) => {
         // this should never happen
-        console.log(err);
+        logger.error({err}, "Failed to fetch corresponding relaychain header number");
       });
 
       this.emit("Event", <RelayerEventData>{
@@ -291,7 +292,7 @@ export class SubstrateRelayer extends EventEmitter {
     });
 
     if (!event) {
-      console.log("Event not found");
+      logger.warn("Event not found");
       return;
     }
 

--- a/client/packages/executor/src/index.ts
+++ b/client/packages/executor/src/index.ts
@@ -39,6 +39,7 @@ import * as defaultConfig from "../config.json";
 import { problySubstrateSeed, createLogger } from "./utils";
 import { Logger } from "pino";
 import { Prometheus } from "./prometheus";
+import { logger } from "./logging";
 
 dotenv.config();
 
@@ -113,7 +114,7 @@ class Instance {
     // TODO: on nodejs it just freeze execution
     // this.registerExitListener();
     this.registerStateListener();
-    this.logger.info("setup complete");
+    logger.info("Executor setup complete");
     return this;
   }
 

--- a/client/packages/executor/src/pricing/coingecko.ts
+++ b/client/packages/executor/src/pricing/coingecko.ts
@@ -1,6 +1,7 @@
 import { config } from "../../config/config";
 import { BehaviorSubject } from "rxjs";
 import axios from "axios";
+import { logger } from "../logging";
 
 /**
  * MVP implementation of sourcing prices from coingecko
@@ -70,7 +71,7 @@ export class CoingeckoPricing {
           return new Promise((resolve) => setTimeout(resolve, 2000));
         })
         .catch((err) => {
-          console.log("Failed fetching prices due to ->", err.toString());
+          logger.error({err}, "Failed fetching prices");
         });
     }
     setTimeout(this.updateAssetPrices.bind(this), this.updateFrequency);

--- a/client/packages/executor/src/prometheus.ts
+++ b/client/packages/executor/src/prometheus.ts
@@ -11,9 +11,9 @@ export class Prometheus {
   isActive: boolean;
 
   // Metrics
-  bids: Counter;
   events: Counter;
   circuitDisconnects: Counter;
+  executorBids: Counter;
   executorXtxStrategyRejects: Counter;
   executorNoBidAndNoCompetition: Counter;
   executorNoBidButCompetition: Counter;
@@ -35,8 +35,8 @@ export class Prometheus {
   createMetrics() {
     // Collects default metrics
     collectDefaultMetrics({ register: this.register });
-    this.bids = new Counter({
-      name: "bids",
+    this.executorBids = new Counter({
+      name: "executor_bids",
       help: "Number of bids",
       registers: [this.register],
     });
@@ -61,19 +61,19 @@ export class Prometheus {
     });
 
     this.executorNoBidAndNoCompetition = new Counter({
-      name: "no_bid_and_no_competition",
+      name: "executor_no_bid_and_no_competition",
       help: "Number of times no bid and no competition",
       registers: [this.register],
     });
 
     this.executorNoBidButCompetition = new Counter({
-      name: "no_bid_but_competition",
+      name: "executor_no_bid_but_competition",
       help: "Number of times no bid but competition",
       registers: [this.register],
     });
 
     this.executorBeenOutBid = new Counter({
-      name: "been_out_bid",
+      name: "executor_been_out_bid",
       help: "Number of times been out bid",
       registers: [this.register],
     });

--- a/client/packages/executor/src/prometheus.ts
+++ b/client/packages/executor/src/prometheus.ts
@@ -14,16 +14,17 @@ export class Prometheus {
   bids: Counter;
   events: Counter;
   circuitDisconnects: Counter;
-  noBidAndNoCompetition: Counter;
-  noBidButCompetition: Counter;
-  beenOutBid: Counter;
+  executorXtxStrategyRejects: Counter;
+  executorNoBidAndNoCompetition: Counter;
+  executorNoBidButCompetition: Counter;
+  executorBeenOutBid: Counter;
   attestationsBatchesPending: Gauge;
-  attestationsEvents: Counter
+  attestationEvents: Counter
   attestationVerifierCurrentCommitteeSize: Gauge;
   attestationVerifierCurrentBatchIndex: Gauge;
   attestationVerifierCurrentCommitteeTransitionCount: Gauge;
-  attestatonsBatchesProcessed: Counter;
-  attestatonsBatchesFailed: Counter;
+  attestationBatchesProcessed: Counter;
+  attestatonBatchesFailed: Counter;
 
   constructor() {
     const Registry = client.Registry;
@@ -53,19 +54,25 @@ export class Prometheus {
       registers: [this.register],
     });
 
-    this.noBidAndNoCompetition = new Counter({
+    this.executorXtxStrategyRejects = new Counter({
+      name: "executor_xtx_strategy_rejects_total",
+      help: "Number of times executor xtx strategy rejects",
+      registers: [this.register],
+    });
+
+    this.executorNoBidAndNoCompetition = new Counter({
       name: "no_bid_and_no_competition",
       help: "Number of times no bid and no competition",
       registers: [this.register],
     });
 
-    this.noBidButCompetition = new Counter({
+    this.executorNoBidButCompetition = new Counter({
       name: "no_bid_but_competition",
       help: "Number of times no bid but competition",
       registers: [this.register],
     });
 
-    this.beenOutBid = new Counter({
+    this.executorBeenOutBid = new Counter({
       name: "been_out_bid",
       help: "Number of times been out bid",
       registers: [this.register],
@@ -77,7 +84,7 @@ export class Prometheus {
       registers: [this.register],
     });
 
-    this.attestationsEvents = new client.Counter({
+    this.attestationEvents = new client.Counter({
         name: 'attestation_events_total',
         help: 'Number of attestations received',
         registers: [this.register],
@@ -102,13 +109,13 @@ export class Prometheus {
       registers: [this.register],
     });
 
-    this.attestatonsBatchesProcessed = new Counter({
+    this.attestationBatchesProcessed = new Counter({
       name: "attestations_batches_processed_total",
       help: "Number of attestations batches processed",
       registers: [this.register],
     });
 
-    this.attestatonsBatchesFailed = new Counter({
+    this.attestatonBatchesFailed = new Counter({
       name: "attestations_batches_failed_total",
       help: "Number of attestations batches failed",
       registers: [this.register],

--- a/client/packages/executor/src/prometheus.ts
+++ b/client/packages/executor/src/prometheus.ts
@@ -141,7 +141,7 @@ export class Prometheus {
     });
 
     this.server.listen(port, () => {
-      console.log(`Metrics server listening on port ${port}`);
+      logger.info(`Metrics server listening on port ${port}`);
     });
   }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Refactor: Updated logging throughout the codebase to use a shared logger module instead of `console.log`. Replaced `console.log` statements with appropriate logger method calls.
- Bug fix: Fixed Prometheus metric names and added new counters for executor bid monitoring and logging. Renamed existing counters for consistency.
- Chore: Updated command in CI workflow to use `pnpm test` instead of `yarn test`.
- Documentation: Added import statements and TypeScript compiler ignores for type definitions.

> "Code refactored, logs now shine bright,
> Metrics fixed, errors take flight.
> CI workflow dances with glee,
> Docs and imports, clearer to see.
> Changes abound, bugs no more,
> A release to celebrate, let's soar!"
<!-- end of auto-generated comment: release notes by openai -->