### PR TITLE
chore: move docker images from aws to ghcr

### DIFF
--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -130,31 +130,31 @@ jobs:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: 🐋 Login to the GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-  
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-  
-      - name: Build attester
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: test-t0rn-attester
-          IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./client
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . -f attester.Dockerfile
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: 🐳 Build and publish the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/t3rn/${{ env.PARACHAIN_NAME }}-attester:${{ github.sha }}
+          platforms: linux/amd64
+          file: client/attester.Dockerfile
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: EKS
         run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
 
       - name: Helm Upgrade
         working-directory: ./client/packages/attester
-        run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-attester"
+        run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="ghcr.io/t3rn/${{ env.PARACHAIN_NAME }}-attester"

--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -11,6 +11,16 @@ permissions:
   contents: read
   pull-requests: write
   checks: write
+  packages: write
+
+env:
+  APP: attester
+
+# Automatically cancel older in-progress jobs on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/development' }}
+
 
 jobs:
   # This job checks if files has been modified.
@@ -44,7 +54,7 @@ jobs:
         run: |
           echo Detected changes: "${{ steps.changes.outputs.src }}"
 
-  test-attester:
+  test:
     name: Test Attester
     needs: [changes]
     runs-on: self-hosted
@@ -122,13 +132,41 @@ jobs:
   deploy:
     name: Build & Deploy Attester
     runs-on: self-hosted
-    needs: test-attester
+    needs: test
     concurrency: attester
 
     if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-attester')
     steps:
+      - name: Export variables
+        run: echo IMAGE_URL="ghcr.io/t3rn/${{ env.APP }}" >> $GITHUB_ENV
+
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
+
+      - name: 🐋 Login to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: 🐳 Build and publish the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: client
+          push: true
+          tags: ${{ env.IMAGE_URL }}:${{ github.sha }},${{ env.IMAGE_URL }}:latest
+          labels: |
+            org.opencontainers.image.title=t3rn
+            org.opencontainers.image.description=${{ env.APP }}
+          platforms: linux/amd64
+          file: client/${{ env.APP }}.Dockerfile
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -136,25 +174,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-  
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-  
-      - name: Build attester
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: test-t0rn-attester
-          IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./client
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . -f attester.Dockerfile
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
-      - name: EKS
-        run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-
-      - name: Helm Upgrade
+      - name: Deployment on EKS
         working-directory: ./client/packages/attester
-        run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-attester"
+        run: |
+          aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ env.IMAGE_URL }}" --install
+

--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -21,7 +21,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/development' }}
 
-
 jobs:
   # This job checks if files has been modified.
   # Using paths in pull request trigger would make required checks unpassable for PRs without expected changes.
@@ -92,6 +91,9 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/attester/eslint_report.json
+          fail-on-error: true
+          fail-on-warning: false
+          only-pr-files: true
 
       - name: 🏗 Build Docs
         run: pnpm build-docs
@@ -180,4 +182,3 @@ jobs:
         run: |
           aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
           helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ env.IMAGE_URL }}" --install
-

--- a/.github/workflows/attester.yml
+++ b/.github/workflows/attester.yml
@@ -130,31 +130,31 @@ jobs:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
 
-      - name: 🐋 Login to the GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: 🐳 Build and publish the Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/t3rn/${{ env.PARACHAIN_NAME }}-attester:${{ github.sha }}
-          platforms: linux/amd64
-          file: client/attester.Dockerfile
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+  
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+  
+      - name: Build attester
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: test-t0rn-attester
+          IMAGE_TAG: ${{ github.sha }}
+        working-directory: ./client
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . -f attester.Dockerfile
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       - name: EKS
         run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
 
       - name: Helm Upgrade
         working-directory: ./client/packages/attester
-        run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="ghcr.io/t3rn/${{ env.PARACHAIN_NAME }}-attester"
+        run: helm upgrade attester helm -n attester -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-attester"

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,8 +5,13 @@ on:
   merge_group:
 
 permissions:
+  contents: read
   pull-requests: read
   checks: write
+  packages: write
+
+env:
+  APP: cli
 
 jobs:
   # This job checks if files has been modified.
@@ -41,7 +46,7 @@ jobs:
         run: |
           echo Detected changes: "${{ steps.changes.outputs.src }}"
 
-  test-cli:
+  test:
     name: Test CLI
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
@@ -92,14 +97,40 @@ jobs:
           docker build . -f cli.Dockerfile
 
   deploy:
+    name: Build & Deploy CLI
     runs-on: self-hosted
-    needs: [test-cli]
+    needs: test
+    concurrency: cli
 
     if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-cli')
-
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
+
+      - name: Export variables
+        run: echo IMAGE_URL="ghcr.io/t3rn/${{ env.APP }}" >> $GITHUB_ENV
+
+      - name: 🐋 Login to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: 🐳 Build and publish the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: client
+          push: true
+          tags: ${{ env.IMAGE_URL }}:${{ github.sha }},${{ env.IMAGE_URL }}:latest
+          platforms: linux/amd64
+          file: client/${{ env.APP }}.Dockerfile
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -108,25 +139,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build CLI
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: test-t0rn-cli
-          IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./client
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . -f cli.Dockerfile
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-      - name: EKS
-        run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-
-      - name: Helm Upgrade
+      - name: Deployment on EKS
         working-directory: ./client/packages/cli
-        run: helm upgrade cli helm -n cli -f helm/values-t0rn.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-cli"
+        run: |
+          aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository=" ${{ env.IMAGE_URL }}" --install
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -154,5 +154,5 @@ jobs:
         working-directory: ./client/packages/cli
         run: |
           aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values-t0rn.yaml --set tag=${{ github.sha }},repository=" ${{ env.IMAGE_URL }}" --install
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values-t0rn.yaml --set tag=${{ github.sha }},repository="${{ env.IMAGE_URL }}" --install
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,6 +13,11 @@ permissions:
 env:
   APP: cli
 
+# Automatically cancel older in-progress jobs on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/development' }}
+
 jobs:
   # This job checks if files has been modified.
   # Using paths in pull request trigger would make required checks unpassable for PRs without expected changes.

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/cli/eslint_report.json
+          fail-on-error: true
+          fail-on-warning: false
+          only-pr-files: true
 
       - run: pnpm test
 
@@ -104,11 +107,11 @@ jobs:
 
     if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-cli')
     steps:
-      - name: ☁ Checkout git repo
-        uses: actions/checkout@v3
-
       - name: Export variables
         run: echo IMAGE_URL="ghcr.io/t3rn/${{ env.APP }}" >> $GITHUB_ENV
+
+      - name: ☁ Checkout git repo
+        uses: actions/checkout@v3
 
       - name: 🐋 Login to the GitHub Container Registry
         uses: docker/login-action@v2
@@ -126,6 +129,9 @@ jobs:
           context: client
           push: true
           tags: ${{ env.IMAGE_URL }}:${{ github.sha }},${{ env.IMAGE_URL }}:latest
+          labels: |
+            org.opencontainers.image.title=t3rn
+            org.opencontainers.image.description=CLI
           platforms: linux/amd64
           file: client/${{ env.APP }}.Dockerfile
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -149,5 +149,5 @@ jobs:
         working-directory: ./client/packages/cli
         run: |
           aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository=" ${{ env.IMAGE_URL }}" --install
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values-t0rn.yaml --set tag=${{ github.sha }},repository=" ${{ env.IMAGE_URL }}" --install
 

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -84,9 +84,9 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/executor/eslint_report.json
-          fail-on-error: false
-          # fail-on-warning: false
-          # only-pr-files: false
+          fail-on-error: true
+          fail-on-warning: false
+          only-pr-files: true
 
       - run: pnpm run test
         timeout-minutes: 5

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: write
   checks: write
+  packages: write
+
+env:
+  APP: executor
 
 jobs:
   # This job checks if files has been modified.
@@ -80,14 +84,15 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/executor/eslint_report.json
-        # TODO: remove at some point
-        continue-on-error: true
+          fail-on-error: false
+          # fail-on-warning: false
+          # only-pr-files: false
 
       - run: pnpm run test
         timeout-minutes: 5
 
   build-docker:
-    name: Build Executor Docker
+    name: Build Docker Image
     needs: [changes]
     if: needs.changes.outputs.src == 'true' && github.ref != 'refs/heads/development'
 
@@ -98,18 +103,43 @@ jobs:
       - name: Build Docker
         working-directory: ./client
         run: |
-          docker build . -f executor.Dockerfile
+          docker build . -f ${{ env.APP }}.Dockerfile
 
   deploy:
     name: Build & Deploy Executor
     runs-on: self-hosted
-    needs: test-executor
-    concurrency: executor
+    # needs: test-executor
+    # concurrency: executor
 
-    if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-executor')
+    # if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-executor')
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
+
+      - name: Export variables
+        run: echo IMAGE_URL="ghcr.io/t3rn/${{ env.APP }}" >> $GITHUB_ENV
+
+      - name: 🐋 Login to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: 🐳 Build and publish the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: client
+          push: true
+          tags: ${{ env.IMAGE_URL }}:${{ github.sha }},${{ env.IMAGE_URL }}:latest
+          platforms: linux/amd64
+          file: client/${{ env.APP }}.Dockerfile
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -118,24 +148,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build executor
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: test-t0rn-executor
-          IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./client
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . -f executor.Dockerfile
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-      - name: EKS
-        run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-
-      - name: Helm Upgrade
+      - name: Deployment on EKS
         working-directory: ./client/packages/executor
-        run: helm upgrade executor helm -n executor -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-executor" --install
+        run: |
+          aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository=" ${{ env.IMAGE_URL }}" --install

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -16,6 +16,11 @@ permissions:
 env:
   APP: executor
 
+# Automatically cancel older in-progress jobs on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/development' }}
+
 jobs:
   # This job checks if files has been modified.
   # Using paths in pull request trigger would make required checks unpassable for PRs without expected changes.
@@ -108,10 +113,10 @@ jobs:
   deploy:
     name: Build & Deploy Executor
     runs-on: self-hosted
-    # needs: test-executor
-    # concurrency: executor
+    needs: test-executor
+    concurrency: executor
 
-    # if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-executor')
+    if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-executor')
     steps:
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -160,4 +160,4 @@ jobs:
         working-directory: ./client/packages/executor
         run: |
           aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository=" ${{ env.IMAGE_URL }}" --install
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ env.IMAGE_URL }}" --install

--- a/.github/workflows/executor.yml
+++ b/.github/workflows/executor.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo Detected changes: "${{ steps.changes.outputs.src }}"
 
-  test-executor:
+  test:
     name: Test Executor
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
@@ -113,16 +113,16 @@ jobs:
   deploy:
     name: Build & Deploy Executor
     runs-on: self-hosted
-    needs: test-executor
+    needs: test
     concurrency: executor
 
     if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-executor')
     steps:
-      - name: ☁ Checkout git repo
-        uses: actions/checkout@v3
-
       - name: Export variables
         run: echo IMAGE_URL="ghcr.io/t3rn/${{ env.APP }}" >> $GITHUB_ENV
+
+      - name: ☁ Checkout git repo
+        uses: actions/checkout@v3
 
       - name: 🐋 Login to the GitHub Container Registry
         uses: docker/login-action@v2
@@ -140,6 +140,9 @@ jobs:
           context: client
           push: true
           tags: ${{ env.IMAGE_URL }}:${{ github.sha }},${{ env.IMAGE_URL }}:latest
+          labels: |
+            org.opencontainers.image.title=t3rn
+            org.opencontainers.image.description=Executor
           platforms: linux/amd64
           file: client/${{ env.APP }}.Dockerfile
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/grandpa-ranger.yml
+++ b/.github/workflows/grandpa-ranger.yml
@@ -11,6 +11,16 @@ permissions:
   contents: read
   pull-requests: write
   checks: write
+  packages: write
+
+env:
+  APP: grandpa-ranger
+
+# Automatically cancel older in-progress jobs on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/development' }}
+
 
 jobs:
   # This job checks if files has been modified.
@@ -40,7 +50,7 @@ jobs:
         run: |
           echo Detected changes: "${{ steps.changes.outputs.src }}"
 
-  test-grandpa-ranger:
+  test:
     name: Test Grandpa Ranger
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
@@ -74,8 +84,9 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: client/packages/grandpa-ranger/eslint_report.json
-        # TODO: uncomment when ready
-        continue-on-error: true
+          fail-on-error: true
+          fail-on-warning: false
+          only-pr-files: true
 
   build-docker:
     name: Build Docker Grandpa Ranger
@@ -94,12 +105,41 @@ jobs:
   deploy:
     name: Deploy Grandpa Ranger
     runs-on: self-hosted
-    needs: test-grandpa-ranger
+    needs: test
     concurrency: grandpa-ranger
-    if: github.ref == 'refs/heads/development'
+
+    if: github.ref == 'refs/heads/development' || contains(github.event.pull_request.labels.*.name, 'deploy-grandpa-ranger')
     steps:
+      - name: Export variables
+        run: echo IMAGE_URL="ghcr.io/t3rn/${{ env.APP }}" >> $GITHUB_ENV
+
       - name: ☁ Checkout git repo
         uses: actions/checkout@v3
+
+      - name: 🐋 Login to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: 🐳 Build and publish the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: client
+          push: true
+          tags: ${{ env.IMAGE_URL }}:${{ github.sha }},${{ env.IMAGE_URL }}:latest
+          labels: |
+            org.opencontainers.image.title=t3rn
+            org.opencontainers.image.description=${{ env.APP }}
+          platforms: linux/amd64
+          file: client/${{ env.APP }}.Dockerfile
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -107,25 +147,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-  
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-  
-      - name: Build grandpa-ranger
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: test-t0rn-grandpa-ranger
-          IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./client
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . -f grandpa-ranger.Dockerfile
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
-      - name: EKS
-        run: aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
-
-      - name: Helm Upgrade
+      - name: Deployment on EKS
         working-directory: ./client/packages/grandpa-ranger
-        run: helm upgrade grandpa-ranger ./helm -n grandpa-ranger -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ steps.login-ecr.outputs.registry }}/test-t0rn-grandpa-ranger"
+        run: |
+          aws eks --region ${{ secrets.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ secrets.AWS_EKS_CLUSTER }}
+          helm upgrade ${{ env.APP }} helm -n ${{ env.APP }} -f helm/values.yaml --set tag=${{ github.sha }},repository="${{ env.IMAGE_URL }}" --install

--- a/client/packages/cli/helm/values-t0rn.yaml
+++ b/client/packages/cli/helm/values-t0rn.yaml
@@ -13,9 +13,9 @@ jobs:
       - name: SFX_TRAN_INSURANCE
         value: "1"
       - name: SFX_TRAN_AMOUNT
-        value: "0.01"
+        value: "0.001"
       
-    schedule: "*/30 * * * *"
+    schedule: "*/1 * * * *"
     args:
     - submit
     - -s

--- a/client/packages/cli/helm/values-t0rn.yaml
+++ b/client/packages/cli/helm/values-t0rn.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: SFX_TRAN_INSURANCE
         value: "1"
       - name: SFX_TRAN_AMOUNT
-        value: "0.1"
+        value: "0.01"
       
     schedule: "*/30 * * * *"
     args:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
**Chore**: 
- Migrated Docker images from AWS to GitHub Container Registry (GHCR) across multiple workflows.
- Modified workflow, test job, build and publish Docker image steps, and deployment on EKS.
- Enhanced cli.yml with permissions for reading contents and writing packages, setting environment variables, adding concurrency settings, modifying job names, and a step to export variables.

```

> 🎉 In the realm of code, where logic is the key,
> A shift was made, as smooth as can be. 🚀
> From AWS to GHCR, the Docker images flew,
> Bringing enhancements, making everything new. 💫
> Concurrency set, permissions too,
> Celebrate this PR, for progress it drew! 🥳
<!-- end of auto-generated comment: release notes by openai -->