### PR TITLE
fix: check for above-zero target height increase before setting isActive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7306,6 +7306,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
+ "t3rn-types",
 ]
 
 [[package]]
@@ -7316,7 +7317,9 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
+ "sp-std 8.0.0",
  "t3rn-primitives",
+ "t3rn-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7306,6 +7306,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
+ "sp-std 8.0.0",
  "t3rn-types",
 ]
 

--- a/node/parachain/src/rpc.rs
+++ b/node/parachain/src/rpc.rs
@@ -30,10 +30,10 @@ use t1rn_parachain_runtime::{opaque::Block, AccountId, Balance, Nonce};
     not(feature = "default"),
     not(feature = "runtime-benchmarks")
 ))]
-use t3rn_parachain_runtime::{opaque::Block, AccountId, Balance, Nonce};
+use t3rn_parachain_runtime::{opaque::Block, AccountId, Balance, Hash, Nonce};
 
 #[cfg(any(feature = "t0rn", feature = "default", feature = "runtime-benchmarks"))]
-use t0rn_parachain_runtime::{opaque::Block, AccountId, Balance, Nonce};
+use t0rn_parachain_runtime::{opaque::Block, AccountId, Balance, Hash, Nonce};
 
 #[cfg(not(feature = "t3rn"))]
 use pallet_portal_rpc::{Portal, PortalApiServer};

--- a/node/parachain/src/rpc.rs
+++ b/node/parachain/src/rpc.rs
@@ -64,7 +64,7 @@ where
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: pallet_xdns_rpc::XdnsRuntimeApi<Block, AccountId>,
-    C::Api: pallet_portal_rpc::PortalRuntimeApi<Block, AccountId>,
+    C::Api: pallet_portal_rpc::PortalRuntimeApi<Block, AccountId, Balance, Hash>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {

--- a/node/standalone/src/rpc.rs
+++ b/node/standalone/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use circuit_standalone_runtime::{opaque::Block, AccountId, Balance, Nonce};
+use circuit_standalone_runtime::{opaque::Block, AccountId, Balance, Hash, Nonce};
 use jsonrpsee::RpcModule;
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
@@ -39,7 +39,7 @@ where
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: pallet_xdns_rpc::XdnsRuntimeApi<Block, AccountId>,
-    C::Api: pallet_portal_rpc::PortalRuntimeApi<Block, AccountId>,
+    C::Api: pallet_portal_rpc::PortalRuntimeApi<Block, AccountId, Balance, Hash>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -880,7 +880,7 @@ pub mod pallet {
                 &mut Machine::<T>::load_xtx(xtx_id)?,
                 |current_fsx, _local_state, _steps_cnt, __status, _requester| {
                     Self::confirm(xtx_id, current_fsx, &sfx_id, &confirmation).map_err(|e| {
-                        println!("Self::confirm hit an error -- {:?}", e);
+                        log::error!("Self::confirm hit an error -- {:?}", e);
                         Error::<T>::ConfirmationFailed
                     })?;
                     Ok(PrecompileResult::TryConfirm(sfx_id, confirmation))

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -504,6 +504,13 @@ pub mod pallet {
             Ok(xtx.requester)
         }
 
+        fn get_pending_xtx_ids() -> Vec<T::Hash> {
+            XExecSignals::<T>::iter()
+                .filter(|(_, xtx)| xtx.status < CircuitStatus::Finished)
+                .map(|(xtx_id, _)| xtx_id)
+                .collect::<Vec<T::Hash>>()
+        }
+
         fn get_xtx_status(
             xtx_id: T::Hash,
         ) -> Result<

--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -880,7 +880,7 @@ pub mod pallet {
                 &mut Machine::<T>::load_xtx(xtx_id)?,
                 |current_fsx, _local_state, _steps_cnt, __status, _requester| {
                     Self::confirm(xtx_id, current_fsx, &sfx_id, &confirmation).map_err(|e| {
-                        log::error!("Self::confirm hit an error -- {:?}", e);
+                        println!("Self::confirm hit an error -- {:?}", e);
                         Error::<T>::ConfirmationFailed
                     })?;
                     Ok(PrecompileResult::TryConfirm(sfx_id, confirmation))

--- a/pallets/circuit/src/machine/test.rs
+++ b/pallets/circuit/src/machine/test.rs
@@ -174,6 +174,45 @@ pub mod test {
                 >>::get_fsx(fsx_ids[0]),);
             });
     }
+    use crate::tests::BOB_RELAYER;
+    use t3rn_types::sfx::SideEffect;
+    #[test]
+    fn read_sfx_api_get_all_pending_xtx() {
+        ExtBuilder::default()
+            .with_standard_sfx_abi()
+            .with_default_xdns_records()
+            .build()
+            .execute_with(|| {
+                stage_single();
+
+                let xtx_id = setup_single_sfx_xtx_and_post_bid_and_set_to_ready(None);
+
+                assert_eq!(<Circuit as ReadSFX<
+                    Hash,
+                    AccountId,
+                    Balance,
+                    BlockNumber,
+                >>::get_pending_xtx_ids(), vec![xtx_id]);
+
+                assert_eq!(<Circuit as ReadSFX<
+                    Hash,
+                    AccountId,
+                    Balance,
+                    BlockNumber,
+                >>::get_pending_xtx_for(BOB_RELAYER), vec![(
+                    xtx_id,
+                    vec![SideEffect {
+                        target: [0, 0, 0, 0],
+                        max_reward: 2,
+                        insurance: 3,
+                        action: [116, 114, 97, 110],
+                        encoded_args: vec![vec![42, 246, 86, 215, 84, 26, 25, 17, 173, 225, 126, 30, 234, 99, 78, 169, 50, 247, 0, 118, 125, 167, 191, 15, 94, 94, 97, 126, 250, 236, 22, 62], vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                        signature: vec![],
+                        enforce_executor: Some(BOB_RELAYER),
+                        reward_asset_id: None
+                    }], vec![hex!("0d24d4c519a7fa4f636d4d64127967b704047b08c40cf6dd49068daa75ce5ffe").into()])]);
+            });
+    }
 
     #[test]
     fn read_sfx_api_errors_get_fsx_if_xtx_does_not_exist() {

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -312,6 +312,52 @@ mod tests {
     }
 
     #[test]
+    fn optimistic_order_single_decoded_sfx_vacuum_delivers_to_circuit() {
+        let mut ext = prepare_ext_builder_playground();
+        ext.execute_with(|| {
+            let executor = AccountId32::from([1u8; 32]);
+            let requester = AccountId32::from([2u8; 32]);
+            let requester_on_dest = AccountId32::from([3u8; 32]);
+
+            mint_required_assets_for_optimistic_actors(
+                requester.clone(),
+                executor,
+                200u128,
+                50u128,
+            );
+
+            activate_all_light_clients();
+
+            assert_ok!(Vacuum::single_order(
+                RuntimeOrigin::signed(requester.clone()),
+                POLKADOT_TARGET,
+                ASSET_DOT,
+                100u128,
+                ASSET_DOT,
+                200u128,
+                50u128,
+                requester_on_dest.clone(),
+                SpeedMode::Fast
+            ));
+
+            let xtx_id = expect_last_event_to_emit_xtx_id();
+
+            assert_eq!(
+                xtx_id,
+                Hash::from(hex!(
+                    "0162cabd6f37c15015e94be4174f7ad95fa0d6f094da6aea5525ce11731308a1"
+                ))
+            );
+
+            // Expect balance of requester to be reduced by max_reward
+            assert_eq!(
+                Assets::balance(ASSET_DOT, &requester),
+                EXISTENTIAL_DEPOSIT as Balance
+            );
+        });
+    }
+
+    #[test]
     fn optimistic_order_single_sfx_vacuum_delivers_to_circuit() {
         let mut ext = prepare_ext_builder_playground();
         ext.execute_with(|| {

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -113,7 +113,7 @@ pub mod pallet {
 
             T::CircuitSubmitAPI::on_extrinsic_trigger(
                 origin,
-                vec![side_effect],
+                sp_std::vec![side_effect],
                 speed_mode,
                 SecurityLvl::Optimistic,
             )?;

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -172,10 +172,11 @@ mod tests {
     use t3rn_primitives::{clock::OnHookQueues, light_client::LightClientAsyncAPI};
 
     use t3rn_mini_mock_runtime::{
-        prepare_ext_builder_playground, AccountId, Assets, Balance, Balances, BlockNumber, Circuit,
-        CircuitError, CircuitEvent, Clock, GlobalOnInitQueues, Hash, MiniRuntime, MockedAssetEvent,
-        OrderStatusRead, Portal, Rewards, RuntimeEvent as Event, RuntimeOrigin, System, Vacuum,
-        VacuumEvent, ASSET_DOT, POLKADOT_TARGET, XDNS,
+        activate_all_light_clients, prepare_ext_builder_playground, AccountId, Assets, Balance,
+        Balances, BlockNumber, Circuit, CircuitError, CircuitEvent, Clock, GlobalOnInitQueues,
+        Hash, MiniRuntime, MockedAssetEvent, OrderStatusRead, Portal, Rewards,
+        RuntimeEvent as Event, RuntimeOrigin, System, Vacuum, VacuumEvent, ASSET_DOT,
+        POLKADOT_TARGET, XDNS,
     };
     use t3rn_primitives::portal::Portal as PortalT;
 
@@ -194,14 +195,6 @@ mod tests {
         monetary::EXISTENTIAL_DEPOSIT,
     };
     use t3rn_types::fsx::TargetId;
-
-    fn activate_all_light_clients() {
-        for &gateway in XDNS::all_gateway_ids().iter() {
-            Portal::turn_on(RuntimeOrigin::root(), gateway).unwrap();
-        }
-        XDNS::process_all_verifier_overviews(System::block_number());
-        XDNS::process_overview(System::block_number());
-    }
 
     fn mint_required_assets_for_optimistic_actors(
         requester: AccountId,
@@ -475,11 +468,11 @@ mod tests {
                         None
                     )],
                     timeouts_at: AdaptiveTimeout::<BlockNumber, TargetId> {
-                        estimated_height_here: 817,
-                        estimated_height_there: 824,
-                        submit_by_height_here: 417,
-                        submit_by_height_there: 424,
-                        emergency_timeout_here: 417,
+                        estimated_height_here: 97,
+                        estimated_height_there: 152,
+                        submit_by_height_here: 65,
+                        submit_by_height_there: 88,
+                        emergency_timeout_here: 433,
                         there: [1, 1, 1, 1],
                         dlq: None
                     },
@@ -505,11 +498,11 @@ mod tests {
                         None
                     )],
                     timeouts_at: AdaptiveTimeout::<BlockNumber, TargetId> {
-                        estimated_height_here: 817,
-                        estimated_height_there: 824,
-                        submit_by_height_here: 417,
-                        submit_by_height_there: 424,
-                        emergency_timeout_here: 417,
+                        estimated_height_here: 97,
+                        estimated_height_there: 152,
+                        submit_by_height_here: 65,
+                        submit_by_height_there: 88,
+                        emergency_timeout_here: 433,
                         there: [1, 1, 1, 1],
                         dlq: None
                     },
@@ -584,11 +577,11 @@ mod tests {
                         Some(AccountId32::new([1u8; 32]))
                     ),],
                     timeouts_at: AdaptiveTimeout::<BlockNumber, TargetId> {
-                        estimated_height_here: 817,
-                        estimated_height_there: 824,
-                        submit_by_height_here: 417,
-                        submit_by_height_there: 424,
-                        emergency_timeout_here: 417,
+                        estimated_height_here: 97,
+                        estimated_height_there: 152,
+                        submit_by_height_here: 65,
+                        submit_by_height_there: 88,
+                        emergency_timeout_here: 433,
                         there: [1, 1, 1, 1],
                         dlq: None
                     },
@@ -685,11 +678,11 @@ mod tests {
                         None
                     )],
                     timeouts_at: AdaptiveTimeout {
-                        estimated_height_here: 817,
-                        estimated_height_there: 824,
-                        submit_by_height_here: 417,
-                        submit_by_height_there: 424,
-                        emergency_timeout_here: 417,
+                        estimated_height_here: 97,
+                        estimated_height_there: 152,
+                        submit_by_height_here: 65,
+                        submit_by_height_there: 88,
+                        emergency_timeout_here: 433,
                         there: [1, 1, 1, 1],
                         dlq: None
                     },
@@ -733,8 +726,9 @@ mod tests {
                 CircuitError::<MiniRuntime>::ConfirmationFailed
             );
 
-            // Wait for after XTX timeout
+            // Wait for after XTX emergency timeout
             System::set_block_number(System::block_number() + 401);
+
             // Trigger XTX revert queue and expect move to DLQ
             Circuit::process_emergency_revert_xtx_queue(
                 System::block_number(),
@@ -769,19 +763,20 @@ mod tests {
                         Some(AccountId32::new([1u8; 32]))
                     ),],
                     timeouts_at: AdaptiveTimeout {
-                        estimated_height_here: 817,
-                        estimated_height_there: 824,
-                        submit_by_height_here: 417,
-                        submit_by_height_there: 424,
-                        emergency_timeout_here: 417,
+                        estimated_height_here: 97,
+                        estimated_height_there: 152,
+                        submit_by_height_here: 65,
+                        submit_by_height_there: 88,
+                        emergency_timeout_here: 433,
                         there: [1, 1, 1, 1],
-                        dlq: Some(453)
+                        dlq: Some(469)
                     },
                 }
             );
 
             // Now activate the LightClient again and expect the DLQ to be processed
             mock_signal_unhalt(POLKADOT_TARGET, GatewayVendor::Polkadot);
+            activate_all_light_clients();
 
             // Advance 1 block
             System::set_block_number(System::block_number() + 1);

--- a/pallets/portal/rpc/Cargo.toml
+++ b/pallets/portal/rpc/Cargo.toml
@@ -22,3 +22,4 @@ sp-blockchain                 = { git = "https://github.com/paritytech/substrate
 sp-core                       = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
 sp-rpc                        = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
 sp-runtime                    = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
+t3rn-types                    = { path = "../../../types" }

--- a/pallets/portal/rpc/Cargo.toml
+++ b/pallets/portal/rpc/Cargo.toml
@@ -18,6 +18,7 @@ jsonrpsee = { workspace = true, features = [ "client-core", "server", "macros" ]
 
 pallet-portal-rpc-runtime-api = { path = "runtime-api" }
 sp-api                        = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
+sp-std                        = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
 sp-blockchain                 = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
 sp-core                       = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }
 sp-rpc                        = { git = "https://github.com/paritytech/substrate", branch = 'polkadot-v1.0.0' }

--- a/pallets/portal/rpc/runtime-api/Cargo.toml
+++ b/pallets/portal/rpc/runtime-api/Cargo.toml
@@ -20,6 +20,7 @@ sp-runtime = { workspace = true }
 
 pallet-portal   = { path = "../..", default-features = false }
 t3rn-primitives = { default-features = false, path = "../../../../primitives" }
+t3rn-types      = { default-features = false, path = "../../../../types" }
 
 [features]
 default = [ "std" ]

--- a/pallets/portal/rpc/runtime-api/Cargo.toml
+++ b/pallets/portal/rpc/runtime-api/Cargo.toml
@@ -16,6 +16,7 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 codec      = { workspace = true, package = "parity-scale-codec" }
 
 sp-api     = { workspace = true }
+sp-std     = { workspace = true }
 sp-runtime = { workspace = true }
 
 pallet-portal   = { path = "../..", default-features = false }
@@ -24,4 +25,4 @@ t3rn-types      = { default-features = false, path = "../../../../types" }
 
 [features]
 default = [ "std" ]
-std     = [ "codec/std", "sp-api/std", "sp-runtime/std", "pallet-portal/std" ]
+std     = [ "codec/std", "sp-api/std", "sp-std/std", "sp-runtime/std", "pallet-portal/std" ]

--- a/pallets/portal/rpc/runtime-api/src/lib.rs
+++ b/pallets/portal/rpc/runtime-api/src/lib.rs
@@ -8,6 +8,7 @@
 
 use codec::Codec;
 
+use sp_std::vec::Vec;
 pub use t3rn_primitives::ChainId;
 use t3rn_types::sfx::SideEffect;
 

--- a/pallets/portal/rpc/runtime-api/src/lib.rs
+++ b/pallets/portal/rpc/runtime-api/src/lib.rs
@@ -8,7 +8,8 @@
 
 use codec::Codec;
 
-use sp_std::vec::Vec;
+use sp_std::prelude::*;
+
 pub use t3rn_primitives::ChainId;
 use t3rn_types::sfx::SideEffect;
 

--- a/pallets/portal/rpc/runtime-api/src/lib.rs
+++ b/pallets/portal/rpc/runtime-api/src/lib.rs
@@ -9,13 +9,21 @@
 use codec::Codec;
 
 pub use t3rn_primitives::ChainId;
+use t3rn_types::sfx::SideEffect;
 
 sp_api::decl_runtime_apis! {
     /// The API to interact with pallet XDNS
-    pub trait PortalRuntimeApi<AccountId> where
+    pub trait PortalRuntimeApi<AccountId, Balance, Hash> where
         AccountId: Codec,
+        Balance: Codec,
+        Hash: Codec,
     {
         /// Returns the current head height of the given chain
         fn fetch_head_height(chain_id: ChainId) -> Option<u128>;
+        fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
+            Hash,                              // xtx_id
+            Vec<SideEffect<AccountId, Balance>>, // side_effects
+            Vec<Hash>,                         // sfx_ids
+        )>;
     }
 }

--- a/pallets/portal/rpc/src/lib.rs
+++ b/pallets/portal/rpc/src/lib.rs
@@ -7,6 +7,8 @@ use jsonrpsee::{
     core::{Error as JsonRpseeError, RpcResult},
     proc_macros::rpc,
 };
+use sp_std::vec::Vec;
+
 use pallet_portal_rpc_runtime_api::ChainId;
 pub use pallet_portal_rpc_runtime_api::PortalRuntimeApi;
 use sp_api::ProvideRuntimeApi;

--- a/pallets/portal/rpc/src/lib.rs
+++ b/pallets/portal/rpc/src/lib.rs
@@ -100,12 +100,6 @@ where
             .map_err(runtime_error_into_rpc_err)?;
 
         Ok(result)
-        // match result {
-        //     Some() => Ok(height),
-        //     None => Err(runtime_error_into_rpc_err(
-        //         "fetch_all_active_xtx failed exist",
-        //     )),
-        // }
     }
 }
 

--- a/pallets/portal/rpc/src/lib.rs
+++ b/pallets/portal/rpc/src/lib.rs
@@ -12,14 +12,27 @@ pub use pallet_portal_rpc_runtime_api::PortalRuntimeApi;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::{Block as BlockT, MaybeDisplay};
+use t3rn_types::sfx::SideEffect;
 
 const RUNTIME_ERROR: i64 = 1;
 
 #[rpc(client, server)]
-pub trait PortalApi<AccountId> {
+pub trait PortalApi<AccountId, Balance, Hash> {
     /// Returns latest finalized header of a gateway if available
     #[method(name = "portal_fetchHeadHeight")]
     fn fetch_head_height(&self, chain_id: ChainId) -> RpcResult<u128>;
+
+    #[method(name = "portal_allActiveXtx")]
+    fn fetch_all_active_xtx(
+        &self,
+        for_executor: AccountId,
+    ) -> RpcResult<
+        Vec<(
+            Hash,                                // xtx_id
+            Vec<SideEffect<AccountId, Balance>>, // side_effects
+            Vec<Hash>,                           // sfx_ids
+        )>,
+    >;
 }
 
 /// A struct that implements the [`PortalApi`].
@@ -38,12 +51,15 @@ impl<C, P> Portal<C, P> {
     }
 }
 
-impl<C, Block, AccountId> PortalApiServer<AccountId> for Portal<C, Block>
+impl<C, Block, AccountId, Balance, Hash> PortalApiServer<AccountId, Balance, Hash>
+    for Portal<C, Block>
 where
     AccountId: Codec + MaybeDisplay,
+    Balance: Codec + MaybeDisplay,
+    Hash: Codec + MaybeDisplay,
     Block: BlockT,
     C: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync + 'static,
-    C::Api: PortalRuntimeApi<Block, AccountId>,
+    C::Api: PortalRuntimeApi<Block, AccountId, Balance, Hash>,
 {
     // ToDo ChainId decoding is not working, like in XDNS
     fn fetch_head_height(&self, chain_id: ChainId) -> RpcResult<u128> {
@@ -58,6 +74,36 @@ where
             Some(height) => Ok(height),
             None => Err(runtime_error_into_rpc_err("ABI doesn't exist")),
         }
+    }
+
+    fn fetch_all_active_xtx(
+        &self,
+        for_executor: AccountId,
+    ) -> RpcResult<
+        Vec<(
+            Hash,                                // xtx_id
+            Vec<SideEffect<AccountId, Balance>>, // side_effects
+            Vec<Hash>,                           // sfx_ids
+        )>,
+    > {
+        let api = self.client.runtime_api();
+        let at = self.client.info().best_hash;
+
+        let result: Vec<(
+            Hash,                                // xtx_id
+            Vec<SideEffect<AccountId, Balance>>, // side_effects
+            Vec<Hash>,                           // sfx_ids
+        )> = api
+            .fetch_all_active_xtx(at, for_executor)
+            .map_err(runtime_error_into_rpc_err)?;
+
+        Ok(result)
+        // match result {
+        //     Some() => Ok(height),
+        //     None => Err(runtime_error_into_rpc_err(
+        //         "fetch_all_active_xtx failed exist",
+        //     )),
+        // }
     }
 }
 

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -281,15 +281,19 @@ pub mod pallet {
                 (Zero::zero(), Zero::zero());
 
             if let Some(last_record) = historic_overview.last() {
-                if let Some((local, target)) =
+                if let Some((target_increase, local_increase)) =
                     FinalityVerifierActivity::determine_finalized_reports_increase(&[
                         last_record.clone(),
                         new_activity.clone(),
                     ])
                 {
-                    is_moving = true;
-                    local_height_increase = local;
-                    target_finalized_height_increase = target;
+                    if local_increase > Zero::zero() {
+                        local_height_increase = local_increase;
+                    }
+                    if target_increase > Zero::zero() {
+                        is_moving = true;
+                        target_finalized_height_increase = target_increase;
+                    }
                 }
             }
 
@@ -303,14 +307,16 @@ pub mod pallet {
 
             if !is_moving {
                 if let Some(previous) = historic_overview.iter().rev().nth(1).cloned() {
-                    if let Some((_, _)) =
+                    if let Some((target_finality_height_increase, _)) =
                         FinalityVerifierActivity::determine_finalized_reports_increase(&[
                             previous,
                             last_record.clone(),
                             new_activity,
                         ])
                     {
-                        is_moving = true;
+                        if target_finality_height_increase > Zero::zero() {
+                            is_moving = true;
+                        }
                     }
                 }
             }

--- a/primitives/src/circuit/traits.rs
+++ b/primitives/src/circuit/traits.rs
@@ -122,6 +122,8 @@ pub type XExecSignalId<T> = <T as ConfigSystem>::Hash;
 pub type XExecStepSideEffectId<T> = <T as ConfigSystem>::Hash;
 
 pub trait ReadSFX<Hash, Account, Balance, BlockNumber> {
+    fn get_pending_xtx_ids() -> Vec<Hash>;
+
     fn get_fsx_of_xtx(xtx_id: Hash) -> Result<Vec<Hash>, DispatchError>;
 
     fn get_fsx_status(fsx_id: Hash) -> Result<CircuitStatus, DispatchError>;

--- a/primitives/src/circuit/traits.rs
+++ b/primitives/src/circuit/traits.rs
@@ -124,6 +124,14 @@ pub type XExecStepSideEffectId<T> = <T as ConfigSystem>::Hash;
 pub trait ReadSFX<Hash, Account, Balance, BlockNumber> {
     fn get_pending_xtx_ids() -> Vec<Hash>;
 
+    fn get_pending_xtx_for(
+        for_executor: Account,
+    ) -> Vec<(
+        Hash,                              // xtx_id
+        Vec<SideEffect<Account, Balance>>, // side_effects
+        Vec<Hash>,                         // sfx_ids
+    )>;
+
     fn get_fsx_of_xtx(xtx_id: Hash) -> Result<Vec<Hash>, DispatchError>;
 
     fn get_fsx_status(fsx_id: Hash) -> Result<CircuitStatus, DispatchError>;

--- a/primitives/src/circuit/traits.rs
+++ b/primitives/src/circuit/traits.rs
@@ -126,6 +126,8 @@ pub trait ReadSFX<Hash, Account, Balance, BlockNumber> {
 
     fn get_fsx_status(fsx_id: Hash) -> Result<CircuitStatus, DispatchError>;
 
+    fn get_fsx_executor(fsx_id: Hash) -> Result<Option<Account>, DispatchError>;
+
     fn get_fsx(
         fsx_id: Hash,
     ) -> Result<FullSideEffect<Account, BlockNumber, Balance>, DispatchError>;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -637,6 +637,17 @@ mod tests_finality_verifier_activity {
     }
 
     #[test]
+    fn test_determines_none_for_two_non_increasing_elements() {
+        let activity1 = FinalityVerifierActivity::<u32>::new_for_finalized_compare(50u32, 100u32);
+        let activity2 = FinalityVerifierActivity::<u32>::new_for_finalized_compare(100u32, 100u32);
+        let activities = vec![activity1, activity2];
+
+        let result =
+            FinalityVerifierActivity::<u32>::determine_finalized_reports_increase(&activities);
+        assert_eq!(result, Some((0u32, 50u32)));
+    }
+
+    #[test]
     fn test_determines_increase_for_three_elements() {
         let activity1 = FinalityVerifierActivity::<u32>::new_for_finalized_compare(50u32, 100u32);
         let activity2 = FinalityVerifierActivity::<u32>::new_for_finalized_compare(75u32, 150u32);

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -1081,7 +1081,6 @@ pub fn activate_all_light_clients() {
     XDNS::process_overview(System::block_number());
 
     make_all_light_clients_move_2_times_by(8);
-    XDNS::process_overview(System::block_number());
 }
 
 pub fn prepare_ext_builder_playground() -> TestExternalities {

--- a/runtime/standalone/src/impl_versioned_runtime_with_api.rs
+++ b/runtime/standalone/src/impl_versioned_runtime_with_api.rs
@@ -15,10 +15,9 @@ pub use frame_support::{
     StorageValue,
 };
 pub use pallet_balances::Call as BalancesCall;
+use pallet_circuit::ChainId;
 use pallet_grandpa::AuthorityId as GrandpaId;
 pub use pallet_timestamp::Call as TimestampCall;
-
-use pallet_circuit::ChainId;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -31,6 +30,7 @@ use sp_runtime::{
 };
 pub use sp_runtime::{Perbill, Permill};
 use t3rn_primitives::{
+    circuit::ReadSFX,
     portal::HeightResult,
     xdns::{FullGatewayRecord, GatewayRecord},
     TreasuryAccountProvider,

--- a/runtime/standalone/src/impl_versioned_runtime_with_api.rs
+++ b/runtime/standalone/src/impl_versioned_runtime_with_api.rs
@@ -330,32 +330,12 @@ impl_runtime_apis! {
             }
         }
 
-               fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
+       fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
             Hash,                              // xtx_id
             Vec<SideEffect<AccountId, Balance>>, // side_effects
             Vec<Hash>,                         // sfx_ids
         )> {
-            let mut active_xtx = Vec::new();
-            for active_xtx_id in Circuit::get_pending_xtx_ids() {
-                let fsx_ids = Circuit::get_fsx_of_xtx(active_xtx_id).unwrap_or_default();
-                let mut executors_of_fsx = Vec::new();
-                let mut side_effects_of_executor = Vec::new();
-                for fsx_id in fsx_ids {
-                    match Circuit::get_fsx(fsx_id.clone()) {
-                        Ok(fsx) => {
-                            if fsx.input.enforce_executor == Some(for_executor.clone()) {
-                                side_effects_of_executor.push(fsx.input);
-                                executors_of_fsx.push(fsx_id);
-                            }
-                        }
-                        Err(_) => {}
-                    }
-                }
-                if !side_effects_of_executor.is_empty() {
-                    active_xtx.push((active_xtx_id, side_effects_of_executor, executors_of_fsx));
-                }
-            }
-            active_xtx
+            Circuit::get_pending_xtx_for(for_executor)
         }
     }
 

--- a/runtime/t0rn-parachain/src/lib.rs
+++ b/runtime/t0rn-parachain/src/lib.rs
@@ -35,6 +35,8 @@ use t3rn_primitives::{
     TreasuryAccountProvider,
 };
 
+use t3rn_types::sfx::SideEffect;
+
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -270,7 +272,7 @@ mod benches {
 
 use frame_system::EventRecord;
 use sp_core::H256;
-
+use t3rn_primitives::circuit::ReadSFX;
 impl_runtime_apis! {
     impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
         fn slot_duration() -> sp_consensus_aura::SlotDuration {
@@ -484,7 +486,7 @@ impl_runtime_apis! {
         }
     }
 
-     impl pallet_portal_rpc_runtime_api::PortalRuntimeApi<Block, AccountId> for Runtime {
+     impl pallet_portal_rpc_runtime_api::PortalRuntimeApi<Block, AccountId, Balance, Hash> for Runtime {
         fn fetch_head_height(chain_id: ChainId) -> Option<u128> {
             let res = <Portal as t3rn_primitives::portal::Portal<Runtime>>::get_fast_height(chain_id);
 
@@ -492,6 +494,34 @@ impl_runtime_apis! {
                 Ok(HeightResult::Height(height)) => Some(height.into()),
                 _ => None,
             }
+        }
+
+        fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
+            Hash,                              // xtx_id
+            Vec<SideEffect<AccountId, Balance>>, // side_effects
+            Vec<Hash>,                         // sfx_ids
+        )> {
+            let mut active_xtx = Vec::new();
+            for active_xtx_id in Circuit::get_pending_xtx_ids() {
+                let fsx_ids = Circuit::get_fsx_of_xtx(active_xtx_id).unwrap_or_default();
+                let mut executors_of_fsx = Vec::new();
+                let mut side_effects_of_executor = Vec::new();
+                for fsx_id in fsx_ids {
+                    match Circuit::get_fsx(fsx_id.clone()) {
+                        Ok(fsx) => {
+                            if fsx.input.enforce_executor == Some(for_executor.clone()) {
+                                side_effects_of_executor.push(fsx.input);
+                                executors_of_fsx.push(fsx_id);
+                            }
+                        }
+                        Err(_) => {}
+                    }
+                }
+                if !side_effects_of_executor.is_empty() {
+                    active_xtx.push((active_xtx_id, side_effects_of_executor, executors_of_fsx));
+                }
+            }
+            active_xtx
         }
     }
 

--- a/runtime/t0rn-parachain/src/lib.rs
+++ b/runtime/t0rn-parachain/src/lib.rs
@@ -501,27 +501,7 @@ impl_runtime_apis! {
             Vec<SideEffect<AccountId, Balance>>, // side_effects
             Vec<Hash>,                         // sfx_ids
         )> {
-            let mut active_xtx = Vec::new();
-            for active_xtx_id in Circuit::get_pending_xtx_ids() {
-                let fsx_ids = Circuit::get_fsx_of_xtx(active_xtx_id).unwrap_or_default();
-                let mut executors_of_fsx = Vec::new();
-                let mut side_effects_of_executor = Vec::new();
-                for fsx_id in fsx_ids {
-                    match Circuit::get_fsx(fsx_id.clone()) {
-                        Ok(fsx) => {
-                            if fsx.input.enforce_executor == Some(for_executor.clone()) {
-                                side_effects_of_executor.push(fsx.input);
-                                executors_of_fsx.push(fsx_id);
-                            }
-                        }
-                        Err(_) => {}
-                    }
-                }
-                if !side_effects_of_executor.is_empty() {
-                    active_xtx.push((active_xtx_id, side_effects_of_executor, executors_of_fsx));
-                }
-            }
-            active_xtx
+            Circuit::get_pending_xtx_for(for_executor)
         }
     }
 

--- a/runtime/t0rn-parachain/src/parachain_config.rs
+++ b/runtime/t0rn-parachain/src/parachain_config.rs
@@ -107,7 +107,7 @@ impl pallet_session::Config for Runtime {
 impl pallet_aura::Config for Runtime {
     type AllowMultipleBlocksPerSlot = ConstBool<false>;
     type AuthorityId = AuraId;
-    type DisabledValidators = ();
+    type DisabledValidators = Session;
     type MaxAuthorities = MaxAuthorities;
 }
 

--- a/runtime/t1rn-parachain/src/lib.rs
+++ b/runtime/t1rn-parachain/src/lib.rs
@@ -72,8 +72,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     state_version: 1, // 0 = old, 1 = new; see above for details
 };
 use frame_system::EnsureRoot;
-use t3rn_primitives::monetary::MILLIT3RN;
-
+use t3rn_primitives::{circuit::ReadSFX, monetary::MILLIT3RN};
 pub const TRN: Balance = UNIT;
 
 /// The version information used to identify this runtime when compiled natively.

--- a/runtime/t1rn-parachain/src/lib.rs
+++ b/runtime/t1rn-parachain/src/lib.rs
@@ -455,6 +455,8 @@ use t3rn_primitives::{
     TreasuryAccountProvider,
 };
 
+use t3rn_types::sfx::SideEffect;
+
 impl_runtime_apis! {
     impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
         fn slot_duration() -> sp_consensus_aura::SlotDuration {
@@ -655,7 +657,7 @@ impl_runtime_apis! {
         }
     }
 
-     impl pallet_portal_rpc_runtime_api::PortalRuntimeApi<Block, AccountId> for Runtime {
+     impl pallet_portal_rpc_runtime_api::PortalRuntimeApi<Block, AccountId, Balance, Hash> for Runtime {
         fn fetch_head_height(chain_id: ChainId) -> Option<u128> {
             let res = <Portal as t3rn_primitives::portal::Portal<Runtime>>::get_fast_height(chain_id);
 
@@ -663,6 +665,34 @@ impl_runtime_apis! {
                 Ok(HeightResult::Height(height)) => Some(height.into()),
                 _ => None,
             }
+        }
+
+               fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
+            Hash,                              // xtx_id
+            Vec<SideEffect<AccountId, Balance>>, // side_effects
+            Vec<Hash>,                         // sfx_ids
+        )> {
+            let mut active_xtx = Vec::new();
+            for active_xtx_id in Circuit::get_pending_xtx_ids() {
+                let fsx_ids = Circuit::get_fsx_of_xtx(active_xtx_id).unwrap_or_default();
+                let mut executors_of_fsx = Vec::new();
+                let mut side_effects_of_executor = Vec::new();
+                for fsx_id in fsx_ids {
+                    match Circuit::get_fsx(fsx_id.clone()) {
+                        Ok(fsx) => {
+                            if fsx.input.enforce_executor == Some(for_executor.clone()) {
+                                side_effects_of_executor.push(fsx.input);
+                                executors_of_fsx.push(fsx_id);
+                            }
+                        }
+                        Err(_) => {}
+                    }
+                }
+                if !side_effects_of_executor.is_empty() {
+                    active_xtx.push((active_xtx_id, side_effects_of_executor, executors_of_fsx));
+                }
+            }
+            active_xtx
         }
     }
 

--- a/runtime/t1rn-parachain/src/lib.rs
+++ b/runtime/t1rn-parachain/src/lib.rs
@@ -666,32 +666,12 @@ impl_runtime_apis! {
             }
         }
 
-               fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
+       fn fetch_all_active_xtx(for_executor: AccountId) -> Vec<(
             Hash,                              // xtx_id
             Vec<SideEffect<AccountId, Balance>>, // side_effects
             Vec<Hash>,                         // sfx_ids
         )> {
-            let mut active_xtx = Vec::new();
-            for active_xtx_id in Circuit::get_pending_xtx_ids() {
-                let fsx_ids = Circuit::get_fsx_of_xtx(active_xtx_id).unwrap_or_default();
-                let mut executors_of_fsx = Vec::new();
-                let mut side_effects_of_executor = Vec::new();
-                for fsx_id in fsx_ids {
-                    match Circuit::get_fsx(fsx_id.clone()) {
-                        Ok(fsx) => {
-                            if fsx.input.enforce_executor == Some(for_executor.clone()) {
-                                side_effects_of_executor.push(fsx.input);
-                                executors_of_fsx.push(fsx_id);
-                            }
-                        }
-                        Err(_) => {}
-                    }
-                }
-                if !side_effects_of_executor.is_empty() {
-                    active_xtx.push((active_xtx_id, side_effects_of_executor, executors_of_fsx));
-                }
-            }
-            active_xtx
+            Circuit::get_pending_xtx_for(for_executor)
         }
     }
 

--- a/types/src/sfx.rs
+++ b/types/src/sfx.rs
@@ -42,6 +42,7 @@ pub const SWAP_SIDE_EFFECT_ID: &[u8; 4] = b"swap";
 pub const DATA_SIDE_EFFECT_ID: &[u8; 4] = b"data";
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct SideEffect<AccountId, BalanceOf> {
     pub target: TargetId,
     pub max_reward: BalanceOf,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Features:**
- Added checks for above-zero target height increase in `pallets/xdns/src/lib.rs`.
- Introduced new test case `test_determines_none_for_two_non_increasing_elements` in `primitives/src/lib.rs`.
- Modified the `DisabledValidators` type in `runtime/t0rn-parachain/src/parachain_config.rs`.
- Updated import statements in `node/parachain/src/rpc.rs`, `node/standalone/src/rpc.rs`.
- Implemented new functions and methods related to side effects and transactions in `pallets/circuit/src/lib.rs`, `pallets/circuit/src/machine/test.rs`, `primitives/src/circuit/traits.rs`.
- Added a new function `fetch_all_active_xtx` to the `PortalRuntimeApi` trait and its implementations across multiple files.
- Removed a call to `XDNS::process_overview(System::block_number())` in `runtime/mini-mock/src/lib.rs`.
- Enabled serialization and deserialization for the `SideEffect` struct in `types/src/sfx.rs`.

> 🎉 Code changes are here, making things clear, 🚀
> New features abound, improvements all around. 🌟
> With each PR merge, we surge, 💪
> On the path of innovation, we continue our journey without reservation. 🛤️
<!-- end of auto-generated comment: release notes by openai -->