### PR TITLE
chore: add XDNS standard sfx abi to standalone chain specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "pallet-transaction-payment-rpc",
  "pallet-xdns",
  "pallet-xdns-rpc",
+ "parity-scale-codec",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Extras
+codec = { workspace = true, features = ["std"] }
 clap      = { version = "4.0.9", features = [ "derive" ] }
 futures   = "0.3.21"
 jsonrpsee = { workspace = true }

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -7,16 +7,16 @@ use circuit_standalone_runtime::{
     Signature,
     SudoConfig,
     SystemConfig,
-    WASM_BINARY,
     // SessionConfig,
     // CollatorSelectionConfig,
-    // XDNSConfig
-    // EvmConfig
+    XDNSConfig, // EvmConfig
+    WASM_BINARY,
 };
 
 const CANDIDACY_BOND: u128 = 0; // 10K TRN
 const DESIRED_CANDIDATES: u32 = 2;
 
+use codec::Encode;
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
@@ -229,7 +229,11 @@ fn testnet_genesis(
         transaction_payment: Default::default(),
         assets: Default::default(),
         rewards: Default::default(),
-        xdns: Default::default(),
+        xdns: XDNSConfig {
+            known_gateway_records: vec![],
+            standard_sfx_abi: t3rn_abi::standard::standard_sfx_abi().encode(),
+            _marker: Default::default(),
+        },
         contracts_registry: Default::default(),
         account_manager: Default::default(),
         attesters: Default::default(),


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Features:**
- Added the XDNS standard sfx ABI to the standalone chain specs in `node/standalone/src/chain_spec.rs`.
- Introduced `Xdns` and `Portal` RPC extensions in `node/standalone/src/rpc.rs`.
- Implemented runtime APIs for the `pallet_xdns` and `pallet_portal` modules in `runtime/standalone/src/impl_versioned_runtime_with_api.rs`.

**Deprecations:**
- Deprecated a function related to fetching ABIs in `runtime/standalone/src/impl_versioned_runtime_with_api.rs`.

> 🎉 With each line of code, we weave a tale,  
> Of gateways known and records that prevail.  
> The ABI's standard, now part of our quest,  
> In the world of XDNS, we're simply the best! 🚀

<!-- end of auto-generated comment: release notes by openai -->