### PR TITLE
fix: update link and title

### DIFF
--- a/docs/main/docs/intro.md
+++ b/docs/main/docs/intro.md
@@ -36,7 +36,7 @@ To facilitate its multichain transactions, t3rn relies on essential network part
 1. **Collator Node Operation:**
    - To participate in the t3rn network, you can set up and run a collator node. This involves installing the software, configuring settings, and syncing with the desired network (e.g., t2rn, t0rn, t1rn, or t3rn).
 1. **Smart Contract Development:**
-   - Develop smart contracts using Solidity or any WASM-compatible language. Deploy your contracts to t3rn’s open-source registry to make them available for multichain execution and collaboration. Learn more about the [t3rn Smart Contract Hub](https://www.notion.so/Docs-Smart-Contract-Hub-b0095284acf14a7faa6a283929b2797d?pvs=21).
+   - Develop smart contracts using Solidity or any WASM-compatible language. Deploy your contracts to t3rn’s open-source registry to make them available for multichain execution and collaboration. Learn more about the [t3rn Smart Contract Hub](t3rn_protocol_wiki/smart-contract-hub).
 1. **Participate as an Executor or Attester:**
    - Join the network as an Executor to process transactions or as an Attester to validate them. Engage in the ecosystem by bidding on orders, executing transactions, and submitting attestations.
 1. **Explore t3rn's Capabilities:**

--- a/docs/main/docs/t3rn_protocol_wiki/_category_.json
+++ b/docs/main/docs/t3rn_protocol_wiki/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "t3rn Protocol Wiki",
+  "position": 10
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Documentation: Updated the link to the t3rn Smart Contract Hub in the introduction documentation. The link now points to a relative path within the project repository instead of an external Notion page, providing a more seamless navigation experience for users.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->