### PR TITLE
Added Detailed guide for CLI Ubuntu/MacOS 

### DIFF
--- a/docs/main/docs/executor/become-an-executor/binary-setup.md
+++ b/docs/main/docs/executor/become-an-executor/binary-setup.md
@@ -13,7 +13,44 @@ Welcome to the t3rn Executor Setup! This guided process will help you configure 
 https://github.com/t3rn/executor-release/releases/
 :::
 
-**2.** After unzip, in terminal, navigate to the folder that includes the executable file named `executor`.
+### Installation Steps
+
+#### For Ubuntu
+```bash
+# Create and navigate to t3rn directory
+mkdir t3rn
+cd t3rn
+
+# Download latest release
+curl -s https://api.github.com/repos/t3rn/executor-release/releases/latest | \
+grep -Po '"tag_name": "\K.*?(?=")' | \
+xargs -I {} wget https://github.com/t3rn/executor-release/releases/download/{}/executor-linux-{}.tar.gz
+
+# Extract the archive
+tar -xzf executor-linux-*.tar.gz
+
+# Navigate to the executor binary location
+cd executor/executor/bin
+```
+
+#### For macOS
+```bash
+# Create and navigate to t3rn directory
+mkdir t3rn
+cd t3rn
+
+# Download latest release
+curl -s https://api.github.com/repos/t3rn/executor-release/releases/latest | \
+grep -o '"tag_name": "[^"]*' | \
+cut -d'"' -f4 | \
+xargs -I {} curl -LO https://github.com/t3rn/executor-release/releases/download/{}/executor-macos-{}.tar.gz
+
+# Extract the archive
+tar -xzf executor-macos-*.tar.gz
+
+# Navigate to the executor binary location
+cd executor/executor/bin
+```
 
 ### Configure Settings and Environment Required Variables
 
@@ -36,7 +73,7 @@ export LOG_PRETTY=false
 
 **3.** Process orders and claims
 
-```
+```bash
 export EXECUTOR_PROCESS_ORDERS=true
 export EXECUTOR_PROCESS_CLAIMS=true
 ```
@@ -95,17 +132,68 @@ The benefit of setting to false and using your own RPC URLs is to avoid issues c
 
 The default value to `EXECUTOR_PROCESS_PENDING_ORDERS_FROM_API` is true.
 
-### Start
+### Running the Executor
 
+#### Start
 To start the Executor, run the following command:
 
 ```bash
 ./executor
 ```
 
+#### Running in Background
+
+##### Option 1: Using Screen (Recommended for Beginners)
+```bash
+# Install screen (Ubuntu)
+sudo apt-get install screen
+
+# Create and start a new screen session
+screen -S t3rn-executor
+
+# Start the executor in the screen session
+./executor
+
+# To detach: Press Ctrl + A, then D
+# To reattach: screen -r t3rn-executor
+```
+
+##### Option 2: Using tmux (Modern Alternative)
+```bash
+# Install tmux (Ubuntu)
+sudo apt-get install tmux
+
+# Create and start new session
+tmux new -s t3rn-executor
+
+# Start the executor in the tmux session
+./executor
+
+# To detach: Press Ctrl + B, then D
+# To reattach: tmux attach -t t3rn-executor
+```
+
+##### Option 3: Using systemd (Ubuntu Only)
+For a permanent solution that starts automatically on boot, you can create a systemd service. Contact your system administrator or refer to systemd documentation for setup.
+
 :::info Faucet
 In order to bid on transaction orders on testnet, you need to have our BRN token. You can find the [faucet link here](../../resources/faucet)
 :::
+
+### Verification & Troubleshooting
+
+To verify the executor is running correctly:
+1. Check the terminal output for any error messages
+2. Monitor the logs using the configured log level
+3. Verify network connections to enabled networks
+
+If you encounter issues:
+- Verify all environment variables are set correctly
+- Ensure your private key is valid
+- Check network connectivity to enabled networks
+- Verify sufficient balance in your wallet for each network
+
+For further assistance, join our [Discord community](https://discord.com/invite/S5kHFQTtp6) or watch the comprehensive setup guide below.
 
 ## Executor Binary Walkthrough
 


### PR DESCRIPTION
# Update Binary Setup Guide

Added setup guides for Ubuntu/macOS and kept original format from website.

## What's new:
- Added Ubuntu installation steps
- Added macOS installation steps
- Added background process options (screen/tmux/systemd)
- Organized installation guides into existing docs
- Kept original welcome message and info blocks
- Added verification steps

All commands tested on Ubuntu 22.04 and macOS Sonoma.

Let me know if any changes needed! 👍