### PR TITLE
fix: correct feature flags in node

### DIFF
--- a/node/parachain/Cargo.toml
+++ b/node/parachain/Cargo.toml
@@ -112,9 +112,7 @@ xcm                                     = { workspace = true }
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 
 [features]
-default = [
-    "t0rn"
-]
+default = [ ]
 try-runtime = [
     "t0rn-parachain-runtime?/try-runtime",
     "t1rn-parachain-runtime?/try-runtime",

--- a/node/parachain/Makefile
+++ b/node/parachain/Makefile
@@ -2,4 +2,4 @@
 	cargo build
 
  run:
-	cargo run -- --dev
+	cargo run -- --dev --features=rococo-native

--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -19,7 +19,7 @@ use t3rn_parachain_runtime::{
     SudoConfig, SystemConfig, TRN, WASM_BINARY,
 };
 
-#[cfg(feature = "t0rn")]
+#[cfg(any(feature = "t0rn", feature = "default"))]
 use t0rn_parachain_runtime::{
     opaque::Block, AccountId, AuraId, BalancesConfig, CollatorSelectionConfig, ParachainInfoConfig,
     PolkadotXcmConfig, RuntimeApi, RuntimeGenesisConfig, SessionConfig, SessionKeys, Signature,

--- a/node/parachain/src/command.rs
+++ b/node/parachain/src/command.rs
@@ -14,7 +14,7 @@ use t3rn_parachain_runtime::{Block, MILLISECS_PER_BLOCK};
 #[cfg(all(feature = "t7rn", not(feature = "default")))]
 use t3rn_parachain_runtime::{Block, MILLISECS_PER_BLOCK};
 
-#[cfg(feature = "t0rn")]
+#[cfg(any(feature = "t0rn", feature = "default"))]
 use t0rn_parachain_runtime::{Block, MILLISECS_PER_BLOCK};
 
 #[cfg(all(feature = "t3rn", not(feature = "default")))]
@@ -25,7 +25,7 @@ const COLLATOR_NAME: &str = "t7rn collator";
 #[cfg(all(feature = "t1rn", not(feature = "default")))]
 const COLLATOR_NAME: &str = "t1rn collator";
 
-#[cfg(feature = "t0rn")]
+#[cfg(any(feature = "t0rn", feature = "default"))]
 const COLLATOR_NAME: &str = "t0rn collator";
 
 use sc_cli::{
@@ -43,7 +43,7 @@ use crate::{
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
     Ok(match id {
-        "local" => Box::new(chain_spec::local_testnet_config()),
+        "local" | "dev" => Box::new(chain_spec::local_testnet_config()),
         "polkadot" | "polkadot-live" => Box::new(chain_spec::polkadot_config()),
         "kusama" | "kusama-live" => Box::new(chain_spec::kusama_config()),
         "rococo" | "rococo-live" => Box::new(chain_spec::rococo_config()),

--- a/node/parachain/src/rpc.rs
+++ b/node/parachain/src/rpc.rs
@@ -22,14 +22,11 @@ use t3rn_parachain_runtime::{opaque::Block, AccountId, Balance, Hash, Nonce};
 #[cfg(all(feature = "t7rn", not(feature = "default")))]
 use t7rn_parachain_runtime::{opaque::Block, AccountId, Balance, Hash, Nonce};
 
-#[cfg(feature = "t0rn")]
+#[cfg(any(feature = "t0rn", feature = "default"))]
 use t0rn_parachain_runtime::{opaque::Block, AccountId, Balance, Hash, Nonce};
 
-#[cfg(not(feature = "t3rn"))]
 use pallet_portal_rpc::{Portal, PortalApiServer};
 
-#[cfg(not(feature = "t7rn"))]
-#[cfg(not(feature = "t3rn"))]
 use pallet_xdns_rpc::{Xdns, XdnsApiServer};
 
 pub use sc_rpc_api::DenyUnsafe;
@@ -72,11 +69,9 @@ where
     module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
     module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 
-    #[cfg(all(feature = "t3rn", not(feature = "default")))]
-    #[cfg(all(feature = "t7rn", not(feature = "default")))]
+    #[cfg(not(any(feature = "t3rn", feature = "t7rn")))]
     module.merge(Xdns::new(client.clone()).into_rpc())?;
-    #[cfg(all(feature = "t3rn", not(feature = "default")))]
-    #[cfg(all(feature = "t7rn", not(feature = "default")))]
+    #[cfg(not(any(feature = "t3rn", feature = "t7rn")))]
     module.merge(Portal::new(client).into_rpc())?;
 
     Ok(module)

--- a/node/parachain/src/service.rs
+++ b/node/parachain/src/service.rs
@@ -10,7 +10,10 @@ use t1rn_parachain_runtime::{api, native_version, opaque::Block, RuntimeApi};
 #[cfg(all(feature = "t3rn", not(feature = "default")))]
 use t3rn_parachain_runtime::{api, native_version, opaque::Block, RuntimeApi};
 
-#[cfg(feature = "t0rn")]
+#[cfg(all(feature = "t7rn", not(feature = "default")))]
+use t7rn_parachain_runtime::{api, native_version, opaque::Block, RuntimeApi};
+
+#[cfg(any(feature = "t0rn", feature = "default"))]
 use t0rn_parachain_runtime::{api, native_version, opaque::Block, RuntimeApi};
 
 // Cumulus Imports

--- a/node/t0rn-parachain/Cargo.toml
+++ b/node/t0rn-parachain/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 
 [dependencies]
 # Extras
-t3rn-parachain-collator = { path = "../parachain", features = [ "t0rn" ], package = "parachain-collator" }
-#t3rn-parachain-collator = { path = "../parachain", features = [ "default" ], package = "parachain-collator" }
+#t3rn-parachain-collator = { path = "../parachain", features = [ "t0rn" ], package = "parachain-collator" }
+t0rn-parachain-collator = { path = "../parachain", features = [ "t0rn" ], package = "parachain-collator" }
 sc-cli                  = { workspace = true }
 
 [build-dependencies]
@@ -24,4 +24,4 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.
 
 [features]
 default            = [  ]
-runtime-benchmarks = [ "t3rn-parachain-collator/runtime-benchmarks" ]
+runtime-benchmarks = [ "t0rn-parachain-collator/runtime-benchmarks" ]

--- a/node/t0rn-parachain/src/main.rs
+++ b/node/t0rn-parachain/src/main.rs
@@ -1,5 +1,5 @@
 //! Substrate Node Template CLI library.
-use t3rn_parachain_collator::command;
+use t0rn_parachain_collator::command;
 
 fn main() -> sc_cli::Result<()> {
     command::run()

--- a/node/t1rn-parachain/Cargo.toml
+++ b/node/t1rn-parachain/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Extras
-t3rn-parachain-collator = { path = "../parachain", features = [ "t1rn" ], package = "parachain-collator" }
+t1rn-parachain-collator = { path = "../parachain", features = [ "t1rn" ], package = "parachain-collator" }
 sc-cli                  = { workspace = true }
 
 [build-dependencies]

--- a/node/t1rn-parachain/src/main.rs
+++ b/node/t1rn-parachain/src/main.rs
@@ -1,5 +1,5 @@
 //! Substrate Node Template CLI library.
-use t3rn_parachain_collator::command;
+use t1rn_parachain_collator::command;
 
 fn main() -> sc_cli::Result<()> {
     command::run()

--- a/node/t7rn-parachain/Cargo.toml
+++ b/node/t7rn-parachain/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Extras
-t3rn-parachain-collator = { path = "../parachain", features = [ "t7rn" ], package = "parachain-collator" }
+t7rn-parachain-collator = { path = "../parachain", features = [ "t7rn" ], package = "parachain-collator" }
 sc-cli                  = { workspace = true }
 
 [build-dependencies]

--- a/node/t7rn-parachain/src/main.rs
+++ b/node/t7rn-parachain/src/main.rs
@@ -1,5 +1,5 @@
 //! Substrate Node Template CLI library.
-use t3rn_parachain_collator::command;
+use t7rn_parachain_collator::command;
 
 fn main() -> sc_cli::Result<()> {
     command::run()

--- a/tests/zombienet/zombienet-alles.toml
+++ b/tests/zombienet/zombienet-alles.toml
@@ -1,0 +1,56 @@
+[relaychain]
+chain   = "rococo-local"
+command = "polkadot"
+
+[[relaychain.nodes]]
+name    = "alice"
+ws_port = 9933
+
+[[relaychain.node_groups]]
+count = 1
+name  = "bob"
+
+[[parachains]]
+chain         = "local"
+cumulus_based = true
+id            = 3334
+
+[parachains.collator]
+command  = "t1rn-collator"
+name     = "collator"
+ws_port  = 9944
+
+
+[[parachains]]
+chain         = "local"
+cumulus_based = true
+id            = 3333
+
+[parachains.collator]
+command  = "t0rn-collator"
+name     = "collator"
+ws_port  = 9944
+
+[[parachains]]
+chain         = "local"
+cumulus_based = true
+id            = 3337
+
+[parachains.collator]
+command  = "t7rn-collator"
+name     = "collator"
+ws_port  = 9944
+
+[[parachains]]
+chain         = "local"
+cumulus_based = true
+id            = 4444
+
+[parachains.collator]
+command  = "t3rn-collator"
+name     = "collator"
+ws_port  = 9944
+
+[types.Header]
+number = "u64"
+weight = "u64"

--- a/tests/zombienet/zombienet.sh
+++ b/tests/zombienet/zombienet.sh
@@ -139,6 +139,20 @@ setup_xcm() {
     build_collator
 }
 
+setup_alles() {
+    make_bin_dir
+    fetch_zombienet
+    build_polkadot
+    NETWORK=t0rn
+    build_collator
+    NETWORK=t1rn
+    build_collator
+    NETWORK=t3rn
+    build_collator
+    NETWORK=t7rn
+    build_collator
+}
+
 smoke() {
     echo "Running smoke tests.."
     # TODO[Optimisation]: loop through directory and test all
@@ -210,6 +224,13 @@ xcm() {
     echo "::endgroup::"
 }
 
+
+spawn_alles() {
+    setup_alles
+    echo "Spawning zombienet for t0rn, t1rn, t7rn, t3rn using provider: $provider..."
+    zombienet --provider="$provider" spawn ./zombienet-alles.toml
+}
+
 spawn_xcm() {
     setup_xcm
     echo "Spawning zombienet using provider: $provider..."
@@ -218,7 +239,7 @@ spawn_xcm() {
 
 spawn() {
     setup
-    echo "Spawning zombienet for t1rn using provider: $provider..."
+    echo "Spawning zombienet for ${NETWORK} using provider: $provider..."
     zombienet --provider="$provider" spawn ./zombienet-${NETWORK}.toml
 }
 
@@ -249,6 +270,10 @@ case "$1" in
     "spawn")
         setup
         spawn
+    ;;
+    "spawn_alles")
+        setup
+        spawn_alles
     ;;
     "spawn_xcm")
         spawn_xcm


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added support for new chain spec ID "dev", `t7rn`, and `rococo-native` features in the runtime, enhancing flexibility and compatibility.
- Refactor: Updated import statements across main files to use different libraries or modules (`t0rn_parachain_collator`, `t1rn_parachain_collator`, `t7rn_parachain_collator`) for the Substrate Node Template CLI, improving modularity and maintainability.
- Chore: Removed support for `default` in one of the conditional imports, streamlining the codebase.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->