### PR TITLE
ci: check for runtime upgrade

### DIFF
--- a/.github/workflows/check-runtime-upgrade.yml
+++ b/.github/workflows/check-runtime-upgrade.yml
@@ -14,16 +14,16 @@ jobs:
 
       - name: Check t0rn
         run: |
-          ./check_runtime.sh t0rn 2>/dev/null
+          ./scripts/check_runtime.sh t0rn 2>/dev/null
 
       - name: Check t1rn
         continue-on-error: true
         timeout-minutes: 1
         run: |
-          ./check_runtime.sh t1rn 2>/dev/null
+          ./scripts/check_runtime.sh t1rn 2>/dev/null
 
       - name: Check t3rn
         continue-on-error: true
         timeout-minutes: 1
         run: |
-          ./check_runtime.sh t3rn 2>/dev/null
+          ./scripts/check_runtime.sh t3rn 2>/dev/null

--- a/.github/workflows/check-runtime-upgrade.yml
+++ b/.github/workflows/check-runtime-upgrade.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: [self-hosted]
-    name: Check if t0rn has latest changes from Github Release
+    name: Check if Parachains have latest changes from Github Release
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-runtime-upgrade.yml
+++ b/.github/workflows/check-runtime-upgrade.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check t0rn
+        timeout-minutes: 30
         run: |
           ./scripts/check_runtime.sh t0rn 2>/dev/null
 

--- a/.github/workflows/check-runtime-upgrade.yml
+++ b/.github/workflows/check-runtime-upgrade.yml
@@ -1,0 +1,29 @@
+name: Runtime Upgrade Check
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  test:
+    runs-on: [self-hosted]
+    name: Check if t0rn has latest changes from Github Release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check t0rn
+        run: |
+          ./check_runtime.sh t0rn 2>/dev/null
+
+      - name: Check t1rn
+        continue-on-error: true
+        timeout-minutes: 1
+        run: |
+          ./check_runtime.sh t1rn 2>/dev/null
+
+      - name: Check t3rn
+        continue-on-error: true
+        timeout-minutes: 1
+        run: |
+          ./check_runtime.sh t3rn 2>/dev/null

--- a/scripts/check_runtime.sh
+++ b/scripts/check_runtime.sh
@@ -1,0 +1,87 @@
+#/usr/env/bin bash
+set -e
+
+# support t1rn t0rn and t3rn
+if [ -z "$1" ]; then
+    echo "Usage: $0 <t0rn|t1rn|t3rn>"
+    exit 1
+fi
+
+DIR=$(git rev-parse --show-toplevel)
+BIN_DIR=$DIR/bin
+PARACHAIN_NAME=$1
+POLKADOT_CLI_VERSION="@polkadot/api-cli@0.55.3"
+
+git fetch --all --tags -f || true > /dev/null
+
+case "$1" in
+    t0rn*)
+        RPC_RELAYCHAIN=wss://rococo-rpc.polkadot.io
+        PARACHAIN_ID=3333
+        RPC_PARACHAIN="wss://rpc.${PARACHAIN_NAME}.io"
+    ;;
+    t1rn*)
+        RPC_RELAYCHAIN=wss://kusama-rpc.polkadot.io
+        PARACHAIN_ID=3334
+        RPC_PARACHAIN="wss://rpc.${PARACHAIN_NAME}.io"
+    ;;
+    t3rn*)
+        RPC_RELAYCHAIN=wss://rpc.polkadot.io
+        PARACHAIN_ID=3333
+        # Outdated RPC endpoint which will be changed after runtime upgrade
+        RPC_PARACHAIN="wss://ws.${PARACHAIN_NAME}.io"
+    ;;
+    *)
+esac
+
+BLOCK_HASH=$(npm exec -- ${POLKADOT_CLI_VERSION} --ws ${RPC_PARACHAIN} rpc.chain.getFinalizedHead | jq -r .getFinalizedHead)
+echo "💈 Script started at ${BLOCK_HASH} block in ${PARACHAIN_NAME} chain"
+
+# Fetch WASM
+case "$1" in
+    t0rn|t1rn)
+        TAG=$(git tag --list --sort=-version:refname "v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*" | head -n 1)
+    ;;
+    t3rn)
+        TAG=$(git tag --list --sort=-version:refname "v[0-9]*.[0-9].[0-9]" | head -n 1)
+    ;;
+    *)
+esac
+WASM_BINARY=$DIR/${PARACHAIN_NAME}-parachain-runtime-${TAG}.compact.compressed.wasm
+
+URL=$(curl -s https://api.github.com/repos/t3rn/t3rn/releases/tags/${TAG} | jq -r '.assets[] | select(.name | endswith ("compact.compressed.wasm")).browser_download_url' | grep ${PARACHAIN_NAME}-parachain-runtime)
+echo "💾 Downloading WASM $URL"
+
+if [ "$URL" == "" ]; then
+    echo "🚨 WASM URL is empty! Releasing in process. Aborting."
+    exit 1
+fi
+curl -s -L -o - "$URL" > $WASM_BINARY 2> /dev/null
+
+# Check if wasm exists
+if [[ ! -f $WASM_BINARY ]]; then
+    echo "🚨 $WASM_BINARY does not exist!"
+    exit 1
+fi
+
+WASM_HASH=$(subwasm info --json $WASM_BINARY | jq -r .blake2_256)
+
+while true; do
+    WASM_HASH_RELAYCHAIN=$(npm exec -- ${POLKADOT_CLI_VERSION} --ws ${RPC_RELAYCHAIN} query.paras.currentCodeHash ${PARACHAIN_ID} | jq -r .currentCodeHash)
+    echo
+    echo "🫧 Check WASM artifact..."
+    echo "🔢 WASM parachain hash: $WASM_HASH"
+    echo "🔢 WASM relaychain hash: $WASM_HASH_RELAYCHAIN"
+    
+    if [[ "$WASM_HASH" != "$WASM_HASH_RELAYCHAIN" ]]; then
+        echo
+        echo "🟡 Parachain $PARACHAIN_NAME is running different version then what is in Github Release."
+        echo "🟡 Waiting for runtime upgrade to finish..."
+    else
+        echo
+        echo "✅ Parachain $PARACHAIN_NAME is running latest version"
+        exit 0
+    fi
+    sleep 10
+done
+

--- a/scripts/check_runtime.sh
+++ b/scripts/check_runtime.sh
@@ -70,8 +70,8 @@ while true; do
     WASM_HASH_RELAYCHAIN=$(npm exec -- ${POLKADOT_CLI_VERSION} --ws ${RPC_RELAYCHAIN} query.paras.currentCodeHash ${PARACHAIN_ID} | jq -r .currentCodeHash)
     echo
     echo "🫧 Check WASM artifact..."
-    echo "🔢 WASM parachain hash: $WASM_HASH"
-    echo "🔢 WASM relaychain hash: $WASM_HASH_RELAYCHAIN"
+    echo "🔢 WASM hash in Github Release: $WASM_HASH"
+    echo "🔢 WASM hash on Relaychain: $WASM_HASH_RELAYCHAIN"
     
     if [[ "$WASM_HASH" != "$WASM_HASH_RELAYCHAIN" ]]; then
         echo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a GitHub Actions workflow "Runtime Upgrade Check" that triggers on pull requests and merge groups. This feature ensures the runtimes "t0rn," "t1rn," and "t3rn" are always updated with the latest changes from the GitHub Release.
- New Feature: Added a bash script "check_runtime.sh" to monitor runtime upgrades in a Polkadot parachain. The script supports three different parachains, fetches the latest block hash, downloads the corresponding WASM binary, and checks if a runtime upgrade is in progress.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->