### PR TITLE
fix: lower SyncCommitteeSupermajority sepolia

### DIFF
--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -326,8 +326,8 @@ parameter_types! {
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
-    pub const CommitteeMajorityThresholdEth2: u32 = 56;
-    pub const CommitteeMajorityThresholdSepolia: u32 = 56;
+    pub const CommitteeMajorityThresholdEth2: u32 = 80;
+    pub const CommitteeMajorityThresholdSepolia: u32 = 1;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Adjusted the values of `CommitteeMajorityThresholdEth2` and `CommitteeMajorityThresholdSepolia` in the circuit configuration. The threshold for Eth2 has been increased to enhance security, while the threshold for Sepolia has been decreased to improve efficiency. These changes aim to optimize the balance between security and performance in the runtime environment.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->