### PR TITLE
feat: enable pre-funded Metamask accounts for t0rn & t2rn 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-attesters"
-version = "1.9.0-rc.0"
+version = "1.85.0-rc.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7246,7 +7246,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-circuit-vacuum"
-version = "1.9.0-rc.0"
+version = "1.85.0-rc.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7996,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-rewards"
-version = "1.9.0-rc.0"
+version = "1.85.0-rc.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
 [[package]]
 name = "amcl"
 version = "0.3.0"
-source = "git+https://github.com/Snowfork/milagro_bls#7d1776edb42870b006430ece9741c15811e4c9e3"
+source = "git+https://github.com/Snowfork/milagro_bls?rev=7d1776edb42870b006430ece9741c15811e4c9e3#7d1776edb42870b006430ece9741c15811e4c9e3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6273,7 +6273,7 @@ dependencies = [
 [[package]]
 name = "milagro_bls"
 version = "1.5.0"
-source = "git+https://github.com/Snowfork/milagro_bls#7d1776edb42870b006430ece9741c15811e4c9e3"
+source = "git+https://github.com/Snowfork/milagro_bls?rev=7d1776edb42870b006430ece9741c15811e4c9e3#7d1776edb42870b006430ece9741c15811e4c9e3"
 dependencies = [
  "amcl",
  "hex",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "pallet-eth2-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=eth-v1.1.9#2d6d7464587912a319fec6968ff594b8ae32ad3b"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=eth-v1.1.11#1fe0c90b980853a95a0d5a4a0b8c1ad1db4320a1"
 dependencies = [
  "eth_trie",
  "ethereum-types",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "pallet-sepolia-finality-verifier"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.15#391d49b572be27804601767121e781f3d02884f5"
+source = "git+https://github.com/t3rn/eth2-light-client?tag=sepolia-v1.1.17#1da666d79a73ebf4da9a64f52bf324d8d438411f"
 dependencies = [
  "eth_trie",
  "ethereum-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6965,6 +6965,7 @@ dependencies = [
  "frame-system",
  "libsecp256k1",
  "pallet-balances",
+ "pallet-evm",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,8 +182,8 @@ parachains-common                   = { git = 'https://github.com/paritytech/cum
 
 ## TODO: t3rn dependencies
 pallet-celestia-light-client     = { git = "https://github.com/t3rn/celestia-light-client", tag = "celestia-v1.0.4", default-features = false }
-pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.9", default-features = false }
-pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.15", default-features = false }
+pallet-eth2-finality-verifier    = { git = "https://github.com/t3rn/eth2-light-client", tag = "eth-v1.1.11", default-features = false }
+pallet-sepolia-finality-verifier = { git = "https://github.com/t3rn/eth2-light-client", tag = "sepolia-v1.1.17", default-features = false }
 
 #pallet-asset-registry = { git = "https://github.com/t3rn/xbi", default-features = false, branch = "build/update-v1" }
 pallet-xbi-portal = { git = "https://github.com/t3rn/xbi", default-features = false, branch = "build/update-v1" }

--- a/node/t0rn-parachain/src/chain_spec.rs
+++ b/node/t0rn-parachain/src/chain_spec.rs
@@ -1,7 +1,7 @@
 use parachain_runtime::{
-    opaque::Block, AccountId, AuraId, BalancesConfig, CollatorSelectionConfig, ParachainInfoConfig,
-    PolkadotXcmConfig, RuntimeApi, RuntimeGenesisConfig, SessionConfig, SessionKeys, Signature,
-    SudoConfig, SystemConfig, XDNSConfig, TRN, WASM_BINARY,
+    opaque::Block, AccountId, AuraId, BalancesConfig, CollatorSelectionConfig, EvmConfig,
+    GenesisAccount, ParachainInfoConfig, PolkadotXcmConfig, RuntimeGenesisConfig, SessionConfig,
+    SessionKeys, Signature, SudoConfig, SystemConfig, XDNSConfig, TRN, U256, WASM_BINARY,
 };
 
 use codec::Encode;
@@ -13,7 +13,7 @@ use sc_service::ChainType;
 use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
-use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
+use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public, H160};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::str::FromStr;
 
@@ -434,7 +434,47 @@ fn polkadot_genesis_full(
         transaction_payment: Default::default(),
         contracts_registry: Default::default(),
         attesters: Default::default(),
-        evm: Default::default(),
+        evm: EvmConfig {
+            accounts: {
+                let mut accounts = std::collections::BTreeMap::new();
+                accounts.insert(
+                    // EVM Alice
+                    H160::from_str("B08E7434dBA205Ae42D1DDcD7048Ce0B0c6cfD0d")
+                        .expect("internal H160 is valid; qed"),
+                    GenesisAccount {
+                        nonce: U256::zero(),
+                        // Using a larger number, so I can tell the accounts apart by balance.
+                        balance: U256::from(2u64 << 61),
+                        code: vec![],
+                        storage: std::collections::BTreeMap::new(),
+                    },
+                );
+                accounts.insert(
+                    // H160 address for Metamask interaction testing
+                    H160::from_str("CEB58Fc447ee30D2104dD00ABFe6Fe29fe470e5C")
+                        .expect("internal H160 is valid; qed"),
+                    GenesisAccount {
+                        balance: U256::from(10u64 << 62),
+                        code: Default::default(),
+                        nonce: Default::default(),
+                        storage: Default::default(),
+                    },
+                );
+                accounts.insert(
+                    // Executor EVM account
+                    H160::from_str("2C7A1CaAC34549ef4D6718ECCF3120AC2f74Df5C")
+                        .expect("internal H160 is valid; qed"),
+                    GenesisAccount {
+                        balance: U256::from(10u64 << 63),
+                        code: Default::default(),
+                        nonce: Default::default(),
+                        storage: Default::default(),
+                    },
+                );
+                accounts.encode()
+            },
+            _marker: Default::default(),
+        },
         three_vm: Default::default(),
         rewards: Default::default(),
         maintenance: Default::default(),

--- a/node/t2rn-parachain/src/chain_spec.rs
+++ b/node/t2rn-parachain/src/chain_spec.rs
@@ -1,17 +1,7 @@
 use sp_core::crypto::UncheckedInto;
 use t2rn_parachain_runtime::{
-    AccountId,
-    AuraConfig,
-    BalancesConfig,
-    GrandpaConfig,
-    RuntimeGenesisConfig,
-    Signature,
-    SudoConfig,
-    SystemConfig,
-    // SessionConfig,
-    // CollatorSelectionConfig,
-    XDNSConfig, // EvmConfig
-    WASM_BINARY,
+    AccountId, AuraConfig, BalancesConfig, EvmConfig, GenesisAccount, GrandpaConfig,
+    RuntimeGenesisConfig, Signature, SudoConfig, SystemConfig, XDNSConfig, H160, U256, WASM_BINARY,
 };
 const CANDIDACY_BOND: u128 = 0; // 10K TRN
 const DESIRED_CANDIDATES: u32 = 2;
@@ -27,6 +17,7 @@ use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
+use std::str::FromStr;
 use t3rn_abi::sfx_abi::SFXAbi;
 use t3rn_primitives::xdns::GatewayRecord;
 use t3rn_types::sfx::Sfx4bId;
@@ -240,7 +231,48 @@ fn testnet_genesis(
         attesters: Default::default(),
         clock: Default::default(),
         three_vm: Default::default(), // TODO: genesis for this needs to be setup for the function pointers\
-        evm: Default::default(),
+        // evm: Default::default(), // Default evm configuration
+        evm: EvmConfig {
+            accounts: {
+                let mut accounts = std::collections::BTreeMap::new();
+                accounts.insert(
+                    // EVM Alice
+                    H160::from_str("B08E7434dBA205Ae42D1DDcD7048Ce0B0c6cfD0d")
+                        .expect("internal H160 is valid; qed"),
+                    GenesisAccount {
+                        nonce: U256::zero(),
+                        // Using a larger number, so I can tell the accounts apart by balance.
+                        balance: U256::from(2u64 << 61),
+                        code: vec![],
+                        storage: std::collections::BTreeMap::new(),
+                    },
+                );
+                accounts.insert(
+                    // H160 address for Metamask interaction testing
+                    H160::from_str("CEB58Fc447ee30D2104dD00ABFe6Fe29fe470e5C")
+                        .expect("internal H160 is valid; qed"),
+                    GenesisAccount {
+                        balance: U256::from(10u64 << 62),
+                        code: Default::default(),
+                        nonce: Default::default(),
+                        storage: Default::default(),
+                    },
+                );
+                accounts.insert(
+                    // Executor EVM account
+                    H160::from_str("2C7A1CaAC34549ef4D6718ECCF3120AC2f74Df5C")
+                        .expect("internal H160 is valid; qed"),
+                    GenesisAccount {
+                        balance: U256::from(10u64 << 63),
+                        code: Default::default(),
+                        nonce: Default::default(),
+                        storage: Default::default(),
+                    },
+                );
+                accounts.encode()
+            },
+            _marker: Default::default(),
+        },
         maintenance_mode: Default::default(),
     }
 }

--- a/pallets/3vm/account-mapping/Cargo.toml
+++ b/pallets/3vm/account-mapping/Cargo.toml
@@ -22,6 +22,7 @@ frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 
 # t3rn packages
+pallet-3vm-evm                  = { default-features = false, path = "../../../pallets/evm", package = "pallet-evm" }
 t3rn-primitives                 = { default-features = false, path = "../../../primitives" }
 circuit-runtime-types           = { default-features = false, path = "../../../runtime/common-types" }
 
@@ -48,6 +49,7 @@ std = [
     "circuit-runtime-types/std",
     "circuit-runtime-pallets/std",
     "t3rn-primitives/std",
+    "pallet-3vm-evm/std",
 ]
 runtime-benchmarks = [
     "libsecp256k1",

--- a/pallets/attesters/Cargo.toml
+++ b/pallets/attesters/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition    = "2018"
+edition    = { workspace = true }
 homepage   = "https://t3rn.io"
 license    = "Apache-2.0"
 name       = "pallet-attesters"
 readme     = "README.md"
 repository = "https://github.com/t3rn/t3rn/"
-version    = "1.9.0-rc.0"
+version    = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/pallets/circuit/vacuum/Cargo.toml
+++ b/pallets/circuit/vacuum/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition    = "2018"
+edition    = { workspace = true }
 homepage   = "https://t3rn.io"
 license    = "Apache-2.0"
 name       = "pallet-circuit-vacuum"
 readme     = "README.md"
 repository = "https://github.com/t3rn/t3rn/"
-version    = "1.9.0-rc.0"
+version    = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/pallets/contracts/primitives/Cargo.toml
+++ b/pallets/contracts/primitives/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-contracts-primitives"
 version = "24.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+edition = { workspace = true }
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"

--- a/pallets/contracts/proc-macro/Cargo.toml
+++ b/pallets/contracts/proc-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+edition = { workspace = true }
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"

--- a/pallets/rewards/Cargo.toml
+++ b/pallets/rewards/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-edition    = "2018"
+edition    =  { workspace = true }
 homepage   = "https://t3rn.io"
 license    = "Apache-2.0"
 name       = "pallet-rewards"
 readme     = "README.md"
 repository = "https://github.com/t3rn/t3rn/"
-version    = "1.9.0-rc.0"
+version    =  { workspace = true }
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]

--- a/primitives/src/threevm.rs
+++ b/primitives/src/threevm.rs
@@ -392,7 +392,7 @@ pub trait Erc20Mapping {
 /// A mapping between `AccountId` and `EvmAddress`.
 pub trait AddressMapping<AccountId> {
     /// Returns the AccountId used go generate the given EvmAddress.
-    fn get_account_id(evm: &EvmAddress) -> AccountId;
+    fn into_account_id(evm: &EvmAddress) -> AccountId;
     /// Returns the EvmAddress associated with a given AccountId or the
     /// underlying EvmAddress of the AccountId.
     /// Returns None if there is no EvmAddress associated with the AccountId

--- a/runtime/mini-mock/Cargo.toml
+++ b/runtime/mini-mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors     = [ "t3rn ltd. <team@t3rn.io>" ]
 description = "A crate that with t3rn ABI cross-codec, SCALE, RLP, and more"
-edition     = "2021"
+edition     = { workspace = true }
 homepage    = "https://t3rn.io"
 license     = "Apache-2.0"
 name        = "t3rn-mini-mock-runtime"

--- a/runtime/t0rn-parachain/Cargo.toml
+++ b/runtime/t0rn-parachain/Cargo.toml
@@ -292,6 +292,8 @@ runtime-benchmarks = [
   "pallet-3vm-ethereum/runtime-benchmarks",
   "pallet-3vm-contracts/runtime-benchmarks",
   "pallet-3vm-account-mapping/runtime-benchmarks",
+  # Other
+  # "pallet-celestia-light-client/runtime-benchmarks",
 ]
 try-runtime = [
   "frame-executive/try-runtime",

--- a/runtime/t0rn-parachain/src/contracts_config.rs
+++ b/runtime/t0rn-parachain/src/contracts_config.rs
@@ -6,7 +6,7 @@ use crate::{
 use frame_support::{
     pallet_prelude::ConstU32,
     parameter_types,
-    traits::{ConstBool, FindAuthor},
+    traits::{ConstBool, Currency, FindAuthor, OnUnbalanced},
     PalletId,
 };
 
@@ -119,10 +119,20 @@ impl FeeCalculator for FixedGasPrice {
 const BLOCK_GAS_LIMIT: u64 = 150_000_000;
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 
+type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
+
+pub struct ToStakingPot;
+impl OnUnbalanced<NegativeImbalance> for ToStakingPot {
+    fn on_nonzero_unbalanced(amount: NegativeImbalance) {
+        let staking_pot = PotId::get().into_account_truncating();
+        Balances::resolve_creating(&staking_pot, amount);
+    }
+}
+
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
     pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
-    pub const ChainId: u64 = 42;
+    pub const ChainId: u64 = 3333;
     // pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
     //     (0_u64, evm_precompile_util::KnownPrecompile::ECRecover),
     //     (1_u64, evm_precompile_util::KnownPrecompile::Sha256),
@@ -144,7 +154,7 @@ parameter_types! {
 // }
 // TODO[https://github.com/t3rn/3vm/issues/102]: configure this appropriately
 impl pallet_3vm_evm::Config for Runtime {
-    type AddressMapping = HashedAddressMapping<Keccak256>;
+    type AddressMapping = EvmAddressMapping<Runtime>;
     type BlockGasLimit = BlockGasLimit;
     type BlockHashMapping = SubstrateBlockHashMapping<Self>;
     type CallOrigin = EnsureAddressTruncated;
@@ -155,7 +165,7 @@ impl pallet_3vm_evm::Config for Runtime {
     type FindAuthor = FindAuthorTruncated<Aura>;
     type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
     type GasWeightMapping = pallet_3vm_evm::FixedGasWeightMapping<Runtime>;
-    type OnChargeTransaction = ();
+    type OnChargeTransaction = pallet_3vm_evm::EVMCurrencyAdapter<Balances, ToStakingPot>;
     type OnCreate = ();
     type PrecompilesType = ();
     // type PrecompilesValue = PrecompilesValue;

--- a/runtime/t0rn-parachain/src/lib.rs
+++ b/runtime/t0rn-parachain/src/lib.rs
@@ -39,7 +39,7 @@ use t3rn_primitives::{
 use codec::Encode;
 use frame_support::{dispatch, traits::OnFinalize};
 use pallet_3vm_evm::{GasWeightMapping, Runner};
-use pallet_3vm_evm_primitives::FeeCalculator;
+pub use pallet_3vm_evm_primitives::{FeeCalculator, GenesisAccount};
 pub use sp_core::{H160, H256, U256};
 use sp_runtime::traits::UniqueSaturatedInto;
 

--- a/runtime/t2rn-parachain/src/lib.rs
+++ b/runtime/t2rn-parachain/src/lib.rs
@@ -35,7 +35,7 @@ use sp_std::{
 use codec::Encode;
 use frame_support::{dispatch, traits::OnFinalize};
 use pallet_3vm_evm::GasWeightMapping;
-use pallet_3vm_evm_primitives::FeeCalculator;
+pub use pallet_3vm_evm_primitives::{FeeCalculator, GenesisAccount};
 pub use sp_core::{H160, H256, U256};
 use sp_runtime::traits::UniqueSaturatedInto;
 pub use sp_runtime::{Perbill, Permill};


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added pre-funded EVM accounts for testing purposes, including an account specifically for Metamask interaction testing.
- Refactor: Updated the handling of Ethereum addresses and account IDs with a new trait `BaseAddressMapping` and modified function signatures.
- New Feature: Enabled pre-funded Metamask accounts for `t0rn` and `t2rn`.
- Refactor: Modified the `OnUnbalanced` trait implementation to resolve negative imbalances to a staking pot.
- Style: Updated the `ChainId` parameter value to 3333 and changed the `AddressMapping` type to `EvmAddressMapping`.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->