### PR TITLE
refactor: revisit and test attestation targets removal

### DIFF
--- a/pallets/attesters/src/lib.rs
+++ b/pallets/attesters/src/lib.rs
@@ -329,6 +329,7 @@ pub mod pallet {
         AttesterAgreedToNewTarget(T::AccountId, TargetId, Vec<u8>),
         CurrentPendingAttestationBatches(TargetId, Vec<(u32, H256)>),
         AttestationsRemovedFromLateBatches(Vec<u32>),
+        AttestationTargetRemoved(TargetId, Vec<TargetId>),
         // ShufflingCompleted(current committee, previous committee, next committee)
         ShufflingCompleted(Vec<T::AccountId>, Vec<T::AccountId>, Vec<T::AccountId>),
     }
@@ -467,14 +468,11 @@ pub mod pallet {
         pub fn remove_attestation_target(origin: OriginFor<T>, target: TargetId) -> DispatchResult {
             ensure_root(origin)?;
 
-            let mut targets = AttestationTargets::<T>::get();
-
-            // Remove target if exists
-            if !targets.contains(&target) {
-                targets.retain(|&x| x != target);
-            }
-
-            AttestationTargets::<T>::put(targets);
+            AttestationTargets::<T>::mutate(|targets| {
+                if let Some(index) = targets.iter().position(|x| x == &target) {
+                    targets.remove(index);
+                }
+            });
             PendingAttestationTargets::<T>::mutate(|pending| {
                 if let Some(index) = pending.iter().position(|x| x == &target) {
                     pending.remove(index);
@@ -485,6 +483,11 @@ pub mod pallet {
             Batches::<T>::remove(target);
             BatchesToSign::<T>::remove(target);
             NextBatch::<T>::remove(target);
+
+            Self::deposit_event(Event::AttestationTargetRemoved(
+                target,
+                AttestationTargets::<T>::get(),
+            ));
 
             Ok(())
         }
@@ -2083,6 +2086,30 @@ pub mod attesters_test {
                 latest_batch_some.signatures,
                 vec![(attester_info.index, signature.try_into().unwrap())]
             );
+        });
+    }
+
+    #[test]
+    fn remove_and_add_back_attestation_targets_with_sudo_access() {
+        let mut ext = ExtBuilder::default()
+            .with_standard_sfx_abi()
+            .with_eth_gateway_record()
+            .build();
+        ext.execute_with(|| {
+            let target: TargetId = ETHEREUM_TARGET;
+            let current_block_1 = add_target_and_transition_to_next_batch(target, 0);
+
+            assert_eq!(Attesters::attestation_targets(), vec![target]);
+
+            Attesters::remove_attestation_target(RuntimeOrigin::root(), target);
+
+            assert_eq!(Attesters::attestation_targets(), Vec::<TargetId>::new());
+
+            System::set_block_number(current_block_1 + 1);
+
+            let current_block_1 = add_target_and_transition_to_next_batch(target, 0);
+
+            assert_eq!(Attesters::attestation_targets(), vec![target]);
         });
     }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added a new event `AttestationTargetRemoved` to the pallet module.
- Updated the `remove_attestation_target` function for enhanced functionality.

**Test:**
- Introduced a new test case for removing and adding back attestation targets with sudo access.

> 🎉 Here's to the code that we've refined,  
> A new event in the pallet we find.  
> Attestation targets can now be removed,  
> With this update, our system improved.  
> Tests ensure our changes are aligned,  
> In our blockchain's fabric, they're intertwined. 🚀
<!-- end of auto-generated comment: release notes by openai -->