### PR TITLE
fix: correct assignment for Polkadot and Kusama vendors and instances to runtimes

### DIFF
--- a/finality-verifiers/grandpa/src/lib.rs
+++ b/finality-verifiers/grandpa/src/lib.rs
@@ -1187,6 +1187,30 @@ pub mod tests {
             assert_ok!(initialize_parachain(Origin::root()));
         })
     }
+    use hex_literal::hex;
+    #[test]
+    fn can_register_again_after_reset_with_valid_data_and_signer() {
+        run_test(|| {
+            assert_ok!(initialize_relaychain(Origin::root()));
+            assert_ok!(initialize_parachain(Origin::root()));
+            assert_eq!(
+                InitialHash::<TestRuntime>::get(),
+                Some(
+                    hex!("dcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a").into()
+                )
+            );
+            assert_ok!(Pallet::<TestRuntime>::reset(Origin::root()));
+            assert_eq!(InitialHash::<TestRuntime>::get(), None);
+            assert_ok!(initialize_relaychain(Origin::root()));
+            assert_ok!(initialize_parachain(Origin::root()));
+            assert_eq!(
+                InitialHash::<TestRuntime>::get(),
+                Some(
+                    hex!("dcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a").into()
+                )
+            );
+        })
+    }
 
     #[test]
     fn cant_register_duplicate_gateway_ids() {

--- a/finality-verifiers/grandpa/src/light_clients.rs
+++ b/finality-verifiers/grandpa/src/light_clients.rs
@@ -16,8 +16,8 @@ use t3rn_primitives::{
 };
 
 pub type RococoInstance = ();
-pub type KusamaInstance = crate::pallet::Instance1;
-pub type PolkadotInstance = crate::pallet::Instance2;
+pub type PolkadotInstance = crate::pallet::Instance1;
+pub type KusamaInstance = crate::pallet::Instance2;
 
 pub type RococoPallet<T> = Pallet<T, RococoInstance>;
 pub type KusamaPallet<T> = Pallet<T, KusamaInstance>;

--- a/pallets/portal/src/lib.rs
+++ b/pallets/portal/src/lib.rs
@@ -138,6 +138,10 @@ pub mod pallet {
             <T as Config>::Xdns::register_new_token(&origin, token_id, token_props.clone())?;
             <T as Config>::Xdns::link_token_to_gateway(token_id, gateway_id, token_props)?;
             <Pallet<T> as Portal<T>>::initialize(origin, gateway_id, encoded_registration_data)
+                .map_err(|e| {
+                    log::error!("Error during registerGW -- Portal::initialize: {:?}", e);
+                    e
+                })
         }
     }
 }

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -317,7 +317,7 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
     type FinalizedConfirmationOffset = ConstU32<0u32>;
     type HeadersToStore = HeadersToStore;
     type LightClientAsyncAPI = XDNS;
-    type MyVendor = PolkadotVendor;
+    type MyVendor = KusamaVendor;
     type RationalConfirmationOffset = ConstU32<0u32>;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -326,7 +326,7 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
     type FinalizedConfirmationOffset = ConstU32<0u32>;
     type HeadersToStore = HeadersToStore;
     type LightClientAsyncAPI = XDNS;
-    type MyVendor = PolkadotVendor;
+    type MyVendor = KusamaVendor;
     type RationalConfirmationOffset = ConstU32<0u32>;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -314,7 +314,7 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
     type FinalizedConfirmationOffset = ConstU32<0u32>;
     type HeadersToStore = HeadersToStore;
     type LightClientAsyncAPI = XDNS;
-    type MyVendor = PolkadotVendor;
+    type MyVendor = KusamaVendor;
     type RationalConfirmationOffset = ConstU32<0u32>;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();

--- a/runtime/t1rn-parachain/src/circuit_config.rs
+++ b/runtime/t1rn-parachain/src/circuit_config.rs
@@ -316,7 +316,7 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
     type FinalizedConfirmationOffset = ConstU32<0u32>;
     type HeadersToStore = HeadersToStore;
     type LightClientAsyncAPI = XDNS;
-    type MyVendor = PolkadotVendor;
+    type MyVendor = KusamaVendor;
     type RationalConfirmationOffset = ConstU32<0u32>;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Test:**
- Added a new test case `can_register_again_after_reset_with_valid_data_and_signer` to verify the registration process after a reset in the Grandpa Finality Verifier and Portal pallets.

**Chore:**
- Enhanced error handling in the `Portal` module by adding error logging when calling the `initialize` function. This will help in better debugging and understanding of any issues that may arise during initialization.

> 🎉 Here's to the code that never rests,  
> Testing registration after resets.  
> With logs for errors, clear as day,  
> We march ahead, come what may! 🚀

<!-- end of auto-generated comment: release notes by openai -->