### PR TITLE
test(zombienet): zombie should test single parachain

### DIFF
--- a/tests/zombienet/smoke/0001-is_up_and_registered.feature
+++ b/tests/zombienet/smoke/0001-is_up_and_registered.feature
@@ -1,17 +1,11 @@
-Description: Smoke test - parachains are up and registered
+Description: Smoke test - parachain is up and registered
 Network: ../zombienet.toml
 Creds: config
 
 alice: is up
 bob: is up
 
-alice: parachain 3333 is registered within 225 seconds
-alice: parachain 3334 is registered within 225 seconds
-
-{% set nodes = ["t3rn-collator01", "t3rn-collator02"] %}
-{% for node in nodes %}
-{{node}}: reports block height is at least 5 within 250 seconds
-{% endfor %}
+alice: parachain 3333 is registered within 125 seconds
 
 {% set nodes = ["t0rn-collator01", "t0rn-collator02"] %}
 {% for node in nodes %}

--- a/tests/zombienet/zombienet.toml
+++ b/tests/zombienet/zombienet.toml
@@ -16,33 +16,16 @@ cumulus_based = true
 id            = 3333
 
 [[parachains.collators]]
-command  = "t3rn-collator"
-name     = "t3rn-collator01"
+command  = "t0rn-collator"
+name     = "t0rn-collator01"
 rpc_port = 8840
 ws_port  = 9940
 
 [[parachains.collators]]
-command  = "t3rn-collator"
-name     = "t3rn-collator02"
-rpc_port = 8841
-ws_port  = 9941
-
-[[parachains]]
-chain         = "local"
-cumulus_based = true
-id            = 3334
-
-[[parachains.collators]]
-command  = "t0rn-collator"
-name     = "t0rn-collator01"
-rpc_port = 8830
-ws_port  = 9930
-
-[[parachains.collators]]
 command  = "t0rn-collator"
 name     = "t0rn-collator02"
-rpc_port = 8831
-ws_port  = 9931
+rpc_port = 8841
+ws_port  = 9941
 
 [types.Header]
 number = "u64"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Test:**
- Adjusted the registration time for a parachain in `tests/zombienet/smoke/0001-is_up_and_registered.feature`.
- Removed the block height check for certain nodes in the same test.

> 🎉 A tweak to the test, a change so fine, 🧪
> 
> Parachains register in their own sweet time. ⏰
> 
> No more block height checks, we've set them free, 🚀
> 
> In our code's symphony, a note of glee! 🎵
<!-- end of auto-generated comment: release notes by openai -->