### PR TITLE
fix: reduce majority threshold to unbrick LC

### DIFF
--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -499,8 +499,8 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThresholdEth2: u32 = 67;
-    pub const CommitteeMajorityThresholdSepolia: u32 = 67;
+    pub const CommitteeMajorityThresholdEth2: u32 = 56;
+    pub const CommitteeMajorityThresholdSepolia: u32 = 56;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {


### PR DESCRIPTION
Temporarily set 56% committee threshold to Eth2 light client, since we'll need to re-connect between Sepolia and Ethereum.

Because https://sepolia.beaconcha.in/slot/2890977 has 58% participation

