### PR TITLE
test: extend mock single vacuum order to test all registered gateways

### DIFF
--- a/client/packages/cli/src/commands/sfxABI/index.ts
+++ b/client/packages/cli/src/commands/sfxABI/index.ts
@@ -16,6 +16,7 @@ export const handleAddSfxAbiCommand = async (
     AddSfxAbiSchema,
     {
       ..._args,
+      palletId: _args?.palletId ? parseInt(_args?.palletId) : undefined,
     },
     {
       configFileName: 'Add SFX ABI to XDNS arguments',


### PR DESCRIPTION
Test warm up asset transfers in Roc to all reqistered gateways via Vacuum::singleOrder. 

CLI can be started with `pnpm cli mockWriter --as-sequential-tx` and with 1min breaks sends test orders for asset = 1 (rococo) out of Alice account. 
<img width="595" alt="Screenshot 2023-11-03 at 07 30 54" src="https://github.com/t3rn/t3rn/assets/6909553/cf9499f0-7c11-40bf-9bbd-44ba22191e23">


 