### PR TITLE
fix: decrease CommitteeMajorityThresholdSepolia for sepolia ranger

### DIFF
--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -346,7 +346,7 @@ parameter_types! {
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
     pub const CommitteeMajorityThresholdEth2: u32 = 80;
-    pub const CommitteeMajorityThresholdSepolia: u32 = 1;
+    pub const CommitteeMajorityThresholdSepolia: u32 = 0;
 }
 
 impl pallet_eth2_finality_verifier::Config for Runtime {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Adjusted the `CommitteeMajorityThresholdSepolia` value from 1 to 0 in the `parameter_types!` block within `runtime/t0rn-parachain/src/circuit_config.rs`. This change may alter the behavior of modules that depend on this constant, potentially affecting consensus mechanisms. Please review your system's configuration and adjust as necessary to accommodate this update.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->