### PR TITLE
fix: derive admin origin set to Escrow for Root token destroys

### DIFF
--- a/pallets/xdns/src/tests.rs
+++ b/pallets/xdns/src/tests.rs
@@ -327,6 +327,40 @@ fn should_register_token_and_populate_assets_storage_successfully() {
 }
 
 #[test]
+fn should_purge_token_and_destroy_asset_as_root_successfully() {
+    ExtBuilder::default()
+        .with_standard_sfx_abi()
+        .with_default_xdns_records()
+        .build()
+        .execute_with(|| {
+            assert_eq!(
+                pallet_xdns::Gateways::<Runtime>::iter().count(),
+                DEFAULT_GATEWAYS_IN_STORAGE_COUNT
+            );
+
+            assert!(!Runtime::contains_asset(&u32::from_le_bytes(*b"test")));
+
+            assert_ok!(XDNS::register_new_token(
+                &Origin::root(),
+                u32::from_le_bytes(*b"test"),
+                TokenInfo::Substrate(SubstrateToken {
+                    id: 1,
+                    symbol: b"test".to_vec(),
+                    decimals: 1,
+                })
+            ));
+
+            assert!(Runtime::contains_asset(&u32::from_le_bytes(*b"test")));
+
+            let res = XDNS::purge_token_record(Origin::root(), u32::from_le_bytes(*b"test"));
+
+            assert_ok!(res);
+
+            assert!(!Runtime::contains_asset(&u32::from_le_bytes(*b"test")));
+        });
+}
+
+#[test]
 fn should_purge_token_and_destroy_asset_storage_successfully() {
     ExtBuilder::default()
         .with_standard_sfx_abi()


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Modified the `destroy` function in the `pallet` module to check if the origin is the root account and set the `origin_admin` to the Escrow account before calling `T::AssetsOverlay::destroy`.
  
**Test:**
- Added a new test case `should_purge_token_and_destroy_asset_as_root_successfully` to verify the functionality of purging a token and destroying its associated asset when called by the root origin.

> 🎉 With roots that run deep, we've refined our sweep, 🧹
> Now tokens are purged, and assets submerged. 🌊
> Tests ensure we're on track, 🛤️
> Celebrate, there's no turning back! 🚀
<!-- end of auto-generated comment: release notes by openai -->