### PR TITLE
fix: inclusion_receipt.height should be lower than submission_target_height

### DIFF
--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -1338,7 +1338,7 @@ impl<T: Config> Pallet<T> {
         }; // Empty encoded_event_params for testing purposes
 
         #[cfg(not(feature = "test-skip-verification"))]
-        if inclusion_receipt.height > fsx.submission_target_height {
+        if inclusion_receipt.height < fsx.submission_target_height {
             log::error!(
                 "Inclusion height is higher than target {:?} > {:?}. Xtx Id: {:?}",
                 inclusion_receipt.height,

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -1340,7 +1340,7 @@ impl<T: Config> Pallet<T> {
         #[cfg(not(feature = "test-skip-verification"))]
         if inclusion_receipt.height < fsx.submission_target_height {
             log::error!(
-                "Inclusion height is higher than target {:?} > {:?}. Xtx Id: {:?}",
+                "Inclusion height is higher than target {:?} < {:?}. Xtx Id: {:?}",
                 inclusion_receipt.height,
                 fsx.submission_target_height,
                 xtx_id,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Corrected the conditional check in `pallets/circuit/src/lib.rs` to ensure `inclusion_receipt.height` is less than `fsx.submission_target_height`. This change fixes an issue where the condition was incorrectly checking for greater than.

> 🎉 Here's to the bugs we chase, 🐞
> 
> In the depths of code, a thrilling race. 💻
> 
> A flip of a sign, a simple twist, 🔀
> 
> Unravels mysteries in the mist. 🌫️
> 
> Celebrate this victory small, 🥳
> 
> For it makes a difference, after all! 🚀
<!-- end of auto-generated comment: release notes by openai -->