### PR TITLE
fix: reduce majority threshold to unbrick LC

### DIFF
--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -499,7 +499,7 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThreshold: u32 = 80;
+    pub const CommitteeMajorityThreshold: u32 = 67;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -499,11 +499,12 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThreshold: u32 = 67;
+    pub const CommitteeMajorityThresholdEth2: u32 = 80;
+    pub const CommitteeMajorityThresholdSepolia: u32 = 67;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {
-    type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
+    type CommitteeMajorityThreshold = CommitteeMajorityThresholdEth2;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
     type Event = Event;
     type GenesisValidatorRoot = GenesisValidatorsRoot;
@@ -515,7 +516,7 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 }
 
 impl pallet_sepolia_finality_verifier::Config for Runtime {
-    type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
+    type CommitteeMajorityThreshold = CommitteeMajorityThresholdSepolia;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
     type Event = Event;
     type GenesisValidatorRoot = GenesisValidatorsRoot;


### PR DESCRIPTION
On sepolia we have a lot of skipped votes. For this reason I am reducing the majority threshold to 67%, in effect unbricking the current light client instance
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
**Refactor:**
- Reduced the `CommitteeMajorityThreshold` constant from 80 to 67.
- Adjusted the majority threshold for `Eth2` and `Sepolia` configurations.

```

> Here's to the code that's leaner, not meaner 🎉
>
> With thresholds lowered, our system's keener 💡
>
> For `Eth2` and `Sepolia`, a change so serene,
>
> In this PR, a more efficient scene! 🚀
<!-- end of auto-generated comment: release notes by openai -->