### PR TITLE
fix: temporarily set 67% committee majority threshold to Sepolia light client 

### DIFF
--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -499,7 +499,7 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThresholdEth2: u32 = 80;
+    pub const CommitteeMajorityThresholdEth2: u32 = 67;
     pub const CommitteeMajorityThresholdSepolia: u32 = 67;
 }
 

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -499,7 +499,7 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThreshold: u32 = 80;
+    pub const CommitteeMajorityThreshold: u32 = 67;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -499,11 +499,12 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThreshold: u32 = 67;
+    pub const CommitteeMajorityThresholdEth2: u32 = 80;
+    pub const CommitteeMajorityThresholdSepolia: u32 = 67;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {
-    type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
+    type CommitteeMajorityThreshold = CommitteeMajorityThresholdEth2;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
     type Event = Event;
     type GenesisValidatorRoot = GenesisValidatorsRoot;
@@ -515,7 +516,7 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 }
 
 impl pallet_sepolia_finality_verifier::Config for Runtime {
-    type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
+    type CommitteeMajorityThreshold = CommitteeMajorityThresholdSepolia;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
     type Event = Event;
     type GenesisValidatorRoot = GenesisValidatorsRoot;


### PR DESCRIPTION
fix: temporarily set 67% committee threshold to Eth2 light client, since we'll need to re-connect between Sepolia and Ethereum. 
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Adjusted the `CommitteeMajorityThresholdEth2` value from 80 to 67 in `runtime/t0rn-parachain/src/circuit_config.rs`.

> 🎉 A tweak, a change, a simple little shift,
> From 80 down to 67, giving our code a lift.
> Like a river's course subtly altered, it flows,
> In the realm of circuits, where the wild data grows. 🌱🌊💻
<!-- end of auto-generated comment: release notes by openai -->