### PR TITLE
feat: re-connect Portal precompiles 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14299,6 +14299,7 @@ dependencies = [
  "pallet-xdns-rpc-runtime-api",
  "parity-scale-codec",
  "polkadot-runtime-common",
+ "precompile-util",
  "scale-info",
  "serde",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13971,6 +13971,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
+ "precompile-util",
  "scale-info",
  "serde",
  "smallvec",

--- a/client/contracts/t3Portal.sol
+++ b/client/contracts/t3Portal.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+contract PortalPrecompileInterface {
+    enum PortalPrecompileInterfaceEnum {
+        GetLatestFinalizedHeader,
+        GetLatestFinalizedHeight,
+        GetLatestUpdatedHeight,
+        GetCurrentEpoch,
+        ReadFastConfirmationOffset,
+        ReadRationalConfirmationOffset,
+        ReadEpochOffset,
+        VerifyEventInclusion,
+        VerifyStateInclusion,
+        VerifyTxInclusion
+    }
+
+    struct ChainId {
+        uint256 value;
+    }
+
+    struct Bytes {
+        bytes value;
+    }
+
+    struct VerifyTxInclusionData {
+        bytes4 id;
+        Bytes data;
+    }
+
+    struct ReadPortalOption {
+        PortalPrecompileInterfaceEnum action;
+        bytes4 id;
+    }
+
+    function encodeReadPrecompileSelect(ReadPortalOption calldata t) public pure returns (bytes memory) {
+        return abi.encodePacked(uint8(t.action), t.id);
+    }
+
+    function encodeReadPrecompileMemorySelect(ReadPortalOption memory t) public pure returns (bytes memory) {
+        return abi.encodePacked(uint8(t.action), t.id);
+    }
+
+    struct VerifyInclusionPortalOption {
+        PortalPrecompileInterfaceEnum action;
+        bytes4 id;
+        bytes data;
+    }
+
+    function encodeVerifyPrecompileSelect(VerifyInclusionPortalOption memory t, address targetContractAddress) public pure returns (bytes memory) {
+        return abi.encodePacked(uint8(t.action), t.id, targetContractAddress, t.data);
+    }
+}
+
+contract t3Portal is PortalPrecompileInterface {
+
+    address private constant PORTAL = address(0x0808080808080808080808080808080808080808); // address of portal precompile
+
+    function getLatestFinalizedHeader(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.GetLatestFinalizedHeader, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function getLatestFinalizedHeight(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.GetLatestFinalizedHeight, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function getLatestUpdatedHeight(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.GetLatestUpdatedHeight, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function getCurrentEpoch(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.GetCurrentEpoch, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function readFastConfirmationOffset(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.ReadFastConfirmationOffset, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function readRationalConfirmationOffset(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.ReadRationalConfirmationOffset, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function readEpochOffset(bytes4 chainId) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeReadPrecompileMemorySelect(ReadPortalOption(PortalPrecompileInterfaceEnum.ReadEpochOffset, chainId))
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function verifyEventInclusion(bytes4 chainId, bytes memory proof, address maybeCheckProofSource) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeVerifyPrecompileSelect(VerifyInclusionPortalOption(PortalPrecompileInterfaceEnum.VerifyEventInclusion, chainId, proof), maybeCheckProofSource)
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function verifyStateInclusion(bytes4 chainId, bytes memory proof, address maybeCheckProofSource) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeVerifyPrecompileSelect(VerifyInclusionPortalOption(PortalPrecompileInterfaceEnum.VerifyStateInclusion, chainId, proof), maybeCheckProofSource)
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+
+    function verifyTxInclusion(bytes4 chainId, bytes memory proof, address maybeCheckProofSource) public view returns (bytes memory) {
+        (bool success, bytes memory returnData) = PORTAL.staticcall(
+            encodeVerifyPrecompileSelect(VerifyInclusionPortalOption(PortalPrecompileInterfaceEnum.VerifyTxInclusion, chainId, proof), maybeCheckProofSource)
+        );
+        if (success) {
+            return returnData;
+        } else {
+            return "";
+        }
+    }
+}

--- a/client/contracts/t3rnTokenInterface.sol
+++ b/client/contracts/t3rnTokenInterface.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+/// @dev The T3rn Token Precompile contract's address.
+address constant T3RN_TOKEN_PRECOMPILE_ADDRESS = 0x0909090909090909090909090909090909090909;
+
+/// @dev The T3rn Token Precompile contract's instance.
+T3rnToken constant T3RN_TOKEN_CONTRACT = T3rnToken(T3RN_TOKEN_PRECOMPILE_ADDRESS);
+
+/// @title The T3rn Token Precompile Interface
+/// @dev The interface through which solidity contracts will interact with pallet-assets & pallet_balances.
+/// @custom:address 0x0909090909090909090909090909090909090909
+interface T3rnToken {
+    /// @dev Gets the total supply of a currency.
+    /// @return An uint256 representing the total supply of a token.
+    function totalSupply() external view returns (uint256);
+
+    /// @dev Gets balance of an address.
+    /// @param owner address The address that owns a token.
+    /// @return An uint256 representing the balance of the owner.
+    function balanceOf(address owner) external view returns (uint256);
+
+    /// @dev Gets the token  allowance of an address.
+    /// @param owner address The address that owns a token
+    /// @param token address The token address
+    /// @return An uint256 representing of the token for the owner.
+    function allowance(address owner, address token) external view returns (uint256);
+
+    /// @dev Gets the name of a token.
+    /// @return A bytes32 array representing the name of a token.
+    function name() external view returns (bytes32);
+
+    /// @dev Gets the symbol of a token.
+    /// @return A bytes32 array representing the symbol of a token.
+    function symbol() external view returns (bytes32);
+
+    /// @dev Gets the decimals of a token.
+    /// @return An uint256 representing the decimals of a token.
+    function decimals() external view returns (uint256);
+
+    /// @dev Transfer token to a specified address
+    /// @param receiver address The address that will receive the token.
+    /// @param value uint256 The value that will be transferred.
+    /// @return true if the transfer was successful, revert otherwise
+    function transfer(address receiver, uint256 value) external returns (bool);
+
+    /// @dev Approve token for transfer.
+    /// @param spender The token spender address.
+    /// @param value uint256 The value that will be approved.
+    /// @return true if the approval was successful, revert otherwise.
+    function approve(address spender, uint256 value) external returns (bool);
+
+    /// @dev Transfer token from a specified address to another one.
+    /// @param sender The token sender address.
+    /// @param receiver The token receiver address.
+    /// @param value uint256 The value that will be transferred.
+    /// @return true if the transfer was successful, revert otherwise.
+    function transferFrom(address sender, address receiver, uint256 value) external returns (bool);
+
+    /// @dev Event emitted when a token is transferred.
+    /// @param sender address The address that transferred the token.
+    /// @param receiver address The address that received the token.
+    /// @param value uint256 The value that was transferred.
+    event Transfer(address sender, address receiver, uint256 value);
+
+    /// @dev Event emitted when a token is approved.
+    /// @param spender The token spender address.
+    /// @param value uint256 The value that was approved.
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/pallets/3vm/account-mapping/src/lib.rs
+++ b/pallets/3vm/account-mapping/src/lib.rs
@@ -177,7 +177,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             eth_address: EvmAddress,
             eth_signature: EcdsaSignature,
-        ) -> DispatchResult {
+        ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
             // check if user already mapped account
@@ -200,6 +200,9 @@ pub mod pallet {
                 Error::<T>::PreImageAddressNotMatchingRecovered
             );
 
+            Accounts::<T>::insert(eth_address, &who);
+            EvmAddresses::<T>::insert(&who, eth_address);
+
             // check if the evm padded address already exists
             let account_id = T::AddressMapping::into_account_id(&eth_address);
             if frame_system::Pallet::<T>::account_exists(&account_id) {
@@ -221,15 +224,12 @@ pub mod pallet {
                 ExistenceRequirement::KeepAlive,
             )?;
 
-            Accounts::<T>::insert(eth_address, &who);
-            EvmAddresses::<T>::insert(&who, eth_address);
-
             Self::deposit_event(Event::ClaimAccount {
                 account_id: who,
                 evm_address: eth_address,
             });
 
-            Ok(())
+            Ok(Pays::No.into())
         }
 
         /// Claim account mapping between Substrate accounts and a generated EVM
@@ -238,7 +238,7 @@ pub mod pallet {
         #[pallet::call_index(1)]
         #[pallet::weight(10_000 + T::DbWeight::get().writes(1).ref_time())]
         #[transactional]
-        pub fn claim_default_account(origin: OriginFor<T>) -> DispatchResult {
+        pub fn claim_default_account(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
             // ensure account_id has not been mapped
@@ -262,7 +262,7 @@ pub mod pallet {
                 evm_address: eth_address,
             });
 
-            Ok(())
+            Ok(Pays::No.into())
         }
     }
 }
@@ -329,6 +329,10 @@ where
     // Returns the AccountId used go generate the given EvmAddress.
     fn into_account_id(address: &EvmAddress) -> T::AccountId {
         if let Some(acc) = Accounts::<T>::get(address) {
+            log::info!(
+                "AddressMapping::into_account_id - found matching account: {:?}",
+                acc
+            );
             acc
         } else {
             let mut data: [u8; 32] = [0u8; 32];
@@ -389,6 +393,7 @@ where
     // Returns the AccountId used go generate the given EvmAddress.
     fn into_account_id(address: EvmAddress) -> T::AccountId {
         if let Some(acc) = Accounts::<T>::get(&address) {
+            log::info!("into_account_id - found matching account: {:?}", acc);
             acc
         } else {
             let mut data: [u8; 32] = [0u8; 32];

--- a/pallets/evm/precompile/util/src/lib.rs
+++ b/pallets/evm/precompile/util/src/lib.rs
@@ -61,9 +61,16 @@ pub struct Precompiles<T: pallet_3vm_evm::Config> {
 }
 
 impl<T: pallet_3vm_evm::Config> Precompiles<T> {
-    pub fn new(inner: BTreeMap<u64, KnownPrecompile<T>>) -> Self {
+    // pub fn new(inner: BTreeMap<u64, KnownPrecompile<T>>) -> Self {
+    //     Self {
+    //         inner: inner.into_iter().map(|(k, v)| (hash(&k), v)).collect(),
+    //         phantom: Default::default(),
+    //     }
+    // }
+
+    pub fn new(inner: BTreeMap<H160, KnownPrecompile<T>>) -> Self {
         Self {
-            inner: inner.into_iter().map(|(k, v)| (hash(&k), v)).collect(),
+            inner: inner.into_iter().map(|(k, v)| (k, v)).collect(),
             phantom: Default::default(),
         }
     }

--- a/runtime/mock/src/contracts_config.rs
+++ b/runtime/mock/src/contracts_config.rs
@@ -130,15 +130,15 @@ parameter_types! {
     pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
     pub const ChainId: u64 = 42;
     pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
-        (0_u64, evm_precompile_util::KnownPrecompile::ECRecover),
-        (1_u64, evm_precompile_util::KnownPrecompile::Sha256),
-        (2_u64, evm_precompile_util::KnownPrecompile::Ripemd160),
-        (3_u64, evm_precompile_util::KnownPrecompile::Identity),
-        (4_u64, evm_precompile_util::KnownPrecompile::Modexp),
-        (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
-        (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
-        (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-        (40_u64, evm_precompile_util::KnownPrecompile::Portal)
+         (sp_core::H160([0u8; 20]), evm_precompile_util::KnownPrecompile::ECRecover),
+         (sp_core::H160([1u8; 20]), evm_precompile_util::KnownPrecompile::Sha256),
+         (sp_core::H160([2u8; 20]), evm_precompile_util::KnownPrecompile::Ripemd160),
+         (sp_core::H160([3u8; 20]), evm_precompile_util::KnownPrecompile::Identity),
+         (sp_core::H160([4u8; 20]), evm_precompile_util::KnownPrecompile::Modexp),
+         (sp_core::H160([5u8; 20]), evm_precompile_util::KnownPrecompile::Sha3FIPS256),
+         (sp_core::H160([6u8; 20]), evm_precompile_util::KnownPrecompile::Sha3FIPS512),
+         (sp_core::H160([7u8; 20]), evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
+         (sp_core::H160([8u8; 20]), evm_precompile_util::KnownPrecompile::Portal)
     ].into_iter().collect());
     // pub MockPrecompiles: MockPrecompiles = MockPrecompileSet;
     pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
@@ -159,7 +159,7 @@ impl pallet_3vm_evm::Config for Runtime {
     type GasWeightMapping = pallet_3vm_evm::FixedGasWeightMapping<Runtime>;
     type OnChargeTransaction = ();
     type OnCreate = ();
-    type PrecompilesType = evm_precompile_util::Precompiles<Self>;
+    type PrecompilesType = evm_precompile_util::Precompiles<Runtime>;
     type PrecompilesValue = PrecompilesValue;
     type Runner = pallet_3vm_evm::runner::stack::Runner<Self>;
     type RuntimeEvent = RuntimeEvent;

--- a/runtime/t0rn-parachain/Cargo.toml
+++ b/runtime/t0rn-parachain/Cargo.toml
@@ -123,7 +123,7 @@ xcm-primitives           = { workspace = true }
 #pallet-xbi-portal     = { workspace = true }
 
 # Smart contracts VMs
-#evm-precompile-util             = { default-features = false, path = "../../pallets/evm/precompile/util", package = "precompile-util" }
+evm-precompile-util             = { default-features = false, path = "../../pallets/evm/precompile/util", package = "precompile-util" }
 pallet-3vm                      = { default-features = false, path = "../../pallets/3vm" }
 pallet-3vm-account-mapping      = { default-features = false, path = "../../pallets/3vm/account-mapping" }
 pallet-3vm-contracts            = { default-features = false, path = "../../pallets/contracts", package = "pallet-contracts" }
@@ -133,6 +133,7 @@ pallet-3vm-evm-primitives       = { default-features = false, path = "../../pall
 fp-rpc                          = { default-features = false, path = "../../pallets/evm/rpc" }
 pallet-3vm-ethereum             = { default-features = false, path = "../../pallets/3vm/ethereum", package = "pallet-ethereum" }
 fp-self-contained               = { workspace = true, default-features = false }
+
 
 # Commons
 circuit-runtime-types = { path = "../common-types", default-features = false }
@@ -182,7 +183,7 @@ std = [
   "fp-rpc/std",
   "fp-self-contained/std",
   "pallet-vacuum/std",
-  #  "evm-precompile-util/std",
+  "evm-precompile-util/std",
   "pallet-account-manager/std",
   "pallet-preimage/std",
   'pallet-scheduler/std',

--- a/runtime/t0rn-parachain/src/contracts_config.rs
+++ b/runtime/t0rn-parachain/src/contracts_config.rs
@@ -133,17 +133,17 @@ parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
     pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
     pub const ChainId: u64 = 3333;
-    // pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
-    //     (0_u64, evm_precompile_util::KnownPrecompile::ECRecover),
-    //     (1_u64, evm_precompile_util::KnownPrecompile::Sha256),
-    //     (2_u64, evm_precompile_util::KnownPrecompile::Ripemd160),
-    //     (3_u64, evm_precompile_util::KnownPrecompile::Identity),
-    //     (4_u64, evm_precompile_util::KnownPrecompile::Modexp),
-    //     (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
-    //     (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
-    //     (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-    //     (40_u64, evm_precompile_util::KnownPrecompile::Portal)
-    // ].into_iter().collect());
+    pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
+         (sp_core::H160([0u8; 20]), evm_precompile_util::KnownPrecompile::ECRecover),
+         (sp_core::H160([1u8; 20]), evm_precompile_util::KnownPrecompile::Sha256),
+         (sp_core::H160([2u8; 20]), evm_precompile_util::KnownPrecompile::Ripemd160),
+         (sp_core::H160([3u8; 20]), evm_precompile_util::KnownPrecompile::Identity),
+         (sp_core::H160([4u8; 20]), evm_precompile_util::KnownPrecompile::Modexp),
+         (sp_core::H160([5u8; 20]), evm_precompile_util::KnownPrecompile::Sha3FIPS256),
+         (sp_core::H160([6u8; 20]), evm_precompile_util::KnownPrecompile::Sha3FIPS512),
+         (sp_core::H160([7u8; 20]), evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
+         (sp_core::H160([8u8; 20]), evm_precompile_util::KnownPrecompile::Portal)
+    ].into_iter().collect());
     // pub MockPrecompiles: MockPrecompiles = MockPrecompileSet;
     pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
@@ -151,7 +151,7 @@ parameter_types! {
 // pub struct Precompiles<Runtime> {
 //     pub inner: BTreeMap<H160, KnownPrecompile<Runtime>>,
 //     phantom: PhantomData<Runtime>,
-// }
+//}
 // TODO[https://github.com/t3rn/3vm/issues/102]: configure this appropriately
 impl pallet_3vm_evm::Config for Runtime {
     type AddressMapping = EvmAddressMapping<Runtime>;
@@ -167,10 +167,9 @@ impl pallet_3vm_evm::Config for Runtime {
     type GasWeightMapping = pallet_3vm_evm::FixedGasWeightMapping<Runtime>;
     type OnChargeTransaction = pallet_3vm_evm::EVMCurrencyAdapter<Balances, ToStakingPot>;
     type OnCreate = ();
-    type PrecompilesType = ();
-    // type PrecompilesValue = PrecompilesValue;
+    type PrecompilesType = evm_precompile_util::Precompiles<Runtime>;
     // fixme: add and compile pre-compiles compile_error!("the wasm*-unknown-unknown targets are not supported by \
-    type PrecompilesValue = ();
+    type PrecompilesValue = PrecompilesValue;
     type Runner = pallet_3vm_evm::runner::stack::Runner<Self>;
     type RuntimeEvent = RuntimeEvent;
     type ThreeVm = ThreeVm;

--- a/runtime/t2rn-parachain/Cargo.toml
+++ b/runtime/t2rn-parachain/Cargo.toml
@@ -47,7 +47,7 @@ t3rn-primitives                  = { default-features = false, path = "../../pri
 t3rn-types                       = { path = "../../types", default-features = false }
 
 # Smart contracts VMs
-#evm-precompile-util                  = { default-features = false, path = "../../pallets/evm/precompile/util", package = "precompile-util" }
+evm-precompile-util                  = { default-features = false, path = "../../pallets/evm/precompile/util", package = "precompile-util" }
 pallet-3vm                      = { default-features = false, path = "../../pallets/3vm" }
 pallet-3vm-account-mapping      = { default-features = false, path = "../../pallets/3vm/account-mapping" }
 pallet-3vm-contracts            = { default-features = false, path = "../../pallets/contracts", package = "pallet-contracts" }
@@ -149,7 +149,7 @@ std = [
   "pallet-3vm-evm/std",
   "pallet-3vm-evm-primitives/std",
   #  "pallet-evm-rpc-runtime-api/std",
-  #  "evm-precompile-util/std",
+  "evm-precompile-util/std",
   "pallet-account-manager/std",
   "pallet-contracts-registry/std",
   "pallet-balances/std",

--- a/runtime/t2rn-parachain/src/contracts_config.rs
+++ b/runtime/t2rn-parachain/src/contracts_config.rs
@@ -134,17 +134,17 @@ parameter_types! {
     pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
     pub const ChainId: u64 = 3333;
     pub const PotId: PalletId = PalletId(*b"PotStake");
-    // pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
-    //     (0_u64, evm_precompile_util::KnownPrecompile::ECRecover),
-    //     (1_u64, evm_precompile_util::KnownPrecompile::Sha256),
-    //     (2_u64, evm_precompile_util::KnownPrecompile::Ripemd160),
-    //     (3_u64, evm_precompile_util::KnownPrecompile::Identity),
-    //     (4_u64, evm_precompile_util::KnownPrecompile::Modexp),
-    //     (5_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS256),
-    //     (6_u64, evm_precompile_util::KnownPrecompile::Sha3FIPS512),
-    //     (7_u64, evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
-    //     (40_u64, evm_precompile_util::KnownPrecompile::Portal)
-    // ].into_iter().collect());
+    pub PrecompilesValue: evm_precompile_util::Precompiles<Runtime> = evm_precompile_util::Precompiles::<Runtime>::new(sp_std::vec![
+        (sp_core::H160([0u8; 20]), evm_precompile_util::KnownPrecompile::ECRecover),
+        (sp_core::H160([1u8; 20]), evm_precompile_util::KnownPrecompile::Sha256),
+        (sp_core::H160([2u8; 20]), evm_precompile_util::KnownPrecompile::Ripemd160),
+        (sp_core::H160([3u8; 20]), evm_precompile_util::KnownPrecompile::Identity),
+        (sp_core::H160([4u8; 20]), evm_precompile_util::KnownPrecompile::Modexp),
+        (sp_core::H160([5u8; 20]), evm_precompile_util::KnownPrecompile::Sha3FIPS256),
+        (sp_core::H160([6u8; 20]), evm_precompile_util::KnownPrecompile::Sha3FIPS512),
+        (sp_core::H160([7u8; 20]), evm_precompile_util::KnownPrecompile::ECRecoverPublicKey),
+        (sp_core::H160([8u8; 20]), evm_precompile_util::KnownPrecompile::Portal)
+    ].into_iter().collect());
     // pub MockPrecompiles: MockPrecompiles = MockPrecompileSet;
     pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
@@ -168,10 +168,10 @@ impl pallet_3vm_evm::Config for Runtime {
     type GasWeightMapping = pallet_3vm_evm::FixedGasWeightMapping<Runtime>;
     type OnChargeTransaction = pallet_3vm_evm::EVMCurrencyAdapter<Balances, ToStakingPot>;
     type OnCreate = ();
-    type PrecompilesType = ();
-    // type PrecompilesValue = PrecompilesValue;
+    type PrecompilesType = evm_precompile_util::Precompiles<Runtime>;
+    type PrecompilesValue = PrecompilesValue;
     // fixme: add and compile pre-compiles compile_error!("the wasm*-unknown-unknown targets are not supported by \
-    type PrecompilesValue = ();
+    // type PrecompilesValue = ();
     type Runner = pallet_3vm_evm::runner::stack::Runner<Self>;
     type RuntimeEvent = RuntimeEvent;
     type ThreeVm = ThreeVm;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `claim_account` and `claim_default_account` functions in the `pallet` module to return `DispatchResultWithPostInfo` for better error handling and post-dispatch information.
- New Feature: Enhanced logging in the `into_account_id` functions within the `pallet` module, improving traceability and debugging capabilities.
- Refactor: Modified the `Precompiles` struct and `PrecompilesValue` constant in the `pallet_3vm_evm` module and `runtime/t2rn-parachain` respectively. The changes include using `BTreeMap` with keys of type `H160` instead of `u64`, enhancing the efficiency and readability of precompile handling.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->