### PR TITLE
build: reset t0rn to genesis runtime version

### DIFF
--- a/runtime/t0rn-parachain/src/lib.rs
+++ b/runtime/t0rn-parachain/src/lib.rs
@@ -78,11 +78,11 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // https://docs.rs/sp-version/latest/sp_version/struct.RuntimeVersion.html
     spec_name: create_runtime_str!("t0rn"),
     impl_name: create_runtime_str!("Circuit Collator"),
-    authoring_version: 2,
-    spec_version: 2,
-    impl_version: 2,
+    authoring_version: 0,
+    spec_version: 0,
+    impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 0,
     // https://github.com/paritytech/cumulus/issues/998
     // https://github.com/paritytech/substrate/pull/9732
     // https://github.com/paritytech/substrate/pull/10073


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the `RuntimeVersion` struct in the `t0rn-parachain` runtime. The `authoring_version`, `spec_version`, `impl_version`, and `transaction_version` have all been reset to 0. This change is part of a larger versioning overhaul and may affect the behavior or external interface of the code. Please ensure your systems are compatible with this new versioning scheme.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->