### PR TITLE
build: reset t0rn-parachain spec versions

### DIFF
--- a/runtime/t0rn-parachain/src/lib.rs
+++ b/runtime/t0rn-parachain/src/lib.rs
@@ -78,11 +78,11 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // https://docs.rs/sp-version/latest/sp_version/struct.RuntimeVersion.html
     spec_name: create_runtime_str!("t0rn"),
     impl_name: create_runtime_str!("Circuit Collator"),
-    authoring_version: 1,
-    spec_version: 1,
-    impl_version: 1,
+    authoring_version: 0,
+    spec_version: 0,
+    impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 1,
+    transaction_version: 0,
     // https://github.com/paritytech/cumulus/issues/998
     // https://github.com/paritytech/substrate/pull/9732
     // https://github.com/paritytech/substrate/pull/10073


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `RuntimeVersion` struct in the `t0rn-parachain` runtime. The `authoring_version`, `spec_version`, and `impl_version` have all been reset to 0. This change is part of a broader effort to streamline version management within the parachain codebase. Please note that this may affect compatibility with previous versions, so ensure to update any dependencies accordingly.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->