### PR TITLE
test: check for drained ImportedHeaders at grandpa LC reset

### DIFF
--- a/finality-verifiers/grandpa/src/lib.rs
+++ b/finality-verifiers/grandpa/src/lib.rs
@@ -1202,8 +1202,26 @@ pub mod tests {
                     hex!("dcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a").into()
                 )
             );
+            assert_eq!(
+                ImportedHeaders::<TestRuntime>::iter_keys().collect::<Vec<H256>>(),
+                vec![
+                    hex!("dcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a").into()
+                ]
+            );
+            assert_eq!(
+                ImportedHashes::<TestRuntime>::iter_keys().collect::<Vec<u32>>(),
+                Vec::<u32>::new()
+            );
             assert_ok!(Pallet::<TestRuntime>::reset(Origin::root()));
             assert_eq!(InitialHash::<TestRuntime>::get(), None);
+            assert_eq!(
+                ImportedHeaders::<TestRuntime>::iter_keys().collect::<Vec<H256>>(),
+                vec![]
+            );
+            assert_eq!(
+                ImportedHashes::<TestRuntime>::iter_keys().collect::<Vec<u32>>(),
+                Vec::<u32>::new()
+            );
             assert_ok!(initialize_relaychain(Origin::root()));
             assert_ok!(initialize_parachain(Origin::root()));
             assert_eq!(


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Test:**
- Added assertions to verify the behavior of `ImportedHeaders` and `ImportedHashes` data structures during a reset operation. This ensures that all expected keys are present in `ImportedHeaders` and `ImportedHashes` is empty post-reset.

> 🎉 Here's to the code that's now more robust, 🥂
> With tests for our data, in correctness we trust. 🛡️
> Reset operations, under the test's gaze, 👀
> Ensuring our structures, in order always stay. 🏗️
<!-- end of auto-generated comment: release notes by openai -->