### PR TITLE
fix: guardian integration flow gas price error

### DIFF
--- a/.github/workflows/test-circuit.yml
+++ b/.github/workflows/test-circuit.yml
@@ -109,7 +109,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-nextest
-          version: '^0.9.68'
+          version: '0.9.68'
 
       - name: Install cargo-llvm-cov
         uses: baptiste0928/cargo-install@v2

--- a/.github/workflows/test-circuit.yml
+++ b/.github/workflows/test-circuit.yml
@@ -109,6 +109,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-nextest
+          version: '^0.9.68'
 
       - name: Install cargo-llvm-cov
         uses: baptiste0928/cargo-install@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ dependencies = [
 name = "circuit-standalone-node"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "circuit-standalone-runtime",
  "clap",
  "frame-benchmarking",
@@ -13892,6 +13893,7 @@ dependencies = [
 name = "t0rn-parachain-collator"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "clap",
  "color-print",
  "cumulus-client-cli",
@@ -14089,6 +14091,7 @@ dependencies = [
 name = "t1rn-parachain-collator"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "clap",
  "color-print",
  "cumulus-client-cli",
@@ -14267,6 +14270,7 @@ dependencies = [
 name = "t2rn"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "clap",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
@@ -14490,6 +14494,7 @@ dependencies = [
 name = "t3rn-parachain-collator"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "clap",
  "color-print",
  "cumulus-client-cli",
@@ -14723,6 +14728,7 @@ dependencies = [
 name = "t7rn-parachain-collator"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "clap",
  "color-print",
  "cumulus-client-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7283,6 +7283,7 @@ dependencies = [
 name = "pallet-circuit-vacuum"
 version = "1.88.0-rc.0"
 dependencies = [
+ "circuit-runtime-types",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -67,7 +67,7 @@ hex-literal            = { workspace = true }
 
 # Local Dependencies
 circuit-standalone-runtime = { path = "../../runtime/standalone" }
-circuit-runtime-types      = { path = "../../runtime/common-types" }
+circuit-runtime-types      = { path = "../../runtime/common-types", default-features = false }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -67,6 +67,7 @@ hex-literal            = { workspace = true }
 
 # Local Dependencies
 circuit-standalone-runtime = { path = "../../runtime/standalone" }
+circuit-runtime-types      = { path = "../../runtime/common-types" }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -1,3 +1,4 @@
+use circuit_runtime_types::UNIT as TRN;
 use circuit_standalone_runtime::{
     AccountId,
     AuraConfig,
@@ -12,7 +13,6 @@ use circuit_standalone_runtime::{
     XDNSConfig, // EvmConfig
     WASM_BINARY,
 };
-use t3rn_primitives::monetary::UNIT as TRN;
 
 const CANDIDACY_BOND: u128 = 0; // 10K TRN
 const DESIRED_CANDIDATES: u32 = 2;

--- a/node/t0rn-parachain/Cargo.toml
+++ b/node/t0rn-parachain/Cargo.toml
@@ -73,7 +73,7 @@ frame-benchmarking-cli = { workspace = true }
 frame-system           = { workspace = true }
 
 parachain-runtime          = { path = "../../runtime/t0rn-parachain", package = "t0rn-parachain-runtime" }
-pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
+pallet-portal-rpc          = { path = "../../pallets/portal/rpc", default-features = false }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }
 t3rn-abi                   = { path = "../../types/abi" }

--- a/node/t0rn-parachain/Cargo.toml
+++ b/node/t0rn-parachain/Cargo.toml
@@ -73,13 +73,13 @@ frame-benchmarking-cli = { workspace = true }
 frame-system           = { workspace = true }
 
 parachain-runtime          = { path = "../../runtime/t0rn-parachain", package = "t0rn-parachain-runtime" }
-
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }
 t3rn-abi                   = { path = "../../types/abi" }
 t3rn-primitives            = { path = "../../primitives" }
 t3rn-types                 = { path = "../../types" }
+circuit-runtime-types      = { path = "../../runtime/common-types"}
 
 sc-chain-spec                  = { workspace = true }
 sc-offchain                    = { workspace = true }

--- a/node/t0rn-parachain/src/chain_spec.rs
+++ b/node/t0rn-parachain/src/chain_spec.rs
@@ -1,9 +1,9 @@
+use circuit_runtime_types::UNIT as TRN;
 use parachain_runtime::{
     opaque::Block, AccountId, AssetsConfig, AuraId, BalancesConfig, CollatorSelectionConfig,
     EvmConfig, GenesisAccount, ParachainInfoConfig, PolkadotXcmConfig, RuntimeGenesisConfig,
     SessionConfig, SessionKeys, Signature, SudoConfig, SystemConfig, XDNSConfig, U256, WASM_BINARY,
 };
-use t3rn_primitives::monetary::UNIT as TRN;
 
 const TST: u128 = TRN * 1_000_000;
 

--- a/node/t1rn-parachain/Cargo.toml
+++ b/node/t1rn-parachain/Cargo.toml
@@ -73,7 +73,7 @@ frame-benchmarking-cli = { workspace = true }
 frame-system           = { workspace = true }
 
 parachain-runtime          = { path = "../../runtime/t1rn-parachain", package = "t1rn-parachain-runtime" }
-
+circuit-runtime-types      = { path = "../../runtime/common-types", default-features = false }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/t1rn-parachain/src/chain_spec.rs
+++ b/node/t1rn-parachain/src/chain_spec.rs
@@ -4,8 +4,8 @@ use parachain_runtime::{
     SudoConfig, SystemConfig, XDNSConfig, WASM_BINARY,
 };
 
+use circuit_runtime_types::UNIT as TRN;
 use codec::Encode;
-use t3rn_primitives::monetary::UNIT as TRN;
 
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;

--- a/node/t2rn-parachain/Cargo.toml
+++ b/node/t2rn-parachain/Cargo.toml
@@ -68,6 +68,7 @@ frame-system           = { workspace = true }
 
 # Local Dependencies
 t2rn-parachain-runtime     = { path = "../../runtime/t2rn-parachain" }
+circuit-runtime-types      = { path = "../../runtime/common-types" }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/t2rn-parachain/Cargo.toml
+++ b/node/t2rn-parachain/Cargo.toml
@@ -68,7 +68,7 @@ frame-system           = { workspace = true }
 
 # Local Dependencies
 t2rn-parachain-runtime     = { path = "../../runtime/t2rn-parachain" }
-circuit-runtime-types      = { path = "../../runtime/common-types" }
+circuit-runtime-types      = { path = "../../runtime/common-types", default-features = false }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/t2rn-parachain/src/chain_spec.rs
+++ b/node/t2rn-parachain/src/chain_spec.rs
@@ -6,7 +6,7 @@ use t2rn_parachain_runtime::{
 const CANDIDACY_BOND: u128 = 0; // 10K TRN
 const DESIRED_CANDIDATES: u32 = 2;
 
-use t3rn_primitives::monetary::UNIT as BASE_UNIT;
+use circuit_runtime_types::UNIT as BASE_UNIT;
 
 const TRN: u128 = BASE_UNIT * 1_000_000;
 

--- a/node/t3rn-parachain/Cargo.toml
+++ b/node/t3rn-parachain/Cargo.toml
@@ -74,7 +74,7 @@ frame-system           = { workspace = true }
 
 # Local Dependencies
 parachain-runtime      = { path = "../../runtime/t3rn-parachain", package = "t3rn-parachain-runtime" }
-circuit-runtime-types  = { path = "../../runtime/common-types" }
+circuit-runtime-types  = { path = "../../runtime/common-types", default-features = false }
 
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }

--- a/node/t3rn-parachain/Cargo.toml
+++ b/node/t3rn-parachain/Cargo.toml
@@ -74,6 +74,7 @@ frame-system           = { workspace = true }
 
 # Local Dependencies
 parachain-runtime      = { path = "../../runtime/t3rn-parachain", package = "t3rn-parachain-runtime" }
+circuit-runtime-types  = { path = "../../runtime/common-types" }
 
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
@@ -81,6 +82,7 @@ pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }
 t3rn-abi                   = { path = "../../types/abi" }
 t3rn-primitives            = { path = "../../primitives" }
 t3rn-types                 = { path = "../../types" }
+
 
 sc-chain-spec                  = { workspace = true }
 sc-offchain                    = { workspace = true }

--- a/node/t3rn-parachain/src/chain_spec.rs
+++ b/node/t3rn-parachain/src/chain_spec.rs
@@ -6,6 +6,7 @@ use parachain_runtime::{
 
 pub use codec::Encode;
 
+use circuit_runtime_types::UNIT as TRN;
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
 use sc_chain_spec::ChainSpecExtension;
@@ -16,7 +17,6 @@ use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::str::FromStr;
-use t3rn_primitives::monetary::UNIT as TRN;
 
 const PARACHAIN_ID: u32 = 3333;
 const PARACHAIN_ID_T1RN: u32 = 3333;

--- a/node/t7rn-parachain/Cargo.toml
+++ b/node/t7rn-parachain/Cargo.toml
@@ -74,7 +74,7 @@ frame-system           = { workspace = true }
 
 # Local Dependencies
 parachain-runtime          = { path = "../../runtime/t7rn-parachain", package = "t7rn-parachain-runtime" }
-circuit-runtime-types      = { path = "../../runtime/common-types" }
+circuit-runtime-types      = { path = "../../runtime/common-types", default-features = false }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/t7rn-parachain/Cargo.toml
+++ b/node/t7rn-parachain/Cargo.toml
@@ -73,8 +73,8 @@ frame-benchmarking-cli = { workspace = true }
 frame-system           = { workspace = true }
 
 # Local Dependencies
-parachain-runtime      = { path = "../../runtime/t7rn-parachain", package = "t7rn-parachain-runtime" }
-
+parachain-runtime          = { path = "../../runtime/t7rn-parachain", package = "t7rn-parachain-runtime" }
+circuit-runtime-types      = { path = "../../runtime/common-types" }
 pallet-portal-rpc          = { path = "../../pallets/portal/rpc" }
 pallet-xdns                = { path = "../../pallets/xdns" }
 pallet-xdns-rpc            = { path = "../../pallets/xdns/rpc" }

--- a/node/t7rn-parachain/src/chain_spec.rs
+++ b/node/t7rn-parachain/src/chain_spec.rs
@@ -1,9 +1,9 @@
+use circuit_runtime_types::UNIT as TRN;
 use parachain_runtime::{
     opaque::Block, AccountId, AuraId, BalancesConfig, CollatorSelectionConfig, ParachainInfoConfig,
     PolkadotXcmConfig, RuntimeGenesisConfig, SessionConfig, SessionKeys, Signature, SudoConfig,
     SystemConfig, WASM_BINARY,
 };
-use t3rn_primitives::monetary::UNIT as TRN;
 
 pub use codec::Encode;
 

--- a/pallets/circuit/vacuum/Cargo.toml
+++ b/pallets/circuit/vacuum/Cargo.toml
@@ -29,9 +29,10 @@ xcm-builder           = { workspace = true, default-features = false, optional =
 pallet-circuit        = { path = "..", default-features = false, optional = true}
 pallet-xdns           = { path = "../../xdns", default-features = false}
 
-t3rn-abi        = { path = "../../../types/abi", default-features = false }
-t3rn-types      = { path = "../../../types", default-features = false, features = [ "runtime" ] }
-t3rn-primitives = { path = "../../../primitives", default-features = false }
+t3rn-abi                = { path = "../../../types/abi", default-features = false }
+t3rn-types              = { path = "../../../types", default-features = false, features = [ "runtime" ] }
+t3rn-primitives         = { path = "../../../primitives", default-features = false }
+circuit-runtime-types   = { path = "../../../runtime/common-types", default-features = false }
 
 
 rlp = { version = "0.5.2", features = [ "derive" ], default-features = false  }
@@ -57,6 +58,7 @@ std = [
     "frame-support/std",
     "frame-system/std",
     "t3rn-primitives/std",
+    "circuit-runtime-types/std",
     "t3rn-abi/std",
     "t3rn-types/std",
     "xcm-builder/std",

--- a/pallets/circuit/vacuum/src/lib.rs
+++ b/pallets/circuit/vacuum/src/lib.rs
@@ -426,7 +426,8 @@ pub mod pallet {
 #[cfg(test)]
 mod tests {
     use codec::Encode;
-    use t3rn_primitives::circuit::OrderOrigin;
+
+    use circuit_runtime_types::UNIT;
 
     use frame_support::{assert_err, assert_ok, traits::Hooks};
     use hex_literal::hex;
@@ -446,12 +447,12 @@ mod tests {
     use t3rn_primitives::{
         circuit::{
             types::{OrderSFX, SFXAction},
-            CircuitSubmitAPI,
+            AdaptiveTimeout, CircuitStatus, CircuitSubmitAPI, OrderOrigin,
         },
         claimable::CircuitRole,
         clock::OnHookQueues,
         light_client::LightClientAsyncAPI,
-        monetary::UNIT,
+        monetary::MOCK_EXISTENTIAL_DEPOSIT as EXISTENTIAL_DEPOSIT,
         portal::Portal as PortalT,
         EthereumToken, ExecutionSource, GatewayVendor, SpeedMode, TokenInfo, TreasuryAccount,
         TreasuryAccountProvider,
@@ -460,10 +461,6 @@ mod tests {
 
     use frame_support::{traits::Currency, weights::Weight};
 
-    use t3rn_primitives::{
-        circuit::{AdaptiveTimeout, CircuitStatus},
-        monetary::MOCK_EXISTENTIAL_DEPOSIT as EXISTENTIAL_DEPOSIT,
-    };
     use t3rn_types::fsx::TargetId;
 
     pub fn mint_required_assets_for_optimistic_actors(

--- a/primitives/src/monetary.rs
+++ b/primitives/src/monetary.rs
@@ -1,6 +1,4 @@
-use circuit_runtime_types::{
-    Balance, MICROUNIT as BASE_MICROUNIT, MILLIUNIT as BASE_MILLIUNIT, UNIT as BASE_UNIT,
-};
+use circuit_runtime_types::{Balance, MILLIUNIT};
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
@@ -8,10 +6,6 @@ use serde::{Deserialize, Serialize};
 use sp_runtime::{traits::CheckedAdd, Perbill, RuntimeDebug};
 
 pub const DECIMALS: u8 = 12;
-// Unit = the base number of indivisible units for balances
-pub const UNIT: Balance = BASE_UNIT;
-pub const MILLIUNIT: Balance = BASE_MILLIUNIT;
-pub const MICROUNIT: Balance = BASE_MICROUNIT;
 
 /// The existential deposit. Set to 1/10 of the Connected Relay Chain.
 pub const EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;

--- a/primitives/src/monetary.rs
+++ b/primitives/src/monetary.rs
@@ -1,4 +1,6 @@
-use circuit_runtime_types::Balance;
+use circuit_runtime_types::{
+    Balance, MICROUNIT as BASE_MICROUNIT, MILLIUNIT as BASE_MILLIUNIT, UNIT as BASE_UNIT,
+};
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
@@ -7,9 +9,9 @@ use sp_runtime::{traits::CheckedAdd, Perbill, RuntimeDebug};
 
 pub const DECIMALS: u8 = 12;
 // Unit = the base number of indivisible units for balances
-pub const UNIT: Balance = 1_000_000_000_000;
-pub const MILLIUNIT: Balance = 1_000_000_000;
-pub const MICROUNIT: Balance = 1_000_000;
+pub const UNIT: Balance = BASE_UNIT;
+pub const MILLIUNIT: Balance = BASE_MILLIUNIT;
+pub const MICROUNIT: Balance = BASE_MICROUNIT;
 
 /// The existential deposit. Set to 1/10 of the Connected Relay Chain.
 pub const EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;

--- a/runtime/common-types/src/lib.rs
+++ b/runtime/common-types/src/lib.rs
@@ -12,8 +12,6 @@ use sp_runtime::{
     MultiSignature, Perbill, Saturating,
 };
 
-pub const MILLIUNIT: Balance = 1_000_000_000;
-
 /// An index to a block.
 pub type BlockNumber = u32;
 
@@ -87,6 +85,9 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
 );
 
 // Currency primitives
+pub const UNIT: Balance = 1_000_000_000_000;
+pub const MILLIUNIT: Balance = 1_000_000_000;
+pub const MICROUNIT: Balance = 1_000_000;
 
 // EVM primitives
 /// EVM max POV size

--- a/runtime/common-types/src/lib.rs
+++ b/runtime/common-types/src/lib.rs
@@ -86,6 +86,27 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
 );
 
+// Currency primitives
+
+// EVM primitives
+/// EVM max POV size
+pub const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+
+/// EVM gas price
+pub const GAS_PRICE: u128 = 1_000;
+
+/// EVM block gas limit
+pub const BLOCK_GAS_LIMIT: u64 = 150_000_000;
+
+/// EVM gas weight
+pub const GAS_WEIGHT: Weight = Weight::from_parts(7u64, 0);
+
+/// EVM weight per gas
+pub const WEIGHT_PER_GAS: Weight = Weight::from_parts(20_000, 0);
+
+/// EVM gas limit POV size ratio
+pub const GAS_LIMIT_POV_SIZE_RATIO: u64 = 4;
+
 parameter_types! {
 
     // This part is copied from Substrate's `bin/node/runtime/src/lib.rs`.

--- a/runtime/mini-mock/src/lib.rs
+++ b/runtime/mini-mock/src/lib.rs
@@ -232,7 +232,7 @@ impl pallet_clock::Config for MiniRuntime {
     type RoundDuration = ConstU32<300>;
     type RuntimeEvent = RuntimeEvent;
 }
-use t3rn_primitives::monetary::UNIT as TRN;
+use circuit_runtime_types::UNIT as TRN;
 
 parameter_types! {
     pub const TotalInflation: Perbill = Perbill::from_parts(44_000_000); // 4.4%

--- a/runtime/mini-mock/src/treasuries_config.rs
+++ b/runtime/mini-mock/src/treasuries_config.rs
@@ -5,7 +5,8 @@ use frame_support::{parameter_types, traits::NeverEnsureOrigin, PalletId};
 use frame_system::EnsureRoot;
 use sp_runtime::{traits::AccountIdConversion, Permill};
 
-use t3rn_primitives::{monetary::UNIT as TRN, TreasuryAccount, TreasuryAccountProvider};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::{TreasuryAccount, TreasuryAccountProvider};
 
 pub type DefaultTreasuryInstance = ();
 pub type EscrowTreasuryInstance = pallet_treasury::pallet::Instance1;

--- a/runtime/mock/src/circuit_config.rs
+++ b/runtime/mock/src/circuit_config.rs
@@ -96,7 +96,8 @@ impl pallet_vacuum::Config for Runtime {
     type Xdns = XDNS;
 }
 
-use t3rn_primitives::{monetary::UNIT as TRN, xdns::PalletAssetsOverlay};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::xdns::PalletAssetsOverlay;
 
 parameter_types! {
     pub const TotalInflation: Perbill = Perbill::from_parts(44_000_000); // 4.4%

--- a/runtime/mock/src/contracts_config.rs
+++ b/runtime/mock/src/contracts_config.rs
@@ -121,7 +121,7 @@ pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
     fn min_gas_price() -> (U256, Weight) {
         // Return some meaningful gas price and weight
-        (1_000_000_000u128.into(), Weight::from_parts(7u64, 0))
+        (1_000u128.into(), Weight::from_parts(7u64, 0))
     }
 }
 

--- a/runtime/mock/src/contracts_config.rs
+++ b/runtime/mock/src/contracts_config.rs
@@ -31,7 +31,7 @@ use t3rn_primitives::threevm::{
     get_tokens_precompile_address, Erc20Mapping, H160_POSITION_ASSET_ID_TYPE,
 };
 
-use t3rn_primitives::monetary::{MILLIUNIT, UNIT};
+use circuit_runtime_types::{MILLIUNIT, UNIT};
 
 // Unit = the base number of indivisible units for balances
 

--- a/runtime/mock/src/treasuries_config.rs
+++ b/runtime/mock/src/treasuries_config.rs
@@ -5,7 +5,8 @@ use frame_support::{parameter_types, traits::NeverEnsureOrigin, PalletId};
 use frame_system::EnsureRoot;
 use sp_runtime::{traits::AccountIdConversion, Permill};
 
-use t3rn_primitives::{monetary::UNIT as TRN, TreasuryAccount, TreasuryAccountProvider};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::{TreasuryAccount, TreasuryAccountProvider};
 
 pub type DefaultTreasuryInstance = ();
 pub type EscrowTreasuryInstance = pallet_treasury::pallet::Instance1;

--- a/runtime/standalone/src/circuit_config.rs
+++ b/runtime/standalone/src/circuit_config.rs
@@ -71,7 +71,8 @@ impl pallet_attesters::Config for Runtime {
     type Xdns = XDNS;
 }
 
-use t3rn_primitives::{monetary::UNIT as TRN, xdns::PalletAssetsOverlay};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::xdns::PalletAssetsOverlay;
 
 parameter_types! {
     pub const TotalInflation: Perbill = Perbill::from_parts(44_000_000); // 4.4%

--- a/runtime/standalone/src/contracts_config.rs
+++ b/runtime/standalone/src/contracts_config.rs
@@ -18,9 +18,9 @@ pub use pallet_3vm_evm_primitives::GenesisAccount as EvmGenesisAccount;
 use sp_core::{H160, U256};
 use sp_runtime::{traits::Keccak256, ConsensusEngineId, RuntimeAppPublic};
 
-use t3rn_primitives::monetary::{MILLIUNIT, UNIT};
+use t3rn_primitives::monetary::EXISTENTIAL_DEPOSIT as _EXISTENTIAL_DEPOSIT;
 
-const _EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;
+use circuit_runtime_types::{MILLIUNIT, UNIT};
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
     (items as Balance * UNIT + (bytes as Balance) * (5 * MILLIUNIT / 100)) / 10

--- a/runtime/standalone/src/lib.rs
+++ b/runtime/standalone/src/lib.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use t3rn_primitives::monetary::MILLIUNIT;
+use circuit_runtime_types::MILLIUNIT;
 
 use frame_system::EnsureRoot;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;

--- a/runtime/standalone/src/treasuries_config.rs
+++ b/runtime/standalone/src/treasuries_config.rs
@@ -3,7 +3,8 @@ use frame_support::{parameter_types, traits::NeverEnsureOrigin, PalletId};
 use frame_system::EnsureRoot;
 use sp_runtime::{traits::AccountIdConversion, Permill};
 
-use t3rn_primitives::{monetary::UNIT as TRN, TreasuryAccount, TreasuryAccountProvider};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::{TreasuryAccount, TreasuryAccountProvider};
 
 pub type DefaultTreasuryInstance = ();
 pub type EscrowTreasuryInstance = pallet_treasury::pallet::Instance1;

--- a/runtime/t0rn-parachain/src/circuit_config.rs
+++ b/runtime/t0rn-parachain/src/circuit_config.rs
@@ -68,7 +68,8 @@ impl pallet_attesters::Config for Runtime {
     type Xdns = XDNS;
 }
 
-use t3rn_primitives::{monetary::UNIT as TRN, xdns::PalletAssetsOverlay};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::xdns::PalletAssetsOverlay;
 
 parameter_types! {
     pub const TotalInflation: Perbill = Perbill::from_parts(44_000_000); // 4.4%

--- a/runtime/t0rn-parachain/src/contracts_config.rs
+++ b/runtime/t0rn-parachain/src/contracts_config.rs
@@ -11,7 +11,10 @@ use frame_support::{
 };
 
 // use evm_precompile_util::KnownPrecompile;
-use circuit_runtime_types::{AssetId, EvmAddress};
+use circuit_runtime_types::{
+    AssetId, EvmAddress, BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE,
+    GAS_WEIGHT, WEIGHT_PER_GAS,
+};
 pub use pallet_3vm_account_mapping::EvmAddressMapping;
 use pallet_3vm_contracts::NoopMigration;
 use pallet_3vm_ethereum::PostLogContent;
@@ -117,12 +120,9 @@ impl FeeCalculator for FixedGasPrice {
         // from 18 (EVM) to 12 (t3rn) the number was divided by 10^6
         // If using another fee calculator the min gas price needs to be converted using
         // t3rn_primitives::threevm::convert_decimals_from_evm<T>
-        (1_000u128.into(), Weight::from_parts(7u64, 0))
+        (GAS_PRICE.into(), GAS_WEIGHT)
     }
 }
-
-const BLOCK_GAS_LIMIT: u64 = 150_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 
@@ -136,10 +136,10 @@ impl OnUnbalanced<NegativeImbalance> for ToStakingPot {
 
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
-    pub const GasLimitPovSizeRatio: u64 = 4;
+    pub const GasLimitPovSizeRatio: u64 = GAS_LIMIT_POV_SIZE_RATIO;
     pub const ChainId: u64 = 3310;
     pub PrecompilesValue: evm_precompile_util::T3rnPrecompiles<Runtime> = evm_precompile_util::T3rnPrecompiles::<_>::new();
-    pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
+    pub WeightPerGas: Weight = WEIGHT_PER_GAS;
 }
 
 // TODO[https://github.com/t3rn/3vm/issues/102]: configure this appropriately

--- a/runtime/t0rn-parachain/src/contracts_config.rs
+++ b/runtime/t0rn-parachain/src/contracts_config.rs
@@ -13,7 +13,7 @@ use frame_support::{
 // use evm_precompile_util::KnownPrecompile;
 use circuit_runtime_types::{
     AssetId, EvmAddress, BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE,
-    GAS_WEIGHT, WEIGHT_PER_GAS,
+    GAS_WEIGHT, MILLIUNIT, UNIT, WEIGHT_PER_GAS,
 };
 pub use pallet_3vm_account_mapping::EvmAddressMapping;
 use pallet_3vm_contracts::NoopMigration;
@@ -28,9 +28,8 @@ use sp_runtime::{
     transaction_validity::TransactionValidityError,
     ConsensusEngineId, RuntimeAppPublic,
 };
-use t3rn_primitives::{
-    monetary::{MILLIUNIT, UNIT},
-    threevm::{get_tokens_precompile_address, Erc20Mapping, H160_POSITION_ASSET_ID_TYPE},
+use t3rn_primitives::threevm::{
+    get_tokens_precompile_address, Erc20Mapping, H160_POSITION_ASSET_ID_TYPE,
 };
 
 // Unit = the base number of indivisible units for balances

--- a/runtime/t0rn-parachain/src/contracts_config.rs
+++ b/runtime/t0rn-parachain/src/contracts_config.rs
@@ -117,7 +117,7 @@ impl FeeCalculator for FixedGasPrice {
         // from 18 (EVM) to 12 (t3rn) the number was divided by 10^6
         // If using another fee calculator the min gas price needs to be converted using
         // t3rn_primitives::threevm::convert_decimals_from_evm<T>
-        (1_000_000_000u128.into(), Weight::from_parts(7u64, 0))
+        (1_000u128.into(), Weight::from_parts(7u64, 0))
     }
 }
 

--- a/runtime/t0rn-parachain/src/lib.rs
+++ b/runtime/t0rn-parachain/src/lib.rs
@@ -67,10 +67,7 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-use t3rn_primitives::{
-    light_client::HeightResult,
-    monetary::{MICROUNIT, MILLIUNIT},
-};
+use t3rn_primitives::light_client::HeightResult;
 
 // Polkadot Imports
 use polkadot_runtime_common::BlockHashCount;

--- a/runtime/t0rn-parachain/src/parachain_config.rs
+++ b/runtime/t0rn-parachain/src/parachain_config.rs
@@ -9,7 +9,7 @@ use frame_support::traits::ConstBool;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 
-use t3rn_primitives::monetary::{MICROUNIT, MILLIUNIT, UNIT};
+use circuit_runtime_types::{MICROUNIT, MILLIUNIT, UNIT};
 // XCM Imports
 use xcm::latest::prelude::BodyId;
 

--- a/runtime/t0rn-parachain/src/treasuries_config.rs
+++ b/runtime/t0rn-parachain/src/treasuries_config.rs
@@ -3,8 +3,8 @@ use frame_support::{parameter_types, traits::NeverEnsureOrigin, PalletId};
 use frame_system::EnsureRoot;
 use sp_runtime::{traits::AccountIdConversion, Permill};
 
-use t3rn_primitives::{monetary::UNIT as TRN, TreasuryAccount, TreasuryAccountProvider};
-
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::{TreasuryAccount, TreasuryAccountProvider};
 pub type DefaultTreasuryInstance = ();
 pub type EscrowTreasuryInstance = pallet_treasury::pallet::Instance1;
 pub type FeeTreasuryInstance = pallet_treasury::pallet::Instance2;

--- a/runtime/t1rn-parachain/src/circuit_config.rs
+++ b/runtime/t1rn-parachain/src/circuit_config.rs
@@ -68,7 +68,8 @@ impl pallet_attesters::Config for Runtime {
     type Xdns = XDNS;
 }
 
-use t3rn_primitives::{monetary::UNIT as TRN, xdns::PalletAssetsOverlay};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::xdns::PalletAssetsOverlay;
 
 parameter_types! {
     pub const TotalInflation: Perbill = Perbill::from_parts(44_000_000); // 4.4%

--- a/runtime/t1rn-parachain/src/contracts_config.rs
+++ b/runtime/t1rn-parachain/src/contracts_config.rs
@@ -10,8 +10,8 @@ use frame_support::{
 };
 
 use circuit_runtime_types::{
-    BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE, GAS_WEIGHT,
-    WEIGHT_PER_GAS,
+    BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE, GAS_WEIGHT, MILLIUNIT,
+    UNIT, WEIGHT_PER_GAS,
 };
 
 // use evm_precompile_util::KnownPrecompile;
@@ -22,7 +22,6 @@ use pallet_3vm_evm_primitives::FeeCalculator;
 pub use pallet_3vm_evm_primitives::GenesisAccount as EvmGenesisAccount;
 use sp_core::{H160, U256};
 use sp_runtime::{traits::Keccak256, ConsensusEngineId, RuntimeAppPublic};
-use t3rn_primitives::monetary::{MILLIUNIT, UNIT};
 
 const _EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;
 

--- a/runtime/t1rn-parachain/src/contracts_config.rs
+++ b/runtime/t1rn-parachain/src/contracts_config.rs
@@ -101,7 +101,7 @@ pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
     fn min_gas_price() -> (U256, Weight) {
         // Return some meaningful gas price and weight
-        (1_000_000_000u128.into(), Weight::from_parts(7u64, 0))
+        (1_000u128.into(), Weight::from_parts(7u64, 0))
     }
 }
 

--- a/runtime/t1rn-parachain/src/contracts_config.rs
+++ b/runtime/t1rn-parachain/src/contracts_config.rs
@@ -9,6 +9,11 @@ use frame_support::{
     traits::{ConstBool, FindAuthor},
 };
 
+use circuit_runtime_types::{
+    BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE, GAS_WEIGHT,
+    WEIGHT_PER_GAS,
+};
+
 // use evm_precompile_util::KnownPrecompile;
 use pallet_3vm_contracts::NoopMigration;
 use pallet_3vm_evm::{EnsureAddressTruncated, HashedAddressMapping, SubstrateBlockHashMapping};
@@ -101,18 +106,15 @@ pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
     fn min_gas_price() -> (U256, Weight) {
         // Return some meaningful gas price and weight
-        (1_000u128.into(), Weight::from_parts(7u64, 0))
+        (GAS_PRICE.into(), GAS_WEIGHT)
     }
 }
 
-const BLOCK_GAS_LIMIT: u64 = 150_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
-
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
-    pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+    pub const GasLimitPovSizeRatio: u64 = GAS_LIMIT_POV_SIZE_RATIO;
     pub const ChainId: u64 = 3331;
-    pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
+    pub WeightPerGas: Weight = WEIGHT_PER_GAS;
     // pub PrecompilesValue: evm_precompile_util::T3rnPrecompiles<Runtime> = evm_precompile_util::T3rnPrecompiles::<_>::new();;
 }
 

--- a/runtime/t1rn-parachain/src/lib.rs
+++ b/runtime/t1rn-parachain/src/lib.rs
@@ -18,7 +18,6 @@ pub mod xbi_config;
 
 pub use crate::{parachain_config::*, signed_extrinsics_config::*};
 pub use circuit_runtime_types::*;
-use t3rn_primitives::monetary::{MICROUNIT, MILLIUNIT, UNIT};
 
 use frame_system::EnsureRoot;
 use pallet_xdns_rpc_runtime_api::{ChainId, GatewayABIConfig};

--- a/runtime/t1rn-parachain/src/parachain_config.rs
+++ b/runtime/t1rn-parachain/src/parachain_config.rs
@@ -10,7 +10,7 @@ use frame_support::traits::ConstBool;
 pub use sp_runtime::BuildStorage;
 
 // XCM Imports
-use t3rn_primitives::monetary::{MICROUNIT, MILLIUNIT};
+use circuit_runtime_types::{MICROUNIT, MILLIUNIT};
 use xcm::latest::prelude::BodyId;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the

--- a/runtime/t1rn-parachain/src/treasuries_config.rs
+++ b/runtime/t1rn-parachain/src/treasuries_config.rs
@@ -3,7 +3,8 @@ use frame_support::{parameter_types, traits::NeverEnsureOrigin, PalletId};
 use frame_system::EnsureRoot;
 use sp_runtime::{traits::AccountIdConversion, Permill};
 
-use t3rn_primitives::{monetary::UNIT as TRN, TreasuryAccount, TreasuryAccountProvider};
+use circuit_runtime_types::UNIT as TRN;
+use t3rn_primitives::{TreasuryAccount, TreasuryAccountProvider};
 
 pub type DefaultTreasuryInstance = ();
 pub type EscrowTreasuryInstance = pallet_treasury::pallet::Instance1;

--- a/runtime/t2rn-parachain/Cargo.toml
+++ b/runtime/t2rn-parachain/Cargo.toml
@@ -104,8 +104,7 @@ frame-system-benchmarking = { default-features = false, git = "https://github.co
 
 # Common
 # circuit-runtime-pallets = { path = "../common-pallets", default-features = false  }
-circuit-runtime-types           = { path = "../common-types", default-features = false }
-
+circuit-runtime-types      = { path = "../../runtime/common-types", default-features = false }
 pallet-maintenance-mode         = { path = "../../pallets/maintenance-mode", default-features = false }
 
 [features]

--- a/runtime/t2rn-parachain/src/circuit_config.rs
+++ b/runtime/t2rn-parachain/src/circuit_config.rs
@@ -71,7 +71,9 @@ impl pallet_attesters::Config for Runtime {
     type Xdns = XDNS;
 }
 
-use t3rn_primitives::{monetary::UNIT as BASE_UNIT, xdns::PalletAssetsOverlay};
+use t3rn_primitives::xdns::PalletAssetsOverlay;
+
+use circuit_runtime_types::UNIT as BASE_UNIT;
 
 pub const TRN: Balance = BASE_UNIT * 1_000_000;
 

--- a/runtime/t2rn-parachain/src/contracts_config.rs
+++ b/runtime/t2rn-parachain/src/contracts_config.rs
@@ -11,7 +11,10 @@ use frame_support::{
 };
 
 // use evm_precompile_util::KnownPrecompile;
-use circuit_runtime_types::{AssetId, EvmAddress};
+use circuit_runtime_types::{
+    AssetId, EvmAddress, BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE,
+    GAS_WEIGHT, WEIGHT_PER_GAS,
+};
 pub use pallet_3vm_account_mapping::EvmAddressMapping;
 use pallet_3vm_contracts::NoopMigration;
 use pallet_3vm_ethereum::PostLogContent;
@@ -34,6 +37,8 @@ const UNIT: Balance = BASE_UNIT * 1_000_000;
 const MILLIUNIT: Balance = BASE_MILLIUNIT * 1_000_000;
 
 const _EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;
+
+const GAS_PRICE: u128 = BASE_GAS_PRICE * 1_000_000;
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
     (items as Balance * UNIT + (bytes as Balance) * (5 * MILLIUNIT / 100)) / 10
@@ -115,12 +120,9 @@ pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
     fn min_gas_price() -> (U256, Weight) {
         // Return some meaningful gas price and weight
-        (1_000_000_000u128.into(), Weight::from_parts(7u64, 0))
+        (GAS_PRICE.into(), GAS_WEIGHT)
     }
 }
-
-const BLOCK_GAS_LIMIT: u64 = 150_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 
@@ -134,11 +136,11 @@ impl OnUnbalanced<NegativeImbalance> for ToStakingPot {
 
 parameter_types! {
     pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
-    pub const GasLimitPovSizeRatio: u64 = 4;
+    pub const GasLimitPovSizeRatio: u64 = GAS_LIMIT_POV_SIZE_RATIO;
     pub const ChainId: u64 = 3301;
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub PrecompilesValue: evm_precompile_util::T3rnPrecompiles<Runtime> = evm_precompile_util::T3rnPrecompiles::<_>::new();
-    pub WeightPerGas: Weight = Weight::from_parts(20_000, 0);
+    pub WeightPerGas: Weight = WEIGHT_PER_GAS;
 }
 
 // TODO[https://github.com/t3rn/3vm/issues/102]: configure this appropriately

--- a/runtime/t2rn-parachain/src/contracts_config.rs
+++ b/runtime/t2rn-parachain/src/contracts_config.rs
@@ -13,7 +13,7 @@ use frame_support::{
 // use evm_precompile_util::KnownPrecompile;
 use circuit_runtime_types::{
     AssetId, EvmAddress, BLOCK_GAS_LIMIT, GAS_LIMIT_POV_SIZE_RATIO, GAS_PRICE as BASE_GAS_PRICE,
-    GAS_WEIGHT, WEIGHT_PER_GAS,
+    GAS_WEIGHT, MILLIUNIT as BASE_MILLIUNIT, UNIT as BASE_UNIT, WEIGHT_PER_GAS,
 };
 pub use pallet_3vm_account_mapping::EvmAddressMapping;
 use pallet_3vm_contracts::NoopMigration;
@@ -28,9 +28,8 @@ use sp_runtime::{
     transaction_validity::TransactionValidityError,
     ConsensusEngineId, RuntimeAppPublic,
 };
-use t3rn_primitives::{
-    monetary::{MILLIUNIT as BASE_MILLIUNIT, UNIT as BASE_UNIT},
-    threevm::{get_tokens_precompile_address, Erc20Mapping, H160_POSITION_ASSET_ID_TYPE},
+use t3rn_primitives::threevm::{
+    get_tokens_precompile_address, Erc20Mapping, H160_POSITION_ASSET_ID_TYPE,
 };
 
 const UNIT: Balance = BASE_UNIT * 1_000_000;

--- a/runtime/t2rn-parachain/src/lib.rs
+++ b/runtime/t2rn-parachain/src/lib.rs
@@ -19,7 +19,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     state_version: 1,
 };
 
-use t3rn_primitives::monetary::MILLIUNIT as BASE_MILLIUNIT;
+use circuit_runtime_types::MILLIUNIT as BASE_MILLIUNIT;
 
 use frame_system::EnsureRoot;
 

--- a/runtime/t2rn-parachain/src/treasuries_config.rs
+++ b/runtime/t2rn-parachain/src/treasuries_config.rs
@@ -3,7 +3,8 @@ use frame_support::{parameter_types, traits::NeverEnsureOrigin, PalletId};
 use frame_system::EnsureRoot;
 use sp_runtime::{traits::AccountIdConversion, Permill};
 
-use t3rn_primitives::{monetary::UNIT as BASE_UNIT, TreasuryAccount, TreasuryAccountProvider};
+use circuit_runtime_types::UNIT as BASE_UNIT;
+use t3rn_primitives::{TreasuryAccount, TreasuryAccountProvider};
 
 pub type DefaultTreasuryInstance = ();
 pub type EscrowTreasuryInstance = pallet_treasury::pallet::Instance1;

--- a/runtime/t3rn-parachain/Cargo.toml
+++ b/runtime/t3rn-parachain/Cargo.toml
@@ -83,7 +83,7 @@ pallet-collator-selection           = { git = 'https://github.com/paritytech/cum
 parachain-info                      = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v1.0.0', default-features = false }
 
 # Commons
-circuit-runtime-types = { path = "../common-types", default-features = false }
+circuit-runtime-types = { path = "../../runtime/common-types", default-features = false }
 t3rn-primitives       = { default-features = false, path = "../../primitives" }
 
 [features]

--- a/runtime/t3rn-parachain/src/parachain_config.rs
+++ b/runtime/t3rn-parachain/src/parachain_config.rs
@@ -5,13 +5,13 @@ use frame_support::{
     PalletId,
 };
 
+use circuit_runtime_types::{MICROUNIT, UNIT as TRN};
 use frame_system::EnsureRoot;
 use smallvec::smallvec;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{impl_opaque_keys, Permill};
 use sp_std::{cmp::Ordering, prelude::*};
-use t3rn_primitives::monetary::{MICROUNIT, UNIT as TRN};
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.

--- a/runtime/t7rn-parachain/Cargo.toml
+++ b/runtime/t7rn-parachain/Cargo.toml
@@ -83,7 +83,7 @@ pallet-collator-selection           = { git = 'https://github.com/paritytech/cum
 parachain-info                      = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v1.0.0', default-features = false }
 
 # Commons
-circuit-runtime-types = { path = "../common-types", default-features = false }
+circuit-runtime-types = { path = "../../runtime/common-types", default-features = false }
 t3rn-primitives       = { default-features = false, path = "../../primitives" }
 
 [features]

--- a/runtime/t7rn-parachain/src/parachain_config.rs
+++ b/runtime/t7rn-parachain/src/parachain_config.rs
@@ -5,13 +5,14 @@ use frame_support::{
     PalletId,
 };
 
+use circuit_runtime_types::{MICROUNIT, UNIT as TRN};
 use frame_system::EnsureRoot;
 use smallvec::smallvec;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{impl_opaque_keys, Permill};
 use sp_std::{cmp::Ordering, prelude::*};
-use t3rn_primitives::monetary::{EXISTENTIAL_DEPOSIT, MICROUNIT, UNIT as TRN};
+use t3rn_primitives::monetary::EXISTENTIAL_DEPOSIT;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.


### PR DESCRIPTION
…ock , t0rn, and t1rn


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated import statements across multiple files to use `circuit_runtime_types` instead of `t3rn_primitives` for monetary constants, improving code clarity and reducing redundancy.
- Refactor: Adjusted various constants related to candidacy, deposits, gas prices, and limits in the chain specification and contract configuration files, enhancing the system's performance and efficiency.
- Chore: Updated the version parameter for cargo-nextest installation in the GitHub workflow file, ensuring compatibility with the latest updates.
- Test: Modified imports and constants in the test module of the pallet, leading to more accurate testing scenarios.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->