### PR TITLE
fix: speed up CI with actions that can run on smaller workers

### DIFF
--- a/.github/workflows/subalfred.yml
+++ b/.github/workflows/subalfred.yml
@@ -42,7 +42,7 @@ jobs:
 
   check:
     name: Subalfred Check Features
-    runs-on: [self-hosted, rust]
+    runs-on: [self-hosted]
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
 

--- a/.github/workflows/test-cargo-release.yml
+++ b/.github/workflows/test-cargo-release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   cargo-release-dry-run:
     name: Cargo Release Dry Run
-    runs-on: [self-hosted, rust]
+    runs-on: [self-hosted]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -48,7 +48,7 @@ jobs:
 
   test:
     name: Generate E2E Tests & Test
-    runs-on: [self-hosted, rust]
+    runs-on: [self-hosted]
     needs: [changes]
     if: needs.changes.outputs.src == 'true'
     steps:

--- a/.github/workflows/update-dev-docs.yml
+++ b/.github/workflows/update-dev-docs.yml
@@ -11,7 +11,7 @@ on:
     
 jobs:
   rust:
-    runs-on: [self-hosted, rust]
+    runs-on: [self-hosted]
     if: ${{ (contains(github.event.head_commit.message, 'build(release):')) }}
 
     steps:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated GitHub Actions workflows to run on any self-hosted worker, not just those labeled as `rust`. This change enhances the efficiency of our CI process by allowing jobs to execute on a broader range of workers, potentially reducing wait times for job execution.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->