### PR TITLE
fix: docker image name aligned

### DIFF
--- a/.github/workflows/runtime-upgrade-t0rn.yml
+++ b/.github/workflows/runtime-upgrade-t0rn.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/t3rn/${{ env.PARACHAIN_NAME }}-collator:v${{ env.PUSHED_TAG }}
+          tags: ghcr.io/t3rn/${{ env.PARACHAIN_NAME }}-collator:${{ env.PUSHED_TAG }}
           platforms: linux/amd64
           file: collator.${{ env.PARACHAIN_NAME }}.Dockerfile
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our current docker images are built with double `v` in front of the release number
Example: `ghcr.io/t3rn/t0rn-collator:vv1.48.4-rc.0`

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Fixed the docker image name alignment in the `.github/workflows/runtime-upgrade-t0rn.yml` file by removing an extra 'v' character from the image tag.

> Here's to the bugs we chase, 🐞
> In code's vast and endless space. 💻
> A 'v' too many, a simple mistake, 🆚
> But oh, what difference does it make! 🎯
> Now fixed, aligned, all set to sail, 🚀
> On Docker's vast and windy gale. 🌬️
> So raise your glasses, let's give a cheer, 🥂
> For every bug that disappears! 🎉
<!-- end of auto-generated comment: release notes by openai -->