### PR TITLE
chore: update sepolia pallet version to tag 1.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ docs/attester
 **/parachains-integration-tests
 .idea
 *.iml
+*.txt
 
 vendor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7414,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "pallet-sepolia-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.2#08b3a8636afd58535eb0342ee35c20bb4cbc3f92"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.3#fe8a6260edd931686cae0708b36f11966cb3b7dc"
 dependencies = [
  "eth_trie",
  "ethereum-types",

--- a/runtime/common-pallets/Cargo.toml
+++ b/runtime/common-pallets/Cargo.toml
@@ -106,7 +106,7 @@ pallet-xdns                      = { path = "../../pallets/xdns", default-featur
 pallet-xdns-rpc-runtime-api      = { path = "../../pallets/xdns/rpc/runtime-api", default-features = false }
 pallet-vacuum                    = { path = "../../pallets/circuit/vacuum", package = "pallet-circuit-vacuum", default-features = false }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.1", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.2", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.3", default-features = false }
 pallet-rewards                   = { path = "../../pallets/rewards", default-features = false }
 
 # Smart contracts VMs

--- a/runtime/mini-mock/Cargo.toml
+++ b/runtime/mini-mock/Cargo.toml
@@ -60,6 +60,6 @@ pallet-portal                    = { path = "../../pallets/portal" }
 pallet-rewards                   = { path = "../../pallets/rewards" }
 pallet-xdns                      = { path = "../../pallets/xdns" }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.1" }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.2" }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.3" }
 
 circuit-runtime-types = { path = "../../runtime/common-types" }

--- a/runtime/standalone/Cargo.toml
+++ b/runtime/standalone/Cargo.toml
@@ -34,7 +34,7 @@ pallet-clock                              = { path = "../../pallets/clock", defa
 pallet-contracts-registry                 = { path = "../../pallets/contracts-registry", default-features = false }
 #pallet-contracts-registry-rpc-runtime-api = { path = "../../pallets/contracts-registry/rpc/runtime-api", default-features = false }
 pallet-eth2-finality-verifier             = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.1", default-features = false }
-pallet-sepolia-finality-verifier          = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.2", default-features = false }
+pallet-sepolia-finality-verifier          = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.3", default-features = false }
 pallet-grandpa-finality-verifier          = { path = "../../finality-verifiers/grandpa", default-features = false }
 pallet-portal                             = { path = "../../pallets/portal", default-features = false }
 pallet-portal-rpc-runtime-api             = { path = "../../pallets/portal/rpc/runtime-api", default-features = false }

--- a/runtime/t0rn-parachain/Cargo.toml
+++ b/runtime/t0rn-parachain/Cargo.toml
@@ -99,7 +99,7 @@ pallet-attesters                 = { path = "../../pallets/attesters", default-f
 pallet-vacuum                    = { path = "../../pallets/circuit/vacuum", package = "pallet-circuit-vacuum", default-features = false }
 pallet-rewards                   = { path = "../../pallets/rewards", default-features = false }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.1", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.2", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.3", default-features = false }
 pallet-account-manager           = { path = "../../pallets/account-manager", default-features = false }
 pallet-circuit                   = { path = "../../pallets/circuit", package = "pallet-circuit", default-features = false }
 pallet-clock                     = { path = "../../pallets/clock", default-features = false }

--- a/runtime/t1rn-parachain/Cargo.toml
+++ b/runtime/t1rn-parachain/Cargo.toml
@@ -101,7 +101,7 @@ pallet-attesters                 = { path = "../../pallets/attesters", default-f
 pallet-vacuum                    = { path = "../../pallets/circuit/vacuum", package = "pallet-circuit-vacuum", default-features = false }
 pallet-rewards                   = { path = "../../pallets/rewards", default-features = false }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.1", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.2", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.3", default-features = false }
 pallet-account-manager           = { path = "../../pallets/account-manager", default-features = false }
 pallet-circuit                   = { path = "../../pallets/circuit", package = "pallet-circuit", default-features = false }
 pallet-clock                     = { path = "../../pallets/clock", default-features = false }


### PR DESCRIPTION
Update sepolia pallet version to tag 1.1.3
The new version introduces multiple logs to debug track the submission of new sync committees.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

## Release Notes

**Chore**: Updated the sepolia pallet version to tag 1.1.3. This update includes the addition of a new text file.

> 🎉 A version, oh so new, we greet with cheer, 🥳
>
> To sepolia pallet, we've brought you near. 🚀
>
> With every update, our code takes flight, ✈️
>
> In the realm of software, a shining light. 💡
<!-- end of auto-generated comment: release notes by openai -->