### PR TITLE
chore: update t0rn session parameters: time to 1h, kick threshold to 6h, no disabled validators from session

### DIFF
--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -670,4 +670,12 @@ mod tests {
     fn supply_is_right() {
         assert_eq!(SUPPLY, 100_000_000_000_000_000_000);
     }
+
+    #[test]
+    fn should_match_correct_aura_keys_for_t0rn() {
+        assert_eq!(
+            get_aura_id_from_adrs("5FKjxoi5Yfjwa1aXesFWRXMpvs4vJMXFeG2ydFPyNwUn4qiW").encode(),
+            hex!("902c7861618ce57396b7052b9ca769f7ea38cdf7d6287783e11e7ac740423942").to_vec()
+        );
+    }
 }

--- a/runtime/t0rn-parachain/src/parachain_config.rs
+++ b/runtime/t0rn-parachain/src/parachain_config.rs
@@ -86,7 +86,7 @@ impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
     pub const Period: u32 = 1 * HOURS;
-    pub const KickThreshold: u32 = Period * 6;
+    pub const KickThreshold: u32 = 6 * HOURS;
     pub const Offset: u32 = 0;
     pub const MaxAuthorities: u32 = 100_000;
 }

--- a/runtime/t0rn-parachain/src/parachain_config.rs
+++ b/runtime/t0rn-parachain/src/parachain_config.rs
@@ -85,7 +85,8 @@ impl pallet_authorship::Config for Runtime {
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
-    pub const Period: u32 = 6 * HOURS;
+    pub const Period: u32 = 1 * HOURS;
+    pub const KickThreshold: u32 = Period * 6;
     pub const Offset: u32 = 0;
     pub const MaxAuthorities: u32 = 100_000;
 }
@@ -107,15 +108,14 @@ impl pallet_session::Config for Runtime {
 impl pallet_aura::Config for Runtime {
     type AllowMultipleBlocksPerSlot = ConstBool<false>;
     type AuthorityId = AuraId;
-    type DisabledValidators = Session;
+    type DisabledValidators = ();
     type MaxAuthorities = MaxAuthorities;
 }
 
 parameter_types! {
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub const MaxCandidates: u32 = 1000;
-    // pub const MinCandidates: u32 = 2;
-    pub const MinCandidates: u32 = 5;
+    pub const MinCandidates: u32 = 2;
     pub const SessionLength: BlockNumber = 6 * HOURS;
     pub const MaxInvulnerables: u32 = 100;
     pub const ExecutiveBody: BodyId = BodyId::Executive;
@@ -127,7 +127,7 @@ pub type CollatorSelectionUpdateOrigin = EnsureRoot<AccountId>;
 impl pallet_collator_selection::Config for Runtime {
     type Currency = Balances;
     // should be a multiple of session or things will get inconsistent
-    type KickThreshold = Period;
+    type KickThreshold = KickThreshold;
     type MaxCandidates = MaxCandidates;
     type MaxInvulnerables = MaxInvulnerables;
     type MinEligibleCollators = MinCandidates;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Test: Added a new test case `should_match_correct_aura_keys_for_t0rn` to ensure the accuracy of the function `get_aura_id_from_adrs`.
- Refactor: Updated session parameters in `parachain_config.rs`. The `Period` is now set to 1 hour, and a new constant `KickThreshold` has been introduced, which is 6 times the `Period`.
- Refactor: Changed the `DisabledValidators` type from `Session` to `()`, indicating no disabled validators from the session.
- Refactor: Adjusted the `MinCandidates` constant to 2, modifying the minimum number of candidates required.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->