### PR TITLE
feat(grandpa-ranger): get justification from signedBlock if there are more than 500 headers

### DIFF
--- a/client/packages/grandpa-ranger/config/polkadot.ts
+++ b/client/packages/grandpa-ranger/config/polkadot.ts
@@ -1,24 +1,25 @@
 export default {
- circuit: {
-  rpc1: {
-   ws: "wss://rpc.t0rn.io",
-   http: "https://rpc.t0rn.io"
+  circuit: {
+    rpc1: {
+      ws: 'wss://rpc.t0rn.io',
+      http: 'https://rpc.t0rn.io',
+    },
+    rpc2: {
+      ws: 'wss://rpc.t0rn.io',
+      http: 'https://rpc.t0rn.io',
+    },
   },
-  rpc2: {
-   ws: "wss://rpc.t0rn.io",
-   http: "https://rpc.t0rn.io"
+  target: {
+    // we dont need to specify the http endpoint for the target
+    rpc1: {
+      ws: 'wss://rpc.polkadot.io',
+    },
+    rpc2: {
+      ws: 'wss://polkadot-rpc.dwellir.com',
+    },
   },
- },
- target: { // we dont need to specify the http endpoint for the target
-  rpc1: {
-   ws: "wss://rpc.polkadot.io",
-  },
-  rpc2: {
-   ws: "wss://polkadot-rpc.dwellir.com"
-  },
- },
- rangeInterval: 0, // time between range submissions in seconds
- targetGatewayId: "pdot",
- batches_max: 1,
- batching: true,
+  rangeInterval: 0, // time between range submissions in seconds
+  targetGatewayId: 'pdot',
+  batches_max: 1,
+  batching: false,
 }

--- a/client/packages/grandpa-ranger/pnpm-lock.yaml
+++ b/client/packages/grandpa-ranger/pnpm-lock.yaml
@@ -856,7 +856,7 @@ packages:
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       get-intrinsic: 1.2.1
     dev: false
 
@@ -1105,18 +1105,13 @@ packages:
     dev: true
     optional: true
 
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: false
-
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       has: 1.0.3
       has-proto: 1.0.1
       has-symbols: 1.0.3
@@ -1167,7 +1162,7 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
     dev: false
 
   /hash.js@1.1.7:

--- a/client/packages/grandpa-ranger/src/collect.ts
+++ b/client/packages/grandpa-ranger/src/collect.ts
@@ -28,7 +28,7 @@ export const generateRange = async (
 ): Promise<any[]> => {
   return new Promise(async (resolve, reject) => {
     try {
-      const circuitHeight = await currentGatewayHeight(
+      let circuitHeight = await currentGatewayHeight(
         circuitConnection,
         config.targetGatewayId
       )
@@ -43,6 +43,12 @@ export const generateRange = async (
       )
 
       if (targetHeight > circuitHeight) {
+        // @t3rn/sdk": "^0.2.5":
+        // The submitted GrandpaJustification is not valid"
+        // if (targetHeight - circuitHeight > 100) {
+        //   circuitHeight = targetHeight - 100
+        // }
+
         let batches = await generateBatchProof(
           circuitConnection.client,
           targetConnection.client,
@@ -91,16 +97,26 @@ const generateBatchProof = async (
       // Only one block in epoch missing
       signed_header = await getHeader(targetClient, from)
       from = parseInt(signed_header.number) + 1
-    } else if (headers.length > 500) {
-      signed_header = await getHeader(targetClient, from)
+    }
+    // @t3rn/sdk": "^0.2.5":
+    // The submitted GrandpaJustification is not valid"
+    // else if (headers.length > 10) {
+    //   const blockNumber = to - 10
+    //   const finalityProof = await targetClient.rpc.grandpa.proveFinality(
+    //     blockNumber
+    //   )
+    //   const decodedFinalityProof =
+    //     Encodings.Substrate.Decoders.finalityProofDecode(finalityProof)
 
-      const blockHash = await targetClient.rpc.chain.getBlockHash(from)
-      const signedBlock = await targetClient.rpc.chain.getBlock(blockHash)
-      justification = signedBlock.justifications.registry.createdAtHash
+    //   justification = decodedFinalityProof.justification
+    //   headers = decodedFinalityProof.headers
 
-      headers = [signed_header]
-      from = parseInt(signed_header.number) + 1
-    } else {
+    //   signed_header = headers.pop()
+    //   headers = [await getHeader(targetClient, blockNumber), ...headers]
+    //   from = parseInt(signed_header.number.toJSON()) + 1
+    // }
+    //
+    else {
       signed_header = headers.pop()
       headers = [await getHeader(targetClient, from), ...headers]
       from = parseInt(signed_header.number.toJSON()) + 1

--- a/client/packages/grandpa-ranger/src/collect.ts
+++ b/client/packages/grandpa-ranger/src/collect.ts
@@ -91,6 +91,15 @@ const generateBatchProof = async (
       // Only one block in epoch missing
       signed_header = await getHeader(targetClient, from)
       from = parseInt(signed_header.number) + 1
+    } else if (headers.length > 500) {
+      signed_header = await getHeader(targetClient, from)
+
+      const blockHash = await targetClient.rpc.chain.getBlockHash(from)
+      const signedBlock = await targetClient.rpc.chain.getBlock(blockHash)
+      justification = signedBlock.justifications.registry.createdAtHash
+
+      headers = [signed_header]
+      from = parseInt(signed_header.number) + 1
     } else {
       signed_header = headers.pop()
       headers = [await getHeader(targetClient, from), ...headers]


### PR DESCRIPTION
In situations where there is a significant gap between the circuit and the target, a set of headers from proveFinality is too big as well, and we're not able to send them to the circuit. 

There's no way to modify a result that proveFinality returns, so my current idea is to get justification from the signed block, but I encountered a new problem:

`{\"targetHash\":\"BlockHash\",\"targetNumber\":\"BlockNumber\",\"precommits\":\"Vec<GrandpaSignedPrecommit>\"}:: decodeU8a: failed at 0x2489ff2ce8147884a3e22785d1ba89fd… on targetHash (index 0/3): H256:: Expected input with 32 bytes (256 bits), found 24 bytes"}`