### PR TITLE
fix: drain imported headers at grandpa reset

### DIFF
--- a/finality-verifiers/grandpa/src/lib.rs
+++ b/finality-verifiers/grandpa/src/lib.rs
@@ -247,7 +247,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn get_imported_headers)]
     pub(super) type ImportedHeaders<T: Config<I>, I: 'static = ()> =
-        StorageMap<_, Blake2_256, BridgedBlockHash<T, I>, BridgedHeader<T, I>>;
+        StorageMap<_, Identity, BridgedBlockHash<T, I>, BridgedHeader<T, I>>;
 
     #[pallet::storage]
     pub(super) type RelayChainId<T: Config<I>, I: 'static = ()> =
@@ -261,7 +261,7 @@ pub mod pallet {
     /// Maps a parachain chain_id to the corresponding chain ID.
     #[pallet::storage]
     pub(super) type ParachainIdMap<T: Config<I>, I: 'static = ()> =
-        StorageMap<_, Blake2_256, ChainId, ParachainRegistrationData>;
+        StorageMap<_, Identity, ChainId, ParachainRegistrationData>;
 
     /// Optional pallet owner.
     ///
@@ -343,6 +343,8 @@ pub mod pallet {
             ensure_root(origin)?;
             <EverInitialized<T, I>>::kill();
             <BestFinalizedHash<T, I>>::kill();
+            <ParachainIdMap<T, I>>::drain();
+            <ImportedHeaders<T, I>>::drain();
             <InitialHash<T, I>>::kill();
             <ImportedHashesPointer<T, I>>::kill(); // one ahead of first value
             <RelayChainId<T, I>>::kill();


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Changed the storage maps `ImportedHeaders` and `ParachainIdMap` to use the `Identity` hasher instead of `Blake2_256`.
- Added functionality to drain the `ParachainIdMap` and `ImportedHeaders` storages under certain conditions.

> 🎉 With a change in hash, we make our dash,
> 
> From Blake to Identity, with much audacity.
> 
> Draining storages when conditions align,
> 
> In this PR's glory, we bask and shine! 🌟
<!-- end of auto-generated comment: release notes by openai -->