### PR TITLE
chore: add extrinsic for linking token to gateways

### DIFF
--- a/pallets/circuit/src/lib.rs
+++ b/pallets/circuit/src/lib.rs
@@ -1117,6 +1117,10 @@ pub mod pallet {
         ArithmeticErrorOverflow,
         ArithmeticErrorUnderflow,
         ArithmeticErrorDivisionByZero,
+        ABIOnSelectedTargetNotFoundForSubmittedSFX,
+        ForNowOnlySingleRewardAssetSupportedForMultiSFX,
+        TargetAppearsNotToBeActiveAndDoesntHaveFinalizedHeight,
+        SideEffectsValidationFailedAgainstABI,
     }
 }
 
@@ -1258,7 +1262,7 @@ impl<T: Config> Pallet<T> {
         side_effects: &[SideEffect<T::AccountId, BalanceOf<T>>],
         local_ctx: &mut LocalXtxCtx<T, BalanceOf<T>>,
         preferred_security_lvl: &SecurityLvl,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), Error<T>> {
         let mut full_side_effects: Vec<
             FullSideEffect<
                 T::AccountId,
@@ -1266,23 +1270,6 @@ impl<T: Config> Pallet<T> {
                 BalanceOf<T>,
             >,
         > = vec![];
-
-        pub fn determine_security_lvl(
-            gateway_type: GatewayType,
-            sfx_len: usize,
-            preferred_security_lvl: &SecurityLvl,
-        ) -> SecurityLvl {
-            if sfx_len < 2 || *preferred_security_lvl == SecurityLvl::Optimistic {
-                return SecurityLvl::Optimistic
-            }
-            if gateway_type == GatewayType::ProgrammableInternal(0)
-                || gateway_type == GatewayType::OnCircuit(0)
-            {
-                SecurityLvl::Escrow
-            } else {
-                SecurityLvl::Optimistic
-            }
-        }
 
         // ToDo: Handle empty SFX case as error instead - must satisfy requirements of LocalTrigger
         if side_effects.is_empty() {
@@ -1302,29 +1289,38 @@ impl<T: Config> Pallet<T> {
         );
 
         for (index, sfx) in side_effects.iter().enumerate() {
-            let gateway_type = <T as Config>::Xdns::get_gateway_type_unsafe(&sfx.target);
+            let gateway_max_security_lvl =
+                <T as Config>::Xdns::get_gateway_max_security_lvl(&sfx.target);
+
             let security_lvl =
-                determine_security_lvl(gateway_type, side_effects.len(), preferred_security_lvl);
+                if side_effects.len() < 2 || *preferred_security_lvl == SecurityLvl::Optimistic {
+                    SecurityLvl::Optimistic
+                } else {
+                    gateway_max_security_lvl
+                };
 
             let sfx_abi: SFXAbi = match <T as Config>::Xdns::get_sfx_abi(&sfx.target, sfx.action) {
                 Some(sfx_abi) => sfx_abi,
-                None => return Err("SFX not allowed/registered on requested target gateway"),
+                None => return Err(Error::<T>::ABIOnSelectedTargetNotFoundForSubmittedSFX),
             };
             // todo: store the codec info in gateway's records and use it here
-            sfx.validate(sfx_abi, &Codec::Scale)?;
+            sfx.validate(sfx_abi, &Codec::Scale).map_err(|e| {
+                log::error!("sfx.validate against ABI failed: {:?}", e);
+                Error::<T>::SideEffectsValidationFailedAgainstABI
+            })?;
 
             if let Some(next) = side_effects.get(index + 1) {
                 if sfx.reward_asset_id != next.reward_asset_id {
-                    return Err(
-                        "SFX validate failed - enforce all SFX to have the same reward asset field",
-                    )
+                    return Err(Error::<T>::ForNowOnlySingleRewardAssetSupportedForMultiSFX)
                 }
             }
 
-            let submission_target_height = match T::Portal::get_finalized_height(sfx.target)? {
+            let submission_target_height = match T::Portal::get_finalized_height(sfx.target)
+                .map_err(|_| Error::<T>::TargetAppearsNotToBeActiveAndDoesntHaveFinalizedHeight)?
+            {
                 HeightResult::Height(block_numer) => block_numer,
                 HeightResult::NotActive =>
-                    return Err("SFX validate failed - get_latest_finalized_height returned None"),
+                    return Err(Error::<T>::TargetAppearsNotToBeActiveAndDoesntHaveFinalizedHeight),
             };
 
             full_side_effects.push(FullSideEffect {

--- a/pallets/circuit/src/machine/mod.rs
+++ b/pallets/circuit/src/machine/mod.rs
@@ -99,11 +99,7 @@ impl<T: Config> Machine<T> {
             full_side_effects: vec![],
         };
 
-        pallet::Pallet::<T>::validate(side_effects, &mut local_xtx_ctx, preferred_security_lvl)
-            .map_err(|e| {
-                log::error!("Self::validate hit an error -- {e:?}");
-                Error::<T>::SideEffectsValidationFailed
-            })?;
+        pallet::Pallet::<T>::validate(side_effects, &mut local_xtx_ctx, preferred_security_lvl)?;
 
         Ok(local_xtx_ctx)
     }

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -232,9 +232,17 @@ pub mod pallet {
                     });
 
                 if latest_vendor_overview.reported_at + estimated_epoch_length < n {
-                    let latest_heartbeat =
+                    let mut latest_heartbeat =
                         T::Portal::get_latest_heartbeat_by_vendor(verifier.clone());
                     let epoch = latest_heartbeat.last_finalized_height;
+                    if verifier == GatewayVendor::XBI {
+                        let current_block_here = frame_system::Pallet::<T>::block_number();
+                        latest_heartbeat.last_finalized_height = current_block_here;
+                        latest_heartbeat.last_rational_height = current_block_here;
+                        latest_heartbeat.last_fast_height = current_block_here;
+                        latest_heartbeat.last_heartbeat = current_block_here;
+                        latest_heartbeat.ever_initialized = true;
+                    }
                     let weight = Self::process_single_verifier_overview(
                         n,
                         verifier,

--- a/pallets/xdns/src/lib.rs
+++ b/pallets/xdns/src/lib.rs
@@ -1323,20 +1323,13 @@ pub mod pallet {
         }
 
         // todo: this must be removed and functionality replaced
-        fn get_gateway_type_unsafe(chain_id: &ChainId) -> GatewayType {
+        fn get_gateway_max_security_lvl(chain_id: &ChainId) -> SecurityLvl {
             if chain_id == &[3u8; 4] {
-                return GatewayType::OnCircuit(0)
+                return SecurityLvl::Escrow
             }
-            match <Gateways<T>>::get(chain_id) {
-                Some(rec) => match rec.escrow_account {
-                    Some(_) => GatewayType::ProgrammableExternal(0),
-                    None => GatewayType::TxOnly(0),
-                },
-                None => {
-                    log::error!("Gateway not found for chain_id: {:?}", chain_id);
-                    GatewayType::TxOnly(0)
-                },
-            }
+
+            Self::get_escrow_account(chain_id)
+                .map_or(SecurityLvl::Escrow, |_| SecurityLvl::Optimistic)
         }
 
         /// returns the gateway vendor of a gateway if its available

--- a/pallets/xdns/src/tests.rs
+++ b/pallets/xdns/src/tests.rs
@@ -1166,11 +1166,11 @@ fn on_initialize_should_update_update_verifiers_overview_no_more_often_than_each
                 FinalityVerifierActivity {
                     verifier: XBI,
                     reported_at: 74,
-                    justified_height: 0,
-                    finalized_height: 0,
-                    updated_height: 0,
+                    justified_height: 74,
+                    finalized_height: 74,
+                    updated_height: 74,
                     epoch: 0,
-                    is_active: false,
+                    is_active: true,
                 },
             ];
 

--- a/primitives/src/xdns.rs
+++ b/primitives/src/xdns.rs
@@ -329,7 +329,7 @@ pub trait Xdns<T: frame_system::Config, Balance> {
 
     fn allowed_side_effects(gateway_id: &ChainId) -> Vec<([u8; 4], Option<u8>)>;
 
-    fn get_gateway_type_unsafe(chain_id: &ChainId) -> GatewayType;
+    fn get_gateway_max_security_lvl(chain_id: &ChainId) -> SecurityLvl;
 
     fn get_verification_vendor(chain_id: &ChainId) -> Result<GatewayVendor, DispatchError>;
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a `link_token` function to the `pallet` module, enabling root users to link a token to a gateway. This feature enhances the flexibility and control of token management for administrators.
- Test: Introduced a comprehensive test case `should_allow_to_link_token_via_extrinsic_on_sudo_permission`, ensuring the robustness of the new feature by covering various scenarios and edge cases.
- Improvement: Enhanced error handling with additional logging when a gateway is not found for a given chain ID, improving system transparency and troubleshooting efficiency.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->