### PR TITLE
fix: set correct ParaId = 3334 to XBI config of t1rn

### DIFF
--- a/runtime/t1rn-parachain/src/circuit_config.rs
+++ b/runtime/t1rn-parachain/src/circuit_config.rs
@@ -125,7 +125,7 @@ impl pallet_xdns::Config for Runtime {
     type Portal = Portal;
     type RuntimeEvent = RuntimeEvent;
     type SelfGatewayId = SelfGatewayId;
-    type SelfTokenId = ConstU32<3333>;
+    type SelfTokenId = ConstU32<3334>;
     type Time = Timestamp;
     type TreasuryAccounts = Runtime;
     type WeightInfo = pallet_xdns::weights::SubstrateWeight<Runtime>;
@@ -276,7 +276,7 @@ impl pallet_circuit::Config for Runtime {
     type SFXBiddingPeriod = ConstU32<3u32>;
     type SelfAccountId = crate::accounts_config::EscrowAccount;
     type SelfGatewayId = SelfGatewayId;
-    type SelfParaId = ConstU32<3333u32>;
+    type SelfParaId = ConstU32<3334u32>;
     type SignalQueueDepth = ConstU32<5u32>;
     type TreasuryAccounts = Runtime;
     type WeightInfo = ();

--- a/runtime/t1rn-parachain/src/xbi_config.rs
+++ b/runtime/t1rn-parachain/src/xbi_config.rs
@@ -58,7 +58,7 @@ parameter_types! {
 //     type ExpectedBlockTimeMs = ConstU32<6000>;
 //     type FeeConversion = IdentityFee<Balance>;
 //     type NotificationWeight = NotificationWeight;
-//     type ParachainId = ConstU32<3333>;
+//     type ParachainId = ConstU32<3334>;
 //     type ReserveBalanceCustodian = ReserveBalanceCustodian;
 //     type RuntimeCall = RuntimeCall;
 //     type RuntimeEvent = RuntimeEvent;
@@ -103,7 +103,7 @@ parameter_types! {
     pub const SelfLocation: MultiLocation = MultiLocation::here();
 
     pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
-    pub Ancestry: MultiLocation = Parachain(3333).into();
+    pub Ancestry: MultiLocation = Parachain(3334).into();
     pub UniversalLocation: InteriorMultiLocation = (
         GlobalConsensus(NetworkId::Rococo),
         Parachain(ParachainInfo::parachain_id().into()),
@@ -197,7 +197,7 @@ pub type Barrier = TrailingSetTopicAsId<(
 parameter_types! {
     pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
     pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
-    pub SelfParaId: ParaId = ParaId::from(3333);
+    pub SelfParaId: ParaId = ParaId::from(3334);
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the Parachain ID configuration for the `t1rn` module, `pallet_xdns::Config`, and `pallet_circuit::Config` implementations. The values of `SelfTokenId`, `ParachainId`, `Ancestry`, and `SelfParaId` have been changed from `3333` to `3334`. This change may affect interactions with the associated parachain.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->