### PR TITLE
build: compile t1rn with runtime benchmarks flag

### DIFF
--- a/runtime/t1rn-parachain/src/accounts_config.rs
+++ b/runtime/t1rn-parachain/src/accounts_config.rs
@@ -45,6 +45,8 @@ parameter_types! {
 }
 
 #[cfg(feature = "runtime-benchmarks")]
+use parachains_common::AssetIdForTrustBackedAssets;
+#[cfg(feature = "runtime-benchmarks")]
 pub struct AssetRegistryBenchmarkHelper;
 #[cfg(feature = "runtime-benchmarks")]
 impl pallet_asset_registry::BenchmarkHelper<AssetIdForTrustBackedAssets>

--- a/runtime/t1rn-parachain/src/lib.rs
+++ b/runtime/t1rn-parachain/src/lib.rs
@@ -162,6 +162,8 @@ impl pallet_assets::Config for Runtime {
     type AssetId = circuit_runtime_types::AssetId;
     type AssetIdParameter = circuit_runtime_types::AssetId;
     type Balance = Balance;
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
     type CallbackHandle = ();
     type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;
     type Currency = Balances;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced benchmarking support for the `pallet_assets::Config` implementation. This feature is only enabled when the `runtime-benchmarks` flag is active, providing developers with performance metrics for asset-related operations.
- Refactor: Added new import statements for `AssetIdForTrustBackedAssets` and `AssetRegistryBenchmarkHelper`, improving code modularity and readability. These changes are part of our ongoing efforts to enhance the maintainability of our codebase.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->