### PR TITLE
fix: move process estimation of treasury balances to on_initialize hook

### DIFF
--- a/pallets/rewards/src/lib.rs
+++ b/pallets/rewards/src/lib.rs
@@ -716,7 +716,7 @@ pub mod pallet {
             }
         }
 
-        pub fn process_update_estimated_treasury_balance() {
+        pub fn process_update_estimated_treasury_balance() -> Weight {
             let treasury_balance = TreasuryBalanceSheet {
                 escrow: T::Currency::free_balance(&T::TreasuryAccounts::get_treasury_account(
                     TreasuryAccount::Escrow,
@@ -735,6 +735,8 @@ pub mod pallet {
                 )),
             };
             EstimatedTreasuryBalance::<T>::put(treasury_balance);
+
+            T::DbWeight::get().reads_writes(1, 1)
         }
 
         pub fn process_authors_this_period() -> Weight {
@@ -925,12 +927,10 @@ pub mod pallet {
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-        fn on_finalize(_n: BlockNumberFor<T>) {
-            Self::process_update_estimated_treasury_balance()
-        }
+        fn on_finalize(_n: BlockNumberFor<T>) {}
 
         fn on_initialize(_n: T::BlockNumber) -> Weight {
-            0
+            Self::process_update_estimated_treasury_balance()
         }
     }
 


### PR DESCRIPTION
Closes #1162 

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Moved the process of estimating treasury balances to the `on_initialize` hook in the rewards pallet.
- Added a return type to the `process_update_estimated_treasury_balance` function.
- Removed the call to `process_update_estimated_treasury_balance` from the `on_finalize` hook.

> 🎉 In the heart of our code, a change takes flight, 🚀
> Shifting balance estimates to initialize, oh what a sight! 👀
> Return types added, and finalize set right, ✅
> Our code dances with joy, basking in the light. 💃🕺
<!-- end of auto-generated comment: release notes by openai -->