### PR TITLE
fix: remove last 18 decimals converted unit for t2rn

### DIFF
--- a/runtime/t2rn-parachain/src/lib.rs
+++ b/runtime/t2rn-parachain/src/lib.rs
@@ -19,7 +19,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     state_version: 1,
 };
 
-use circuit_runtime_types::MILLIUNIT as BASE_MILLIUNIT;
+use circuit_runtime_types::MILLIUNIT;
 
 use frame_system::EnsureRoot;
 
@@ -62,7 +62,6 @@ use pallet_3vm_evm::Runner;
 
 pub type CurrencyAdapter = accounts_config::AccountManagerCurrencyAdapter<Balances, ()>;
 
-const MILLIUNIT: Balance = BASE_MILLIUNIT * 1_000_000;
 const MT3RN: Balance = MILLIUNIT as Balance;
 
 parameter_types! {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `runtime/t2rn-parachain/src/lib.rs` file to improve code maintainability. The constant `MILLIUNIT` is now directly imported from `circuit_runtime_types`, eliminating redundancy in the local scope. This change does not affect any functionalities or features visible to the end-user.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->