### PR TITLE
fix: loosen fail checks in CLI SDK signAndSafeSafe 

### DIFF
--- a/client/packages/cli/src/commands/sfxABI/index.ts
+++ b/client/packages/cli/src/commands/sfxABI/index.ts
@@ -74,7 +74,7 @@ export const handleAddSfxAbiCommand = async (
       tx = targetApi.tx.xdns.enrollNewAbiToSelectedGateway(
         args.target,
         args.sfxId,
-        args.sfxAbi,
+        JSON.parse(args.sfxAbi),
         args.palletId,
       )
     } else {
@@ -86,8 +86,10 @@ export const handleAddSfxAbiCommand = async (
         )
       } else {
         console.log(
-          `SFX ABI descriptor is not provided, but SFX ID is known - using the built-in ABI descriptor ${isKnownABI}`,
+          `SFX ABI descriptor is not provided, but SFX ID is known - using the built-in ABI descriptor:`,
         )
+        console.log(JSON.stringify(isKnownABI, null, 2))
+
         tx = targetApi.tx.xdns.enrollNewAbiToSelectedGateway(
           args.target,
           args.sfxId,
@@ -121,8 +123,7 @@ export const handleAddSfxAbiCommand = async (
         } else if (
           status.isInBlock ||
           status.isFinalized ||
-          status.isReady ||
-          status.asInBlock
+          status.isReady
         ) {
           // check if we have an error event in a custom module
           events.forEach((eventEntry) => {

--- a/client/packages/sdk/package.json
+++ b/client/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3rn/sdk",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "t3rn's client side SDK",
   "files": [
     "dist/**/*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the `handleAddSfxAbiCommand` function in the CLI SDK to accept a parsed JSON object for the `args.sfxAbi` parameter, improving data handling.
- Improvement: Added console logs to display the built-in ABI descriptor when `args.sfxAbi` is not provided but `args.sfxId` is known, enhancing user feedback.
- Refactor: Updated the condition for checking transaction status, optimizing code logic.
- Bug Fix: Modified error event handling in custom modules to check for error events only when events are present, preventing potential errors.
- Chore: Imported the `cryptoWaitReady` function from the `@polkadot/util-crypto` package, enhancing cryptographic operations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->