### PR TITLE
build: add force option to rebootgateway

### DIFF
--- a/client/packages/cli/src/cli.ts
+++ b/client/packages/cli/src/cli.ts
@@ -53,6 +53,7 @@ withExportMode(
     .command('rebootGateway')
     .argument('vendor')
     .description('Reboot a gateway')
+    .option('-f, --force', 'Force on live chain')
     .action(wrapCryptoWaitReady(handleRebootCommand)),
 )
 

--- a/client/packages/cli/src/commands/rebootGateway/index.ts
+++ b/client/packages/cli/src/commands/rebootGateway/index.ts
@@ -1,18 +1,17 @@
 import { Args } from '@/types.ts'
-import { log } from '@/utils/log.ts'
+import { colorLogMsg, log } from '@/utils/log.ts'
 import '@t3rn/types'
 import ora from 'ora'
-import { colorLogMsg } from '@/utils/log.ts'
 import { createCircuitContext } from '@/utils/circuit.ts'
-import {
-  //@ts-ignore - TS doesn't know about the type
-  T3rnPrimitivesGatewayVendor,
-} from '@polkadot/types/lookup'
+import { T3rnPrimitivesGatewayVendor } from '@polkadot/types/lookup'
 import { createType } from '@t3rn/types'
 
 export const spinner = ora()
 
-export const handleRebootCommand = async (args: Args<'vendor' | 'export'>) => {
+export const handleRebootCommand = async (
+  args: Args<'vendor' | 'export'>,
+  options: { [key: string]: string },
+) => {
   log('INFO', `Rebooting ${args} gateway...`)
 
   if (!args) {
@@ -27,7 +26,8 @@ export const handleRebootCommand = async (args: Args<'vendor' | 'export'>) => {
       'ws://localhost:9944',
       'ws://0.0.0.0:9944',
       'ws://127.0.0.1:9944',
-    ].includes(endpoint)
+    ].includes(endpoint) &&
+    !options.force
   ) {
     log(
       'ERROR',
@@ -43,9 +43,10 @@ export const handleRebootCommand = async (args: Args<'vendor' | 'export'>) => {
       'T3rnPrimitivesGatewayVendor',
       args.toLowerCase() as never,
     )
-    log('INFO', verificationVendor)
+    log('INFO', verificationVendor as unknown as string)
     await sdk.circuit.tx.signAndSendSafe(
       sdk.circuit.tx.createSudo(
+        // @ts-ignore
         circuit.tx.xdns.rebootSelfGateway(verificationVendor.toJSON()),
       ),
     )

--- a/client/packages/cli/src/commands/registerGateway/vendors/eth.ts
+++ b/client/packages/cli/src/commands/registerGateway/vendors/eth.ts
@@ -138,7 +138,7 @@ const fetchInitData = async (
   if (res.status !== 200) {
     const reason = await res.text()
     throw new Error(
-      `Failed fetch init data, STATUS: ${res.status}, REASON: ${reason}`,
+      `Failed to fetch init data, STATUS: ${res.status}, REASON: ${reason}`,
     )
   }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a `--force` option to the `rebootGateway` command. This allows users to force a reboot on the live chain, providing more control over gateway management.
- Bug Fix: Improved error messaging in the `fetchInitData` function within the `registerGateway` command. The updated message provides clearer information when initial data fetch operations fail.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->