### PR TITLE
fix: correct ABI descriptor for RLP-encoded "tass" & refresh standard ABI list at XDNS::reboot

### DIFF
--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -554,6 +554,55 @@ mod tests {
     }
 
     #[test]
+    fn optimistic_order_single_rlp_encoded_sfx_vacuum_delivers_to_circuit() {
+        let mut ext = prepare_ext_builder_playground();
+        ext.execute_with(|| {
+            let executor = AccountId32::from([1u8; 32]);
+            let requester = AccountId32::from([2u8; 32]);
+            let requester_on_dest = AccountId32::from([3u8; 32]);
+
+            mint_required_assets_for_optimistic_actors(
+                requester.clone(),
+                executor,
+                200u128,
+                50u128,
+                ASSET_DOT,
+            );
+
+            activate_all_light_clients();
+
+            assert_ok!(Vacuum::single_order(
+                RuntimeOrigin::signed(requester.clone()),
+                ETHEREUM_TARGET,
+                ASSET_DOT,
+                100u128,
+                ASSET_DOT,
+                200u128,
+                50u128,
+                requester_on_dest.clone(),
+                SpeedMode::Fast
+            ));
+
+            let xtx_id = expect_last_event_to_emit_xtx_id();
+
+            assert_eq!(
+                xtx_id,
+                Hash::from(hex!(
+                    "0162cabd6f37c15015e94be4174f7ad95fa0d6f094da6aea5525ce11731308a1"
+                ))
+            );
+
+            // Expect balance of requester to be reduced by max_reward
+            assert_eq!(
+                Assets::balance(ASSET_DOT, &requester),
+                EXISTENTIAL_DEPOSIT as Balance
+            );
+
+            assert!(false);
+        });
+    }
+
+    #[test]
     fn optimistic_order_single_sfx_vacuum_delivers_to_circuit() {
         let mut ext = prepare_ext_builder_playground();
         ext.execute_with(|| {

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -598,7 +598,6 @@ mod tests {
                 EXISTENTIAL_DEPOSIT as Balance
             );
 
-            assert!(false);
         });
     }
 

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -597,7 +597,6 @@ mod tests {
                 Assets::balance(ASSET_DOT, &requester),
                 EXISTENTIAL_DEPOSIT as Balance
             );
-
         });
     }
 

--- a/pallets/xdns/src/tests.rs
+++ b/pallets/xdns/src/tests.rs
@@ -18,17 +18,14 @@
 //! Runtimes for pallet-xdns.
 
 use super::*;
-use circuit_mock_runtime::{
-    ExtBuilder, Portal,
-    RuntimeOrigin as Origin, *,
-};
+use circuit_mock_runtime::{ExtBuilder, Portal, RuntimeOrigin as Origin, *};
 use codec::Decode;
 
 use frame_support::pallet_prelude::Weight;
 
 use frame_support::{assert_err, assert_noop, assert_ok, traits::OnInitialize};
 use sp_core::{crypto::AccountId32, H256};
-use sp_runtime::{DispatchError};
+use sp_runtime::DispatchError;
 use t3rn_primitives::{
     circuit::SecurityLvl::{Escrow, Optimistic},
     clock::OnHookQueues,

--- a/types/abi/src/standard.rs
+++ b/types/abi/src/standard.rs
@@ -72,7 +72,7 @@ pub fn get_sfx_transfer_asset_abi() -> SFXAbi {
         },
         egress_abi_descriptors: PerCodecAbiDescriptors {
             // assume all indexed in topics ("+")
-            for_rlp: b"Transfer:Log(from+:Account20,to+:Account20,amount:Value256)".to_vec(),
+            for_rlp: b"Assets:Struct(asset_id:Value32,to:Account32,amount:Value128)".to_vec(),
             for_scale: b"Assets:Struct(asset_id:Value32,to:Account32,amount:Value128)".to_vec(),
         },
         maybe_prefix_memo: None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new test case `optimistic_order_single_rlp_encoded_sfx_vacuum_delivers_to_circuit` to validate the behavior of the `single_order` function in the `Vacuum` module.
- Refactor: Updated the `GenesisConfig` implementation in the `pallet` module to refresh the list of standard ABI based on the latest implementation. Improved error handling for the `insert` operation and updated the `SFXABIRegistry` for linked gateways.
- Test: Enhanced existing tests and added new ones to verify the behavior of rebooting a gateway and refreshing entries of standard ABI to other gateways.
- Chore: Modified the ABI descriptor for RLP-encoded "tass" in the `get_sfx_transfer_asset_abi` function, changing it from a transfer log to an asset struct.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->