### PR TITLE
fix: add BRN faucet link in docs

### DIFF
--- a/docs/main/docs/resources/faucet.md
+++ b/docs/main/docs/resources/faucet.md
@@ -4,4 +4,5 @@ sidebar_position: 2
 
 # Faucet
 
-To get some `T0RN` (t0rn testnet tokens), please visit: https://faucet.t0rn.io
+- To get some `T0RN` (t0rn testnet tokens), please visit: https://faucet.t0rn.io
+- To get some `BRN` (t1rn testnet tokens), please visit: https://faucet.brn.t3rn.io/


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Documentation: Added a new link in the Faucet section of the documentation. Users can now obtain `BRN` testnet tokens in addition to `T0RN` tokens, enhancing the testing capabilities and flexibility on the testnet environment.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->