### PR TITLE
fix: successful USDT and TRN XCM transfers using CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13184,6 +13184,7 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
+ "polkadot-core-primitives",
  "polkadot-parachain",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ pallet-xcm                 = { git = "https://github.com/paritytech/polkadot", b
 polkadot-parachain         = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }
 polkadot-runtime-common    = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }
 polkadot-runtime-constants = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }
+polkadot-core-primitives   = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v1.0.0" }
 xcm                        = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }
 xcm-builder                = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }
 xcm-executor               = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0", default-features = false }

--- a/client/packages/cli/package.json
+++ b/client/packages/cli/package.json
@@ -25,7 +25,7 @@
     "@chainsafe/ssz": "^0.11.1",
     "@lodestar/config": "^1.11.3",
     "@lodestar/types": "^1.11.3",
-    "@t3rn/sdk": "^0.4.2",
+    "@t3rn/sdk": "^0.4.3",
     "@t3rn/types": "^0.1.11",
     "chalk": "^4.1.2",
     "clean-stack": "^3.0.1",

--- a/client/packages/cli/pnpm-lock.yaml
+++ b/client/packages/cli/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.11.3
     version: 1.11.3
   '@t3rn/sdk':
-    specifier: ^0.4.2
-    version: 0.4.2
+    specifier: ^0.4.3
+    version: 0.4.3
   '@t3rn/types':
     specifier: ^0.1.11
     version: 0.1.11(@polkadot/util-crypto@9.7.2)(@polkadot/util@9.7.2)(@types/node@20.8.7)(typescript@5.1.6)
@@ -1911,8 +1911,8 @@ packages:
     resolution: {integrity: sha512-USEkXA46P9sqClL7PZv0QFsit4S8Im97wchKG0/H/9q3AT/S76r40UHfCr4Un7eBJPE23f7fU9BZ0ITpP9MCsA==}
     dev: false
 
-  /@t3rn/sdk@0.4.2:
-    resolution: {integrity: sha512-XOkvSWTp1NrhyPxx+rEJ6Vez24nS/dZ31CzfFlbrLn9gtrP2/sXNDnO71LZv5ANVcBxguUCgr3da5nXiD0DJRw==}
+  /@t3rn/sdk@0.4.3:
+    resolution: {integrity: sha512-+1CJy/m0lMi8yZCqWq/v2YuTioKBc8q4c4QTRzcY+mCILyH44gXinqQwbVCSnVthy5Md3XaQ8BGeMAm+5BNWXQ==}
     dependencies:
       '@polkadot/api': 8.14.1
       '@polkadot/types': 8.14.1

--- a/client/packages/sdk/package.json
+++ b/client/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3rn/sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "t3rn's client side SDK",
   "files": [
     "dist/**/*"

--- a/client/packages/sdk/src/utils/xcm.ts
+++ b/client/packages/sdk/src/utils/xcm.ts
@@ -3,10 +3,17 @@ import type {
    InteriorMultiLocation,
    VersionedMultiAssets,
    VersionedMultiLocation,
+   WeightLimitV2,
 } from '@polkadot/types/interfaces'
 import {u8, u32, u128} from '@polkadot/types'
 type ORIGIN = "relay" | "para" | "system" | "t0rn"
 type ASSET  = "ROC" | "USDT" | "TRN"
+/*
+type WeightLimt = {
+   refTime: string,
+   proofSize: string,
+}
+ */
 
 interface ICreateXcmParameters {
    createDestination: (api: ApiPromise, destChainId: string, originType: ORIGIN) => VersionedMultiLocation
@@ -14,7 +21,7 @@ interface ICreateXcmParameters {
    createAssets: (api: ApiPromise, assetType: ASSET, originType: ORIGIN, amount: string) => VersionedMultiAssets
    createFeeAssetItem: (api: ApiPromise, feeAssetItem: number) => u32
    createNativeAssetAmount: (api: ApiPromise, amount: number) => u128
-   //createWeightLimit: (api: ApiPromise, isLimited: bool, weight: u32) => u32
+   createWeightLimit: (api: ApiPromise/*, isLimited: bool, weightLimit: WeightLimit*/) => WeightLimitV2
 }
 
 export const XcmTransferParameters: ICreateXcmParameters = {
@@ -120,5 +127,20 @@ export const XcmTransferParameters: ICreateXcmParameters = {
    },
    createNativeAssetAmount: (api: ApiPromise, amount: number): u128 => {
       return api.registry.createType("u128", amount)
+   },
+   createWeightLimit: (api: ApiPromise/*, isLimited: bool, weightLimit: WeightLimit*/): WeightLimitV2 => {
+      // if (!isLimited) {
+      return api.registry.createType('XcmV3WeightLimit', {
+         Unlimited: null
+      })
+      //}
+      //else {
+      //   return api.registry.createType('XcmV3WeightLimit', {
+      //      Limited: {
+      //         refTime: weightLimit.refTime,
+      //         proofSize: weightLimit.proofSize,
+      //      }
+      //  })
+      //}
    }
 }

--- a/client/packages/sdk/src/utils/xcm.ts
+++ b/client/packages/sdk/src/utils/xcm.ts
@@ -8,8 +8,9 @@ import type {
 import {u8, u32, u128} from '@polkadot/types'
 type ORIGIN = "relay" | "para" | "system" | "t0rn"
 type ASSET  = "ROC" | "USDT" | "TRN"
+
 /*
-type WeightLimt = {
+type WeightLimit = {
    refTime: string,
    proofSize: string,
 }
@@ -72,35 +73,28 @@ export const XcmTransferParameters: ICreateXcmParameters = {
          case "USDT":
             if (originType == "system") {
                assetInterior = api.registry.createType('InteriorMultiLocation', {
-                  X2: {
-                     PalletInstance: 50,
-                     GeneralIndex: 1984,
-                  },
+                  X2: [
+                     { PalletInstance: 50 },
+                     { GeneralIndex: 1984 },
+                  ],
                })
             }
             else {
                assetInterior = api.registry.createType('InteriorMultiLocation', {
-                  X3: {
-                     parachain: 1000,
-                     PalletInstance: 50,
-                     GeneralIndex: 1984,
-                  },
+                  X3: [
+                     { Parachain: 1000 },
+                     { PalletInstance: 50 },
+                     { GeneralIndex: 1984 },
+                  ],
                })
             }
             break
          case "TRN":
-            if (originType == "t0rn") {
-               assetInterior = api.registry.createType('InteriorMultiLocation', {
-                  X1: {
-                     parachain: 3333,
-                  },
-               })
-            }
-            else {
-               assetInterior = api.registry.createType('InteriorMultiLocation', {
-                  Here: '',
-               })
-            }
+            assetInterior = api.registry.createType('InteriorMultiLocation', {
+               X1: {
+                  parachain: 3333,
+               },
+            })
             break
          default:
             assetInterior = api.registry.createType('InteriorMultiLocation', {

--- a/runtime/t0rn-parachain/Cargo.toml
+++ b/runtime/t0rn-parachain/Cargo.toml
@@ -70,6 +70,7 @@ pallet-xcm                 = { workspace = true }
 polkadot-parachain         = { workspace = true }
 polkadot-runtime-common    = { workspace = true }
 polkadot-runtime-constants = { workspace = true }
+polkadot-core-primitives   = { workspace = true }
 xcm                        = { workspace = true }
 xcm-builder                = { workspace = true }
 xcm-executor               = { workspace = true }
@@ -188,6 +189,7 @@ std = [
   "parachain-info/std",
   "polkadot-parachain/std",
   "polkadot-runtime-common/std",
+  "polkadot-core-primitives/std",
   "smallvec/write",
   "sp-api/std",
   "sp-block-builder/std",

--- a/runtime/t0rn-parachain/src/xbi_config.rs
+++ b/runtime/t0rn-parachain/src/xbi_config.rs
@@ -350,11 +350,11 @@ pub type AccountIdOf<R> = <R as frame_system::Config>::AccountId;
 /// Logic for the author to get a portion of fees.
 pub struct ToAuthor<R>(PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for ToAuthor<R>
-    where
-        R: pallet_balances::Config + pallet_collator_selection::Config,
-        AccountIdOf<R>: From<polkadot_core_primitives::v2::AccountId>
+where
+    R: pallet_balances::Config + pallet_collator_selection::Config,
+    AccountIdOf<R>: From<polkadot_core_primitives::v2::AccountId>
         + Into<polkadot_core_primitives::v2::AccountId>,
-        <R as frame_system::Config>::RuntimeEvent: From<pallet_balances::Event<R>>,
+    <R as frame_system::Config>::RuntimeEvent: From<pallet_balances::Event<R>>,
 {
     fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
         let author = <pallet_collator_selection::Pallet<R>>::account_id();


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a weight limit parameter to the XCM transfer command, enhancing flexibility and control over asset transfers.
- New Feature: Introduced handling for "system" type and "TRN" target asset in XCM transfers, expanding the range of supported operations.
- Refactor: Updated `XcmTransferParameters` with a new function `createWeightLimit` for creating `WeightLimitV2` objects, paving the way for future enhancements related to weight limits.
- New Feature: Enhanced the `Traders` type in the runtime configuration to include author rewards, improving the reward distribution mechanism.
- Refactor: Introduced convenient type aliases and modified parameter types in the runtime configuration, improving code readability and maintainability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->