### PR TITLE
chore: change initialize grandpa light client to dispatch result

### DIFF
--- a/finality-verifiers/grandpa/src/lib.rs
+++ b/finality-verifiers/grandpa/src/lib.rs
@@ -1055,7 +1055,7 @@ pub mod tests {
 
     fn initialize_relaychain(
         origin: Origin,
-    ) -> Result<RelaychainRegistrationData<AccountId>, &'static str> {
+    ) -> Result<RelaychainRegistrationData<AccountId>, DispatchError> {
         let genesis = test_header_with_correct_parent(0, None);
         let init_data = RelaychainRegistrationData::<AccountId> {
             authorities: authorities(),
@@ -1070,7 +1070,7 @@ pub mod tests {
     fn initialize_named_relaychain(
         origin: Origin,
         gateway_id: ChainId,
-    ) -> Result<RelaychainRegistrationData<AccountId>, &'static str> {
+    ) -> Result<RelaychainRegistrationData<AccountId>, DispatchError> {
         let genesis = test_header(0);
         let init_data = RelaychainRegistrationData::<AccountId> {
             authorities: authorities(),
@@ -1086,11 +1086,11 @@ pub mod tests {
         origin: Origin,
         gateway_id: ChainId,
         init_data: RelaychainRegistrationData<AccountId>,
-    ) -> Result<RelaychainRegistrationData<AccountId>, &'static str> {
+    ) -> Result<RelaychainRegistrationData<AccountId>, DispatchError> {
         Pallet::<TestRuntime>::initialize(origin, gateway_id, init_data.encode()).map(|_| init_data)
     }
 
-    fn initialize_parachain(origin: Origin) -> Result<ParachainRegistrationData, &'static str> {
+    fn initialize_parachain(origin: Origin) -> Result<ParachainRegistrationData, DispatchError> {
         let _genesis = test_header(0);
         let init_data = ParachainRegistrationData {
             relay_gateway_id: *b"pdot",
@@ -1103,7 +1103,7 @@ pub mod tests {
     fn initialize_named_parachain(
         origin: Origin,
         gateway_id: ChainId,
-    ) -> Result<ParachainRegistrationData, &'static str> {
+    ) -> Result<ParachainRegistrationData, DispatchError> {
         let init_data = ParachainRegistrationData {
             relay_gateway_id: *b"pdot",
             id: 0,
@@ -1116,7 +1116,7 @@ pub mod tests {
         origin: Origin,
         gateway_id: ChainId,
         init_data: ParachainRegistrationData,
-    ) -> Result<ParachainRegistrationData, &'static str> {
+    ) -> Result<ParachainRegistrationData, DispatchError> {
         Pallet::<TestRuntime>::initialize(origin, gateway_id, init_data.encode()).map(|_| init_data)
     }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Changed the return type of several functions (`initialize_relay_chain`, `register_side_effect` and others) from `Result<(), &'static str>` to `DispatchResult`.
- Improved error handling in `can_init_relay_chain` function by replacing a match statement with the `ensure!` macro.

> 🎉 In the realm of code, where logic is queen,
> A refactor was made, so clean and serene.
> Errors now dance, with grace they prance,
> With `DispatchResult`, they've got a better chance. 🚀

<!-- end of auto-generated comment: release notes by openai -->