### PR TITLE
fix: remove remaining deprecated XDNS records with storage migration

### DIFF
--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -182,6 +182,22 @@ pub mod pallet {
                         // Return the weight consumed by the migration.
                         Ok::<Weight, DispatchError>(T::DbWeight::get().writes(1))
                     }
+                    // Storage Migration: Another Raw XDNS storage entry kill
+                    // Storage Migration Details: 27-07-2023; v1.4.44-rc -> v1.4.45-rc
+                    //     Many Collators on t0rn hit: frame_support::storage: (key, value) failed to decode at [84, 10, 79, 135, 84, 170, 82, 152, 163, 214, 233, 170, 9, 233, 63, 151, 78, 11,
+                    //      18, 119, 80, 58, 19, 112, 111, 133, 165, 20, 116, 96, 124, 88, 24, 172, 250, 191, 195, 140, 91, 41, 106, 32, 177, 28, 37, 248, 177, 35, 27, 230, 169, 204, 8, 192, 121, 163, 226, 24, 100, 166, 207, 36, 66, 173, 219, 150, 184, 250, 101, 171, 135, 85,]
+                    2 => {
+                        // Manually kill the old XDNS storage entry (XDNSRegistry is now replaced by Gateways)
+                        frame_support::storage::unhashed::kill(&[84, 10, 79, 135, 84, 170, 82, 152, 163, 214, 233, 170, 9, 233, 63, 151, 78, 11,
+                            18, 119, 80, 58, 19, 112, 111, 133, 165, 20, 116, 96, 124, 88, 24, 172, 250,
+                            191, 195, 140, 91, 41, 106, 32, 177, 28, 37, 248, 177, 35, 27, 230, 169, 204,
+                            8, 192, 121, 163, 226, 24, 100, 166, 207, 36, 66, 173, 219, 150, 184, 250, 101,
+                            171, 135, 85,]);
+                        // Set migrations_done to true
+                        *current_version = CURRENT_STORAGE_VERSION;
+                        // Return the weight consumed by the migration.
+                        Ok::<Weight, DispatchError>(T::DbWeight::get().writes(1))
+                    }
                     // Add more migration cases here, if needed in the future
                     _ => {
                         // No migration needed.

--- a/pallets/xdns/src/tests.rs
+++ b/pallets/xdns/src/tests.rs
@@ -1467,3 +1467,43 @@ fn test_storage_migration_v143_to_v144_that_kills_old_xdns_records_entry() {
             );
         });
 }
+
+#[test]
+fn test_storage_migration_v144_to_v145_that_kills_old_xdns_records_entry() {
+    ExtBuilder::default()
+        .with_standard_sfx_abi()
+        .with_default_xdns_records()
+        .build()
+        .execute_with(|| {
+            // Insert raw xdns records entry
+            frame_support::storage::unhashed::put_raw(
+                &[
+                    84, 10, 79, 135, 84, 170, 82, 152, 163, 214, 233, 170, 9, 233, 63, 151, 78, 11,
+                    18, 119, 80, 58, 19, 112, 111, 133, 165, 20, 116, 96, 124, 88, 24, 172, 250,
+                    191, 195, 140, 91, 41, 106, 32, 177, 28, 37, 248, 177, 35, 27, 230, 169, 204,
+                    8, 192, 121, 163, 226, 24, 100, 166, 207, 36, 66, 173, 219, 150, 184, 250, 101,
+                    171, 135, 85,
+                ],
+                &[3, 2, 1],
+            );
+
+            pallet_xdns::StorageMigrations::<Runtime>::set(2);
+
+            // Perform the runtime upgrade (call the `on_runtime_upgrade` function)
+            let consumed_weight =
+                <XDNS as frame_support::traits::OnRuntimeUpgrade>::on_runtime_upgrade();
+            let max_weight = <Runtime as frame_system::Config>::DbWeight::get().reads_writes(0, 1);
+            assert_eq!(consumed_weight, max_weight);
+
+            assert_eq!(
+                frame_support::storage::unhashed::get::<Vec<u8>>(&[
+                    84, 10, 79, 135, 84, 170, 82, 152, 163, 214, 233, 170, 9, 233, 63, 151, 78, 11,
+                    18, 119, 80, 58, 19, 112, 111, 133, 165, 20, 116, 96, 124, 88, 24, 172, 250,
+                    191, 195, 140, 91, 41, 106, 32, 177, 28, 37, 248, 177, 35, 27, 230, 169, 204,
+                    8, 192, 121, 163, 226, 24, 100, 166, 207, 36, 66, 173, 219, 150, 184, 250, 101,
+                    171, 135, 85,
+                ],),
+                None
+            );
+        });
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
**Refactor:**
- Added a new migration case to remove deprecated XDNS storage entries. This change ensures the system remains clean and efficient by eliminating outdated data.

**Test:**
- Introduced a test case `test_storage_migration_v144_to_v145_that_kills_old_xdns_records_entry()` to verify the successful removal of specific XDNS records during storage migration.
```

> Here's to the code that's lean and bright, 🌟  
> To the old records gone from sight. 🚀  
> With tests in place, we stand upright, 💪  
> Celebrating our code's new flight! 🎉
<!-- end of auto-generated comment: release notes by openai -->