### PR TITLE
chore: update sepolia LC version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "pallet-sepolia-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.9#f01e828293d697a94ba39d77587f2af38c07f212"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.10#e3740f928531fe06aafd2083de8cd5618cabc08e"
 dependencies = [
  "eth_trie",
  "ethereum-types",

--- a/runtime/common-pallets/Cargo.toml
+++ b/runtime/common-pallets/Cargo.toml
@@ -106,7 +106,7 @@ pallet-xdns                      = { path = "../../pallets/xdns", default-featur
 pallet-xdns-rpc-runtime-api      = { path = "../../pallets/xdns/rpc/runtime-api", default-features = false }
 pallet-vacuum                    = { path = "../../pallets/circuit/vacuum", package = "pallet-circuit-vacuum", default-features = false }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.4", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.9", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.10", default-features = false }
 pallet-rewards                   = { path = "../../pallets/rewards", default-features = false }
 
 # Smart contracts VMs

--- a/runtime/mini-mock/Cargo.toml
+++ b/runtime/mini-mock/Cargo.toml
@@ -60,6 +60,6 @@ pallet-portal                    = { path = "../../pallets/portal" }
 pallet-rewards                   = { path = "../../pallets/rewards" }
 pallet-xdns                      = { path = "../../pallets/xdns" }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.4", features = ["testing"]  }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.9", features = ["testing"]  }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.10", features = ["testing"]  }
 
 circuit-runtime-types = { path = "../../runtime/common-types" }

--- a/runtime/standalone/Cargo.toml
+++ b/runtime/standalone/Cargo.toml
@@ -34,7 +34,7 @@ pallet-clock                              = { path = "../../pallets/clock", defa
 pallet-contracts-registry                 = { path = "../../pallets/contracts-registry", default-features = false }
 #pallet-contracts-registry-rpc-runtime-api = { path = "../../pallets/contracts-registry/rpc/runtime-api", default-features = false }
 pallet-eth2-finality-verifier             = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.4", default-features = false }
-pallet-sepolia-finality-verifier          = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.9", default-features = false }
+pallet-sepolia-finality-verifier          = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.10", default-features = false }
 pallet-grandpa-finality-verifier          = { path = "../../finality-verifiers/grandpa", default-features = false }
 pallet-portal                             = { path = "../../pallets/portal", default-features = false }
 pallet-portal-rpc-runtime-api             = { path = "../../pallets/portal/rpc/runtime-api", default-features = false }

--- a/runtime/t0rn-parachain/Cargo.toml
+++ b/runtime/t0rn-parachain/Cargo.toml
@@ -100,7 +100,7 @@ pallet-attesters                 = { path = "../../pallets/attesters", default-f
 pallet-vacuum                    = { path = "../../pallets/circuit/vacuum", package = "pallet-circuit-vacuum", default-features = false }
 pallet-rewards                   = { path = "../../pallets/rewards", default-features = false }
 pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.4", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.9", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.10", default-features = false }
 pallet-account-manager           = { path = "../../pallets/account-manager", default-features = false }
 pallet-circuit                   = { path = "../../pallets/circuit", package = "pallet-circuit", default-features = false }
 pallet-clock                     = { path = "../../pallets/clock", default-features = false }


### PR DESCRIPTION
* `v1.1.10` fixes linkage of execution ranges of Unsigned -> Signed epochs

