### PR TITLE
fix: docker image paths and docs

### DIFF
--- a/.github/workflows/runtime-upgrade-t0rn.yml
+++ b/.github/workflows/runtime-upgrade-t0rn.yml
@@ -162,7 +162,6 @@ jobs:
           asset_name: ${{ env.WASM_RELEASE_ASSET }}.info.json
           asset_content_type: text/plain
 
-
   runtime-upgrade-zombienet-test:
     runs-on: [self-hosted, rust]
     concurrency: runtime-upgrade

--- a/collator.t0rn.Dockerfile
+++ b/collator.t0rn.Dockerfile
@@ -5,9 +5,8 @@ ENV RELAYCHAIN_NAME=rococo
 ENV PARACHAIN_NAME=t0rn
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /node runner && \
-    mkdir /node/data && \
-    mkdir /node/keystore && \
-    mkdir /node/specs
+    mkdir -p /node/data /node/keystore /node/specs && \
+    chown -R runner /node/data /node/keystore
 
 COPY --chown=runner target/release/${PARACHAIN_NAME}-collator /usr/local/bin/collator
 COPY --chown=runner specs/$RELAYCHAIN_NAME.raw.json /node/specs/$RELAYCHAIN_NAME.raw.json
@@ -15,6 +14,6 @@ COPY --chown=runner specs/$PARACHAIN_NAME.raw.json /node/specs/$PARACHAIN_NAME.r
 
 USER runner
 VOLUME /node/data
-EXPOSE 33333 1833 1933 7003
+EXPOSE 33333 1933 1944 7003
 
 ENTRYPOINT ["/usr/local/bin/collator"]

--- a/collator.t3rn.Dockerfile
+++ b/collator.t3rn.Dockerfile
@@ -5,16 +5,15 @@ ENV RELAYCHAIN_NAME=polkadot
 ENV PARACHAIN_NAME=t3rn
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /node runner && \
-    mkdir /node/data && \
-    mkdir /node/keystore && \
-    mkdir /node/specs
+    mkdir -p /node/data /node/keystore /node/specs && \
+    chown -R runner /node/data /node/keystore
 
-COPY --chown=runner target/release/${PARACHAIN_NAME}-collator /usr/local/bin/collator
-COPY --chown=runner specs/$RELAYCHAIN_NAME.raw.json /node/specs/$RELAYCHAIN_NAME.raw.json
-COPY --chown=runner specs/$PARACHAIN_NAME.raw.json /node/specs/$PARACHAIN_NAME.raw.json
+COPY target/release/${PARACHAIN_NAME}-collator /usr/local/bin/collator
+COPY specs/$RELAYCHAIN_NAME.raw.json /node/specs/$RELAYCHAIN_NAME.raw.json
+COPY specs/$PARACHAIN_NAME.raw.json /node/specs/$PARACHAIN_NAME.raw.json
 
 USER runner
 VOLUME /node/data
-EXPOSE 33333 1833 1933 7003
+EXPOSE 33333 1933 1944 7003
 
 ENTRYPOINT ["/usr/local/bin/collator"]

--- a/docs/main/docs/collator/testnet/testnet-collator.md
+++ b/docs/main/docs/collator/testnet/testnet-collator.md
@@ -137,13 +137,13 @@ docker pull ghcr.io/t3rn/t0rn-collator:v1.48.5-rc.0
 #### Start the Collator
 
 ```sh
-docker run -p 33333:33333 -p 33334:33334 -p 9944:9944 -p 9933:9933 \
+docker run -p 33333:33333 -p 33334:33334 -p 9944:9944 -p 9933:9933 -p 7003:7003 \
   -v /node ghcr.io/t3rn/t0rn-collator:v1.48.5-rc.0 \
   --collator \
   --name=<collator-name> \
-  --base-path=data \
-  --keystore-path=keystore \
-  --chain=specs/t0rn.raw.json \
+  --base-path=/node/data \
+  --keystore-path=/node/keystore \
+  --chain=/node/specs/t0rn.raw.json \
   --bootnodes="/dns/bootnode.t0rn.io/tcp/33333/p2p/12D3KooWEepV69XCJB4Zi193cZcm5W22ZR62DEP84iLFTUKVPtwp" \
   --rpc-port=9944 \
   --port=33333 \
@@ -151,7 +151,7 @@ docker run -p 33333:33333 -p 33334:33334 -p 9944:9944 -p 9933:9933 \
   --telemetry-url='wss://telemetry.polkadot.io/submit 1' \
   --pruning=archive \
   -- \
-  --chain=specs/rococo.raw.json \
+  --chain=/node/specs/rococo.raw.json \
   --rpc-port=9933 \
   --port=33334 \
   --prometheus-port=7004 \


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Updated Dockerfiles for `collator.t0rn` and `collator.t3rn` to create and assign ownership of directories `/node/data`, `/node/keystore`, `/node/specs`.
- Adjusted exposed ports in Dockerfiles.
- Removed the `--chown=runner` flag from `COPY` commands in `collator.t3rn.Dockerfile`.

**Documentation:**
- Fixed Docker image paths in `testnet-collator.md`.
- Updated Docker run command with new port mapping and path updates.

> 🎉 Ports are shifting, directories aligning,
> In Docker's realm, there's no room for whining.
> Paths corrected, documents refined,
> To the keen observer, no change left behind. 🚀
<!-- end of auto-generated comment: release notes by openai -->