### PR TITLE
fix: include binary for docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 **/target
 **/node_modules
-!target/release/t3rn-collator
 !target/release/t0rn-collator
+!target/release/t1rn-collator
+!target/release/t3rn-collator

--- a/.github/workflows/release-t1rn.yml
+++ b/.github/workflows/release-t1rn.yml
@@ -17,7 +17,6 @@ jobs:
   build-release:
     runs-on: [self-hosted, rust]
     name: t1rn Kusama Release
-    concurrency: runtime-upgrade
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - "**/runtime-upgrade-t0rn.yml"
       - "collator.*.Dockerfile"
       - "specs/*.raw.json"
+      - ".dockerignore"
 
 env:
   PARACHAIN_NAME: t0rn

--- a/.github/workflows/semantic-version.yml
+++ b/.github/workflows/semantic-version.yml
@@ -10,6 +10,7 @@ on:
       - "**/runtime-upgrade-t0rn.yml"
       - "collator.*.Dockerfile"
       - "specs/*.raw.json"
+      - ".dockerignore"
 
 permissions:
   pull-requests: write


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated `.dockerignore` file to refine the Docker context, improving the build process and potentially impacting runtime behavior.
- Chore: Modified GitHub Actions workflows (`release.yml`, `semantic-version.yml`) to trigger on changes to the `.dockerignore` file, ensuring that workflow runs reflect the latest Docker context configuration.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->