### PR TITLE
refactor(grandpa-ranger): submissions without interval

### DIFF
--- a/client/packages/grandpa-ranger/config/kusama.ts
+++ b/client/packages/grandpa-ranger/config/kusama.ts
@@ -17,7 +17,7 @@ export default {
    ws: "wss://kusama-rpc.dwellir.com"
   },
  },
- rangeInterval: 30, // time between range submissions in seconds
+ rangeInterval: 0, // time between range submissions in seconds
  targetGatewayId: "kusm",
  batches_max: 10,
  batching: true,

--- a/client/packages/grandpa-ranger/config/local.ts
+++ b/client/packages/grandpa-ranger/config/local.ts
@@ -17,7 +17,7 @@ export default {
 			ws: "wss://rococo-community-rpc.laminar.codes/ws"
 		},
 	},
-	rangeInterval: 10, // time between range submissions in seconds
+	rangeInterval: 0, // time between range submissions in seconds
 	targetGatewayId: "roco",
 	batches_max: 10,
 }

--- a/client/packages/grandpa-ranger/config/polkadot.ts
+++ b/client/packages/grandpa-ranger/config/polkadot.ts
@@ -17,7 +17,7 @@ export default {
    ws: "wss://polkadot-rpc.dwellir.com"
   },
  },
- rangeInterval: 30, // time between range submissions in seconds
+ rangeInterval: 0, // time between range submissions in seconds
  targetGatewayId: "pdot",
  batches_max: 1,
  batching: true,

--- a/client/packages/grandpa-ranger/config/rococo.ts
+++ b/client/packages/grandpa-ranger/config/rococo.ts
@@ -17,7 +17,7 @@ export default {
    ws: "wss://rococo-community-rpc.laminar.codes/ws"
   },
  },
- rangeInterval: 30, // time between range submissions in seconds
+ rangeInterval: 0, // time between range submissions in seconds
  targetGatewayId: "roco",
  batches_max: 10,
  batching: true,

--- a/client/packages/grandpa-ranger/helm/templates/deployment.yaml
+++ b/client/packages/grandpa-ranger/helm/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
+            failureThreshold: 6
 
       {{- with $nodeSelector }}
       nodeSelector:

--- a/client/packages/grandpa-ranger/helm/templates/deployment.yaml
+++ b/client/packages/grandpa-ranger/helm/templates/deployment.yaml
@@ -61,8 +61,14 @@ spec:
                 secretKeyRef:
                   name: grandpa-ranger
                   key: {{ $profile }}
-          resources:
-            {{- toYaml $resources | nindent 12 }}
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
 
       {{- with $nodeSelector }}
       nodeSelector:

--- a/client/packages/grandpa-ranger/helm/templates/deployment.yaml
+++ b/client/packages/grandpa-ranger/helm/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
                   key: {{ $profile }}
           resources:
             {{- toYaml $resources | nindent 12 }}
+
       {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/client/packages/grandpa-ranger/helm/templates/prometheusrule.yaml
+++ b/client/packages/grandpa-ranger/helm/templates/prometheusrule.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     heritage: Helm
   name: grandpa-ranger-{{ $profile }}.rules
-  namespace: monitoring
+  namespace: grandpa-ranger
 spec:
   groups:
   - name: grandpa-ranger-{{ $profile }}.rules

--- a/client/packages/grandpa-ranger/helm/templates/prometheusrule.yaml
+++ b/client/packages/grandpa-ranger/helm/templates/prometheusrule.yaml
@@ -1,0 +1,31 @@
+# https://github.com/paritytech/substrate/blob/b797b89a9633c387ebc2f283af83d9cd450f5f50/scripts/ci/monitoring/alerting-rules/alerting-rules.yaml
+
+{{- range $profile := .Values.rangers }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: t3rn-blockchain
+    release: kube-prometheus-stack    
+    app: kube-prometheus-stack
+    app.kubernetes.io/instance: kube-prometheus-stack
+    app.kubernetes.io/managed-by: Helm
+    heritage: Helm
+  name: grandpa-ranger-{{ $profile }}.rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: grandpa-ranger-{{ $profile }}.rules
+    rules:
+
+    - alert: GrandpaRangerHeightDiffError
+      annotations:
+        description: Grandpa Ranger Circuit and Target height diff has increased and is more than 50 blocks
+        monitoring: https://monitoring.t3rn.io/d/metrics-dashboard/grandpa-ranger?orgId=1&from=now-6h&to=now&refresh=1m
+      expr: max(height{service="grandpa-ranger-{{ $profile }}"}) - min(height{service="grandpa-ranger-{{ $profile }}"}) > 100
+      for: 30m
+      labels:
+        severity: error
+
+{{- end }}

--- a/client/packages/grandpa-ranger/prettier.rc
+++ b/client/packages/grandpa-ranger/prettier.rc
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "singleQuote": true,
+    "semi": false
+}

--- a/client/packages/grandpa-ranger/src/collect.ts
+++ b/client/packages/grandpa-ranger/src/collect.ts
@@ -26,6 +26,7 @@ export const generateRange = async (
         },
         "Current heights"
       )
+      prometheus.heightDiff = targetHeight - circuitHeight
       prometheus.height.set({ target: "circuit" }, circuitHeight)
 
       if (targetHeight > circuitHeight) {

--- a/client/packages/grandpa-ranger/src/index.ts
+++ b/client/packages/grandpa-ranger/src/index.ts
@@ -127,7 +127,6 @@ class GrandpaRanger {
           logger.info(`Creating tx for ${this.config.targetGatewayId}`)
           let tx
           if (this.config.batching) {
-            logger.debug("Batching ranges")
             // create a single tx with all the batches
             tx = this.circuit.sdk.circuit.tx.createBatch(
               range.map(args => {
@@ -198,12 +197,11 @@ class GrandpaRanger {
 
           const txSize = Math.floor(tx.encodedLength / 1024)
           logger.info(`Range tx size: ${txSize}kB`)
-          if (tx.encodedLength > 4000000) {
-            logger.error(`TX size is too big: ${txSize}kB`)
-            throw new Error(`Tx size is too big: ${txSize}kB`)
-          } else if (tx.encodedLength > 1000000) {
-            logger.warn(`Tx size is big: ${txSize}kB`)
-          }
+          this.prometheus.txSize.set(
+            { target: this.config.targetGatewayId },
+            tx.encodedLength
+          )
+
           let res = await this.circuit.sdk.circuit.tx.signAndSendSafe(tx)
           resolve(res)
         } else {

--- a/client/packages/grandpa-ranger/src/prometheus.ts
+++ b/client/packages/grandpa-ranger/src/prometheus.ts
@@ -71,7 +71,8 @@ export class Prometheus {
           res.end(metrics)
         } else if (req.url === "/status") {
           res.setHeader("Content-Type", "text/plain")
-          res.statusCode = this.circuitActive && this.targetActive ? 200 : (this.heightDiff > 250 ? 500 : res.statusCode);
+          res.statusCode = this.circuitActive && this.targetActive ? 200 : 500
+          res.statusCode = this.heightDiff > 250 ? 500 : res.statusCode
           res.end(
             JSON.stringify({
               circuitActive: this.circuitActive,

--- a/client/packages/grandpa-ranger/src/prometheus.ts
+++ b/client/packages/grandpa-ranger/src/prometheus.ts
@@ -10,6 +10,7 @@ export class Prometheus {
   height: any
   submissions: any
   rangeInterval: any
+  txSize: any
   target: string
 
   constructor(target: string) {
@@ -46,6 +47,13 @@ export class Prometheus {
     this.rangeInterval = new client.Counter({
       name: "range_interval",
       help: "The number of seconds between each range submission",
+      registers: [this.register],
+      labelNames: ["target"],
+    })
+
+    this.txSize = new client.Gauge({
+      name: "tx_size",
+      help: "The number of elements in the tx",
       registers: [this.register],
       labelNames: ["target"],
     })

--- a/client/packages/grandpa-ranger/src/prometheus.ts
+++ b/client/packages/grandpa-ranger/src/prometheus.ts
@@ -12,6 +12,7 @@ export class Prometheus {
   rangeInterval: any
   txSize: any
   target: string
+  heightDiff: number = 0
 
   constructor(target: string) {
     this.target = target
@@ -70,7 +71,7 @@ export class Prometheus {
           res.end(metrics)
         } else if (req.url === "/status") {
           res.setHeader("Content-Type", "text/plain")
-          res.statusCode = this.circuitActive && this.targetActive ? 200 : 500
+          res.statusCode = this.circuitActive && this.targetActive ? 200 : (this.heightDiff > 250 ? 500 : res.statusCode);
           res.end(
             JSON.stringify({
               circuitActive: this.circuitActive,

--- a/client/packages/grandpa-ranger/src/prometheus.ts
+++ b/client/packages/grandpa-ranger/src/prometheus.ts
@@ -53,7 +53,7 @@ export class Prometheus {
 
     this.txSize = new client.Gauge({
       name: "tx_size",
-      help: "The number of elements in the tx",
+      help: "Size of the tx",
       registers: [this.register],
       labelNames: ["target"],
     })


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Removed the time interval between range submissions in `grandpa-ranger` configuration files.
- Added a new line of code to assign the difference between `targetHeight` and `circuitHeight` to `prometheus.heightDiff`.
- Removed a debug log statement related to batching ranges in the `GrandpaRanger` class.
- Added a metric to track the size of the transaction (`txSize`) using Prometheus.
- Modified the `/status` endpoint response status code based on the value of `heightDiff`.

**Style:**
- Introduced a new prettier configuration file for code formatting and style preferences.

> 🎉 Changes are here, no need to fear! 🚀
> Time intervals gone, the code is clear. 🧹
> Metrics now track, with no lack, 📊
> And style's on track, there's no going back! 🎨
<!-- end of auto-generated comment: release notes by openai -->