### PR TITLE
feat: bump sepolia & ethereum light client versions; fix benchmarks 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7526,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "pallet-eth2-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=eth-v1.1.6#ee1258cbeed61bf469dfe0e5e1d56cd792c0a820"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=eth-v1.1.7#8cb8471d0b18b1a6819a9a52d94863828bd9d263"
 dependencies = [
  "eth_trie",
  "ethereum-types",
@@ -7534,6 +7534,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hash-db 0.15.2",
+ "hex",
  "hex-literal 0.3.4",
  "keccak-hash 0.10.0",
  "log",
@@ -8033,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "pallet-sepolia-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.12#f91fba300cb43dce1c7ce2a6f4e5992f12c2e616"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.13#c6f9c3466a47e19e5b0237e81eb6e4d256d31996"
 dependencies = [
  "eth_trie",
  "ethereum-types",
@@ -8041,6 +8042,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hash-db 0.15.2",
+ "hex",
  "hex-literal 0.3.4",
  "keccak-hash 0.10.0",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7526,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "pallet-eth2-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=eth-v1.1.7#8cb8471d0b18b1a6819a9a52d94863828bd9d263"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=eth-v1.1.8#ecca5d705b034ab7f54428502df8f3751d003b25"
 dependencies = [
  "eth_trie",
  "ethereum-types",
@@ -8034,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "pallet-sepolia-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.13#c6f9c3466a47e19e5b0237e81eb6e4d256d31996"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.14#8edcb5defb803f4c1abf9580821ff85c8a7b6950"
 dependencies = [
  "eth_trie",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,8 +182,8 @@ parachains-common                   = { git = 'https://github.com/paritytech/cum
 
 ## TODO: t3rn dependencies
 pallet-celestia-light-client     = { git = "https://github.com/t3rn/celestia-light-client", tag = "celestia-v1.0.2", default-features = false }
-pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.7", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.13", default-features = false }
+pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.8", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.14", default-features = false }
 
 #pallet-asset-registry = { git = "https://github.com/t3rn/xbi", default-features = false, branch = "build/update-v1" }
 pallet-xbi-portal = { git = "https://github.com/t3rn/xbi", default-features = false, branch = "build/update-v1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,8 +182,8 @@ parachains-common                   = { git = 'https://github.com/paritytech/cum
 
 ## TODO: t3rn dependencies
 pallet-celestia-light-client     = { git = "https://github.com/t3rn/celestia-light-client", tag = "celestia-v1.0.2", default-features = false }
-pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.6", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.12", default-features = false }
+pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.7", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.13", default-features = false }
 
 #pallet-asset-registry = { git = "https://github.com/t3rn/xbi", default-features = false, branch = "build/update-v1" }
 pallet-xbi-portal = { git = "https://github.com/t3rn/xbi", default-features = false, branch = "build/update-v1" }

--- a/pallets/circuit/vacuum/src/benchmarking.rs
+++ b/pallets/circuit/vacuum/src/benchmarking.rs
@@ -29,7 +29,7 @@ use frame_support::assert_ok;
 use frame_system::{EventRecord, Pallet as System, RawOrigin};
 use pallet_xdns::Pallet as XDNS;
 use t3rn_primitives::monetary::EXISTENTIAL_DEPOSIT;
-
+use t3rn_primitives::xdns::Xdns;
 fn assume_last_xtx_event<T: Config>() -> T::Hash {
     let events = System::<T>::events();
     // let system_event: <T as frame_system::Config>::RuntimeEvent = generic_event.into();

--- a/pallets/circuit/vacuum/src/benchmarking.rs
+++ b/pallets/circuit/vacuum/src/benchmarking.rs
@@ -28,8 +28,7 @@ use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_support::assert_ok;
 use frame_system::{EventRecord, Pallet as System, RawOrigin};
 use pallet_xdns::Pallet as XDNS;
-use t3rn_primitives::monetary::EXISTENTIAL_DEPOSIT;
-use t3rn_primitives::xdns::Xdns;
+use t3rn_primitives::{monetary::EXISTENTIAL_DEPOSIT, xdns::Xdns};
 fn assume_last_xtx_event<T: Config>() -> T::Hash {
     let events = System::<T>::events();
     // let system_event: <T as frame_system::Config>::RuntimeEvent = generic_event.into();

--- a/pallets/portal/src/tests.rs
+++ b/pallets/portal/src/tests.rs
@@ -129,25 +129,25 @@ mod tests {
 
     #[test]
     fn test_initialize_and_submit_ethereum() {
-        let init = generate_initialization(None, None);
-        let submission_data = generate_epoch_update(
-            0,
-            3,
-            Some(
-                init.checkpoint
-                    .attested_beacon
-                    .hash_tree_root::<Runtime>()
-                    .unwrap(),
-            ),
-            None,
-            None,
-        );
-
         ExtBuilder::default()
             .with_standard_sfx_abi()
             .with_default_xdns_records()
             .build()
             .execute_with(|| {
+                let init = generate_initialization(None, None);
+                let submission_data = generate_epoch_update(
+                    0,
+                    3,
+                    Some(
+                        init.checkpoint
+                            .attested_beacon
+                            .hash_tree_root::<Runtime>()
+                            .unwrap(),
+                    ),
+                    None,
+                    None,
+                );
+
                 assert_ok!(Portal::initialize(Origin::root(), *b"eth2", init.encode()));
 
                 assert_eq!(

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -409,7 +409,6 @@ parameter_types! {
     pub const HeadersToStoreEth: u32 = 64 + 1; // we want a multiple of slots_per_epoch + 1
     pub const SessionLength: u64 = 5;
     pub const SyncCommitteeSize: u32 = 26;
-    pub const GenesisValidatorsRoot: Root = [216,234,23,31,60,148,174,162,30,188,66,161,237,97,5,42,207,63,146,9,192,14,78,251,170,221,172,9,237,155,128,120];
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 6;
     pub const CommitteeMajorityThreshold: u32 = 80;
@@ -418,7 +417,6 @@ parameter_types! {
 impl pallet_eth2_finality_verifier::Config for MiniRuntime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;
@@ -430,7 +428,6 @@ impl pallet_eth2_finality_verifier::Config for MiniRuntime {
 impl pallet_sepolia_finality_verifier::Config for MiniRuntime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/mini-mock/src/treasuries_config.rs
+++ b/runtime/mini-mock/src/treasuries_config.rs
@@ -18,7 +18,7 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 10;
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub const SpendPeriod: u32 = 60 / 12;
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: Balance = 100 * (TRN as Balance);
 }
 

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -346,7 +346,6 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
 
 parameter_types! {
     pub const SyncCommitteeSize: u32 = 26;
-    pub const GenesisValidatorsRoot: [u8; 32] = [216,234,23,31,60,148,174,162,30,188,66,161,237,97,5,42,207,63,146,9,192,14,78,251,170,221,172,9,237,155,128,120];
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
@@ -356,7 +355,6 @@ parameter_types! {
 impl pallet_eth2_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;
@@ -368,7 +366,6 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 impl pallet_sepolia_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/mock/src/treasuries_config.rs
+++ b/runtime/mock/src/treasuries_config.rs
@@ -18,7 +18,7 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 10;
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub const SpendPeriod: u32 = 60 / 12;
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: Balance = 100 * (TRN as Balance);
 }
 

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -356,7 +356,6 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
 
 parameter_types! {
     pub const SyncCommitteeSize: u32 = 512;
-    pub const GenesisValidatorsRoot: [u8; 32] = [216,234,23,31,60,148,174,162,30,188,66,161,237,97,5,42,207,63,146,9,192,14,78,251,170,221,172,9,237,155,128,120];
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
@@ -366,7 +365,6 @@ parameter_types! {
 impl pallet_eth2_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;
@@ -378,7 +376,6 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 impl pallet_sepolia_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/standalone/src/treasuries_config.rs
+++ b/runtime/standalone/src/treasuries_config.rs
@@ -16,7 +16,7 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 10;
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub const SpendPeriod: u32 = 60 / 12;
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: Balance = 100 * (TRN as Balance);
 }
 

--- a/runtime/t0rn-parachain/Cargo.toml
+++ b/runtime/t0rn-parachain/Cargo.toml
@@ -280,7 +280,7 @@ runtime-benchmarks = [
   "cumulus-pallet-xcmp-queue/runtime-benchmarks",
   "pallet-grandpa-finality-verifier/runtime-benchmarks",
   "pallet-utility/runtime-benchmarks",
-  "pallet-celestia-light-client/runtime-benchmarks",
+#  "pallet-celestia-light-client/runtime-benchmarks",
   "pallet-eth2-finality-verifier/runtime-benchmarks",
   "pallet-sepolia-finality-verifier/runtime-benchmarks",
   "pallet-asset-tx-payment/runtime-benchmarks",

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -343,7 +343,6 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
 
 parameter_types! {
     pub const SyncCommitteeSize: u32 = 512;
-    pub const GenesisValidatorsRoot: [u8; 32] = [216,234,23,31,60,148,174,162,30,188,66,161,237,97,5,42,207,63,146,9,192,14,78,251,170,221,172,9,237,155,128,120];
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
@@ -354,7 +353,6 @@ parameter_types! {
 impl pallet_eth2_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThresholdEth2;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;
@@ -366,7 +364,6 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 impl pallet_sepolia_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThresholdSepolia;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/t0rn-parachain/src/treasuries_config.rs
+++ b/runtime/t0rn-parachain/src/treasuries_config.rs
@@ -16,7 +16,8 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 10;
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub const SpendPeriod: u32 = 60 / 12;
+    // Set to 1 week
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: Balance = 100 * (TRN as Balance);
 }
 

--- a/runtime/t1rn-parachain/src/circuit_config.rs
+++ b/runtime/t1rn-parachain/src/circuit_config.rs
@@ -343,7 +343,6 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
 
 parameter_types! {
     pub const SyncCommitteeSize: u32 = 512;
-    pub const GenesisValidatorsRoot: [u8; 32] = [216,234,23,31,60,148,174,162,30,188,66,161,237,97,5,42,207,63,146,9,192,14,78,251,170,221,172,9,237,155,128,120];
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
@@ -354,7 +353,6 @@ parameter_types! {
 impl pallet_eth2_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThresholdEth2;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;
@@ -366,7 +364,6 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 impl pallet_sepolia_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThresholdSepolia;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/t1rn-parachain/src/treasuries_config.rs
+++ b/runtime/t1rn-parachain/src/treasuries_config.rs
@@ -16,7 +16,7 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 10;
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub const SpendPeriod: u32 = 60 / 12;
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: Balance = 100 * (TRN as Balance);
 }
 

--- a/runtime/t2rn-parachain/src/circuit_config.rs
+++ b/runtime/t2rn-parachain/src/circuit_config.rs
@@ -356,7 +356,6 @@ impl pallet_grandpa_finality_verifier::Config<KusamaInstance> for Runtime {
 
 parameter_types! {
     pub const SyncCommitteeSize: u32 = 512;
-    pub const GenesisValidatorsRoot: [u8; 32] = [216,234,23,31,60,148,174,162,30,188,66,161,237,97,5,42,207,63,146,9,192,14,78,251,170,221,172,9,237,155,128,120];
     pub const SlotsPerEpoch: u32 = 32;
     pub const EpochsPerSyncCommitteePeriod: u32 = 256;
     pub const HeadersToStoreEth: u32 = 50400 + 1; // 1 week + 1. We want a multiple of 32 + 1.
@@ -366,7 +365,6 @@ parameter_types! {
 impl pallet_eth2_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;
@@ -378,7 +376,6 @@ impl pallet_eth2_finality_verifier::Config for Runtime {
 impl pallet_sepolia_finality_verifier::Config for Runtime {
     type CommitteeMajorityThreshold = CommitteeMajorityThreshold;
     type EpochsPerSyncCommitteePeriod = EpochsPerSyncCommitteePeriod;
-    type GenesisValidatorRoot = GenesisValidatorsRoot;
     type HeadersToStore = HeadersToStoreEth;
     type LightClientAsyncAPI = XDNS;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/t2rn-parachain/src/treasuries_config.rs
+++ b/runtime/t2rn-parachain/src/treasuries_config.rs
@@ -16,7 +16,7 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 10;
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub const SpendPeriod: u32 = 60 / 12;
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: Balance = 100 * (TRN as Balance);
 }
 

--- a/runtime/t3rn-parachain/src/parachain_config.rs
+++ b/runtime/t3rn-parachain/src/parachain_config.rs
@@ -218,7 +218,7 @@ parameter_types! {
     pub const TreasuryId: PalletId = PalletId(*b"pottrsry");
     pub const MaxApprovals: u32 = 100;
     pub const ProposalBond: Permill = Permill::from_percent(3);
-    pub const SpendPeriod: u32 = (60 * 60 * 24) / 12;
+    pub const SpendPeriod: u32 = 7 * 24 * 60 * 60;
     pub const ProposalBondMinimum: u128 = 10_u128 * (TRN as u128);
 }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the `benchmarking.rs` file in the `circuit/vacuum` pallet. The update includes an import statement for the `Xdns` type from the `t3rn_primitives::xdns` module. This change prepares the codebase for future enhancements that will utilize this imported type.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->